### PR TITLE
Bump the version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "reflector"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflector"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.93"
 


### PR DESCRIPTION
Bumps the package version 0.8.0 -> 0.8.1 (Cargo.toml + Cargo.lock). The startup banner (env!("CARGO_PKG_VERSION")) and version.sh pick it up automatically; no other changes.