### PR TITLE
Fix the FreeBSD SIOCGIFAFLAG_IN6 request code

### DIFF
--- a/src/interface/getifaddrs.rs
+++ b/src/interface/getifaddrs.rs
@@ -181,23 +181,20 @@ struct In6Ifreq {
 union In6Ifru {
     addr: libc::sockaddr_in6,
     flags6: c_int,
-    // The kernel's `in6_ifreq` union is sized by its largest member, `icmp6_ifstat` (34
-    // `u_quad_t` on macOS, 48 on FreeBSD). This pad makes the whole struct match — load-
+    // The kernel's `in6_ifreq` union is sized by its largest member, `icmp6_ifstat` — 34
+    // `u_quad_t` on both macOS and FreeBSD. This pad makes the whole struct match — load-
     // bearing: `_IOWR` bakes `sizeof(in6_ifreq)` into the request code and the kernel
     // dispatches on the whole code, so a too-small struct yields a request the kernel
     // rejects, and every v6 address would be silently dropped. See the size assertions.
-    #[cfg(target_os = "macos")]
     _icmp6_ifstat: [u64; 34],
-    #[cfg(target_os = "freebsd")]
-    _icmp6_ifstat: [u64; 48],
 }
 
 // `libc` exposes `in6_ifreq` on macOS, so cross-check the hand-rolled size against it
-// there; FreeBSD's (16 + 48×8) is 400.
+// there; FreeBSD's (16 + 34×8) is 288.
 #[cfg(target_os = "macos")]
 const _: () = assert!(size_of::<In6Ifreq>() == size_of::<libc::in6_ifreq>());
 #[cfg(target_os = "freebsd")]
-const _: () = assert!(size_of::<In6Ifreq>() == 400);
+const _: () = assert!(size_of::<In6Ifreq>() == 288);
 
 /// `_IOWR('i', 73, in6_ifreq)` — the BSD `ioctl` request code, derived from the (now
 /// kernel-accurate) struct size rather than hardcoded.
@@ -238,9 +235,7 @@ mod tests {
     // (omitting the large union members) is exactly how that regresses.
     #[test]
     fn siocgifaflag_in6_is_the_kernel_request_code() {
-        #[cfg(target_os = "macos")]
+        // Identical on macOS and FreeBSD: both size `in6_ifreq` at 288 bytes.
         assert_eq!(siocgifaflag_in6(), 0xc120_6949);
-        #[cfg(target_os = "freebsd")]
-        assert_eq!(siocgifaflag_in6(), 0xc190_6949);
     }
 }


### PR DESCRIPTION
## Problem

On FreeBSD, `SIOCGIFAFLAG_IN6` was computed as `0xc190_6949` but the kernel's registered request is `0xc120_6949`. Because the kernel dispatches on the whole `_IOWR`-encoded request code (which bakes in `sizeof(in6_ifreq)`), the mismatch made **every** per-address v6-flag ioctl fail, so every FreeBSD IPv6 address was treated as unusable and dropped. macOS was unaffected (it already used the correct size).

## Root cause

The `In6Ifru` union padded `in6_ifreq` to its largest member, `struct icmp6_ifstat`, but assumed that struct is 48 `u_quad_t` on FreeBSD → struct size 400 (`0x190`).

FreeBSD's `struct icmp6_ifstat` (`sys/netinet6/in6_var.h`, releng/14.2) actually has **34** `uint64_t` fields (17 input + 17 output) = 272 bytes — the same KAME layout as macOS. So `in6_ifreq` = 16 (`ifr_name`) + 272 = **288** (`0x120`), giving the correct request `0xc120_6949`.

The old `[u64; 48]` field, the `== 400` size assertion, and the `0xc190_6949` test were internally self-consistent but all derived from the same wrong guess rather than from the real struct.

## Fix

- Correct the FreeBSD padding to `[u64; 34]`. Since both macOS and FreeBSD now size the struct at 288, the per-OS `#[cfg]` split collapses to a single unconditional field.
- Update the FreeBSD size assertion `400 → 288`.
- Collapse the ioctl-code test to the single value `0xc120_6949` (identical on both OSes).

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo doc --no-deps --document-private-items` — clean.
- 295 lib tests pass on the macOS host, which builds the shared `[u64; 34]` field and the `0xc120_6949` assertion.
- Note: the `#[cfg(target_os = "freebsd")]` `== 288` assertion is only *compiled* under FreeBSD CI — neither the macOS host nor Linux `docker_test.sh` builds the FreeBSD arm.