### PR TITLE
Allocate stream buffers lazily and uninitialized

### DIFF
--- a/src/net/stream_buffer.rs
+++ b/src/net/stream_buffer.rs
@@ -1,8 +1,13 @@
 //! A fixed-capacity byte buffer for one direction of a proxied TCP stream: appended at the back (from
 //! a recv, possibly after a header rewrite), consumed from the front as a send drains them. Backed by a
-//! `Box<[u8]>` sized once — it never grows, so an append past capacity returns [`Overflow`] and the
-//! proxy drops-and-closes rather than let a stuck peer pin unbounded memory. Two cursors bound the live
-//! bytes: `storage[consumed..filled]`.
+//! `Box<[MaybeUninit<u8>]>` allocated on first use — most send-side buffers never backpressure, so they
+//! never allocate — and never zero-filled, since only the written `storage[consumed..filled]` region is
+//! ever read. Capacity is fixed: an append past it returns [`Overflow`] and the proxy drops-and-closes
+//! rather than let a stuck peer pin unbounded memory. Two cursors bound the live bytes:
+//! `storage[consumed..filled]`.
+
+use std::mem::MaybeUninit;
+use std::{ptr, slice};
 
 /// From [`StreamBuffer::append`] when the data won't fit even after reclaiming the consumed prefix —
 /// the caller drops and closes the connection.
@@ -10,20 +15,24 @@
 pub(crate) struct Overflow;
 
 /// A bounded FIFO byte buffer: append at `filled`, consume from `consumed`, unsent bytes in between.
-/// Fixed capacity (the `Box<[u8]>` length); never reallocates.
+/// The backing box is allocated (uninitialized) on first use, sized to `capacity`, and never reallocates.
 pub(crate) struct StreamBuffer {
-    storage: Box<[u8]>,
-    /// Bytes written; the valid region is `storage[..filled]`.
+    /// The backing store, `None` until the first append or `free_tail_mut`; `capacity` bytes once set.
+    storage: Option<Box<[MaybeUninit<u8>]>>,
+    capacity: usize,
+    /// Bytes written; the initialized region is `storage[..filled]`.
     filled: usize,
     /// Bytes drained from the front; the live (unsent) region is `storage[consumed..filled]`.
     consumed: usize,
 }
 
 impl StreamBuffer {
-    /// Holds at most `cap` live bytes, zero-filled up front — no later allocation.
+    /// Holds at most `cap` live bytes. The backing store is allocated — uninitialized, never zero-filled —
+    /// on the first `append`/`free_tail_mut`, so an idle buffer costs nothing.
     pub(crate) fn with_capacity(cap: usize) -> Self {
         Self {
-            storage: vec![0u8; cap].into_boxed_slice(),
+            storage: None,
+            capacity: cap,
             filled: 0,
             consumed: 0,
         }
@@ -31,7 +40,16 @@ impl StreamBuffer {
 
     /// The unsent bytes, for one `send`.
     pub(crate) fn pending(&self) -> &[u8] {
-        &self.storage[self.consumed..self.filled]
+        match &self.storage {
+            // SAFETY: bytes enter `[..filled]` only via `append` (which writes them) or `commit` (whose
+            // contract is that `free_tail_mut`'s region was written), so `[consumed..filled]` is
+            // initialized. `MaybeUninit<u8>` and `u8` share layout.
+            Some(storage) => unsafe {
+                let live = &storage[self.consumed..self.filled];
+                slice::from_raw_parts(live.as_ptr().cast::<u8>(), live.len())
+            },
+            None => &[],
+        }
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -46,36 +64,50 @@ impl StreamBuffer {
     /// Append `data`, reclaiming the consumed prefix first if the tail can't hold it. `Err` (buffer
     /// unchanged) if the live bytes plus `data` would exceed capacity — the caller drops-and-closes.
     pub(crate) fn append(&mut self, data: &[u8]) -> Result<(), Overflow> {
-        if self.len() + data.len() > self.storage.len() {
+        if self.len() + data.len() > self.capacity {
             return Err(Overflow);
         }
+        if data.is_empty() {
+            return Ok(()); // nothing to write — and no reason to force the lazy allocation
+        }
         // Fits, but maybe not in the tail — slide the live bytes down to reclaim the consumed gap.
-        if self.filled + data.len() > self.storage.len() {
+        if self.filled + data.len() > self.capacity {
             self.compact();
         }
-        let end = self.filled + data.len();
-        self.storage[self.filled..end].copy_from_slice(data);
-        self.filled = end;
+        let filled = self.filled;
+        let storage = self.ensure_alloc();
+        // SAFETY: `filled + data.len() <= capacity` (checked above, and `compact` reclaimed the consumed
+        // prefix if the tail was short), so the destination stays in bounds. Source and destination can't
+        // overlap: `data` is a shared borrow, `storage` lives behind `&mut self`, so `data` aliasing it
+        // would be a shared+exclusive borrow of the same bytes — which the borrow checker rejects.
+        // `MaybeUninit<u8>` and `u8` share layout.
+        unsafe {
+            ptr::copy_nonoverlapping(
+                data.as_ptr(),
+                storage.as_mut_ptr().add(filled).cast::<u8>(),
+                data.len(),
+            );
+        }
+        self.filled = filled + data.len();
         Ok(())
     }
 
     /// The free space at the back, to receive into in place. Reclaims the consumed prefix first when
     /// the tail is exhausted, so the whole spare capacity is offered as one slice; pair with
     /// [`commit`](Self::commit) to mark how many bytes landed. Empty only when full of live bytes — the
-    /// caller then holds an unframable, over-long message and drops-and-closes.
-    pub(crate) fn free_tail_mut(&mut self) -> &mut [u8] {
-        if self.filled == self.storage.len() && self.consumed > 0 {
+    /// caller then holds an unframable, over-long message and drops-and-closes. The bytes are
+    /// uninitialized: write, don't read, until they are committed.
+    pub(crate) fn free_tail_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        if self.filled == self.capacity && self.consumed > 0 {
             self.compact();
         }
-        &mut self.storage[self.filled..]
+        let filled = self.filled;
+        &mut self.ensure_alloc()[filled..]
     }
 
     /// Mark `n` bytes received into [`free_tail_mut`](Self::free_tail_mut) as filled.
     pub(crate) fn commit(&mut self, n: usize) {
-        debug_assert!(
-            self.filled + n <= self.storage.len(),
-            "commit past the capacity"
-        );
+        debug_assert!(self.filled + n <= self.capacity, "commit past the capacity");
         self.filled += n;
     }
 
@@ -96,9 +128,19 @@ impl StreamBuffer {
         }
     }
 
+    /// The backing store, allocating it (uninitialized) on first call.
+    fn ensure_alloc(&mut self) -> &mut [MaybeUninit<u8>] {
+        let capacity = self.capacity;
+        &mut self
+            .storage
+            .get_or_insert_with(|| Box::new_uninit_slice(capacity))[..]
+    }
+
     /// Slide the live bytes to the front, dropping the consumed prefix.
     fn compact(&mut self) {
-        self.storage.copy_within(self.consumed..self.filled, 0);
+        if let Some(storage) = &mut self.storage {
+            storage.copy_within(self.consumed..self.filled, 0);
+        }
         self.filled -= self.consumed;
         self.consumed = 0;
     }
@@ -107,6 +149,13 @@ impl StreamBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Write `data` into the front of an uninitialized tail slice, for tests.
+    fn fill(tail: &mut [MaybeUninit<u8>], data: &[u8]) {
+        for (slot, &byte) in tail.iter_mut().zip(data) {
+            slot.write(byte);
+        }
+    }
 
     #[test]
     fn new_buffer_is_empty() {
@@ -180,7 +229,7 @@ mod tests {
         b.append(b"ab").unwrap();
         let tail = b.free_tail_mut();
         assert_eq!(tail.len(), 6);
-        tail[..3].copy_from_slice(b"xyz");
+        fill(tail, b"xyz");
         b.commit(3);
         assert_eq!(b.pending(), b"abxyz");
     }
@@ -192,7 +241,7 @@ mod tests {
         b.consume(2); // live "cd"; tail exhausted but 2 bytes reclaimable
         let tail = b.free_tail_mut(); // compacts: "cd" slides to the front
         assert_eq!(tail.len(), 2);
-        tail.copy_from_slice(b"ef");
+        fill(tail, b"ef");
         b.commit(2);
         assert_eq!(b.pending(), b"cdef");
     }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -3,6 +3,7 @@
 //! watches its fd; all operations are non-blocking and the socket is close-on-exec.
 
 use std::io;
+use std::mem::MaybeUninit;
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
@@ -107,19 +108,22 @@ impl TcpSocket {
         self.connecting
     }
 
-    /// Read into `buf` (which must be non-empty: `recv` into a zero-length buffer also returns 0,
-    /// aliasing the [`IoStatus::Ready(0)`](IoStatus) clean-EOF signal — the `std::io::Read::read`
-    /// caveat). The peer closing its write side is then the only legitimate `Ready(0)`; the splice loop
-    /// stops reading under backpressure rather than ever passing an empty slice.
+    /// Read into `buf`, which may be uninitialized — `recv` only ever writes the bytes it returns, so on
+    /// [`IoStatus::Ready(n)`](IoStatus) the first `n` bytes of `buf` are now initialized. `buf` must be
+    /// non-empty: a `recv` into a zero-length buffer also returns 0, aliasing the `Ready(0)` clean-EOF
+    /// signal (the `std::io::Read::read` caveat). The peer closing its write side is then the only
+    /// legitimate `Ready(0)`; the splice loop stops reading under backpressure rather than ever passing an
+    /// empty slice.
     ///
     /// # Errors
     /// Propagates a real read error (other than `EAGAIN`/`EWOULDBLOCK`).
-    pub(crate) fn recv(&self, buf: &mut [u8]) -> io::Result<IoStatus> {
+    pub(crate) fn recv(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<IoStatus> {
         debug_assert!(
             !buf.is_empty(),
             "recv into an empty buffer returns 0, aliasing EOF"
         );
-        // SAFETY: `buf` is a valid writable region of `buf.len()` bytes.
+        // SAFETY: `buf` is a valid writable region of `buf.len()` bytes; `recv` writes only the `n` it
+        // returns, leaving the rest untouched (still uninitialized).
         let n = unsafe {
             libc::recv(
                 self.fd.as_raw_fd(),
@@ -352,6 +356,22 @@ mod tests {
 
     use super::*;
 
+    impl TcpSocket {
+        /// Ergonomic recv into an initialized `[u8]` buffer — a thin wrapper over
+        /// [`recv`](TcpSocket::recv) for tests that read into plain byte buffers.
+        pub(crate) fn recv_bytes(&self, buf: &mut [u8]) -> io::Result<IoStatus> {
+            // SAFETY: a `&mut [u8]` is a valid `&mut [MaybeUninit<u8>]` (an initialized byte is a valid
+            // `MaybeUninit`, same layout); `recv` only writes into it.
+            let buf = unsafe {
+                std::slice::from_raw_parts_mut(
+                    buf.as_mut_ptr().cast::<MaybeUninit<u8>>(),
+                    buf.len(),
+                )
+            };
+            self.recv(buf)
+        }
+    }
+
     /// Drive a non-blocking op to completion on loopback (no reactor in the test).
     fn spin<T>(mut op: impl FnMut() -> io::Result<Option<T>>) -> T {
         for _ in 0..2000 {
@@ -380,7 +400,7 @@ mod tests {
             IoStatus::Ready(4)
         ));
         let mut buf = [0u8; 16];
-        let n = spin(|| match server.recv(&mut buf)? {
+        let n = spin(|| match server.recv_bytes(&mut buf)? {
             IoStatus::Ready(0) => panic!("unexpected EOF before the payload"),
             IoStatus::Ready(n) => Ok(Some(n)),
             IoStatus::WouldBlock => Ok(None),
@@ -402,7 +422,7 @@ mod tests {
             .expect("send_vectored");
         assert!(matches!(sent, IoStatus::Ready(8)));
         let mut buf = [0u8; 16];
-        let n = spin(|| match server.recv(&mut buf)? {
+        let n = spin(|| match server.recv_bytes(&mut buf)? {
             IoStatus::Ready(0) => panic!("unexpected EOF before the payload"),
             IoStatus::Ready(n) => Ok(Some(n)),
             IoStatus::WouldBlock => Ok(None),
@@ -421,7 +441,7 @@ mod tests {
         // The client shuts down its write half: the server reads EOF.
         client.shutdown_write();
         let mut buf = [0u8; 16];
-        let eof = spin(|| match server.recv(&mut buf)? {
+        let eof = spin(|| match server.recv_bytes(&mut buf)? {
             IoStatus::Ready(n) => Ok(Some(n)),
             IoStatus::WouldBlock => Ok(None),
         });
@@ -435,7 +455,7 @@ mod tests {
             server.send(b"pong").expect("send"),
             IoStatus::Ready(4)
         ));
-        let n = spin(|| match client.recv(&mut buf)? {
+        let n = spin(|| match client.recv_bytes(&mut buf)? {
             IoStatus::Ready(0) => panic!("the client's read half closed unexpectedly"),
             IoStatus::Ready(n) => Ok(Some(n)),
             IoStatus::WouldBlock => Ok(None),

--- a/src/reflector/dial/connection.rs
+++ b/src/reflector/dial/connection.rs
@@ -583,7 +583,7 @@ mod tests {
                     "forward should stay open on a clean message"
                 );
             }
-            match peer_out.recv(&mut buf).expect("recv on the peer") {
+            match peer_out.recv_bytes(&mut buf).expect("recv on the peer") {
                 IoStatus::Ready(0) => panic!("unexpected EOF before the forwarded bytes"),
                 IoStatus::Ready(n) => return (buf[..n].to_vec(), learned_rest),
                 IoStatus::WouldBlock => sleep(Duration::from_millis(1)),
@@ -789,7 +789,7 @@ mod tests {
         let mut out = Vec::new();
         let mut buf = [0u8; 256];
         for _ in 0..2000 {
-            match sock.recv(&mut buf).expect("recv") {
+            match sock.recv_bytes(&mut buf).expect("recv") {
                 IoStatus::Ready(0) => return out,
                 IoStatus::Ready(n) => out.extend_from_slice(&buf[..n]),
                 IoStatus::WouldBlock => sleep(Duration::from_millis(1)),

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -394,7 +394,7 @@ mod tests {
         let mut closed = false;
         for _ in 0..2000 {
             proxy.accept_rest(&mut reactor);
-            if matches!(client.recv(&mut buf), Ok(IoStatus::Ready(0))) {
+            if matches!(client.recv_bytes(&mut buf), Ok(IoStatus::Ready(0))) {
                 closed = true;
                 break;
             }


### PR DESCRIPTION
## Problem

`StreamBuffer` (one per proxied-connection direction) backed its FIFO with an eager, zero-filled `Box<[u8]>` (`vec![0u8; cap]`). Two facts made that wasteful:

- The **send-side** buffers (8 KB × 2 flows = 16 KB/connection) are only ever touched under backpressure — `send_framed` writes directly via `send_vectored` first and buffers only the unsent tail. In the common case they're allocated and `memset` but never used.
- The recv path reads into the buffer via `recv`, so the up-front zero-fill of the receive region is overwritten immediately anyway.

With `MAX_CONNECTIONS = 64` per proxy (one proxy per device), that's up to ~1 MB/proxy of eagerly-allocated, never-used send-buffer heap at peak.

## Change

Back the FIFO with `Option<Box<[MaybeUninit<u8>]>>` + a `capacity` field:

- **Lazy:** the box is allocated on the first `append`/`free_tail_mut`. A connection that never backpressures never allocates its send buffers.
- **Uninitialized:** allocated with `Box::new_uninit_slice` — no `memset`. Only the written `[consumed..filled]` region is ever exposed as `&[u8]` (via a contained `assume_init` in `pending()`); `free_tail_mut()` hands back `&mut [MaybeUninit<u8>]`.
- `TcpSocket::recv` now reads into `&mut [MaybeUninit<u8>]` (the natural type for a recv target — it only writes the bytes it returns). An ergonomic `&mut [u8]` wrapper (`recv_bytes`) remains for tests, so the socket test call sites stay readable.

### Why not inline/stack buffers

Considered, and rejected for this storage layout: connections live by value in a `Vec`-backed `Arena` (`Slot<Connection>` = `Option<Connection>`). Inline `[u8; N]` buffers would make each slot ~24 KB, retained for the proxy's whole life (freed slots keep their footprint), plus a 24 KB `memcpy` on every arena growth. That would *defeat* free-on-close and increase steady-state footprint. Lazy+uninit keeps arena slots tiny and frees buffers on connection close.

## Verification

- `cargo fmt --check`, `clippy --all-targets -- -D warnings`, `doc --no-deps --document-private-items` — clean on host **and** Linux (docker `rust:slim`).
- `cargo test --lib` — 295 (macOS) / 286 (Linux; different `cfg` test sets) passing.
- **Miri** (`-Zmiri-strict-provenance`) passes all buffer tests — validates the `MaybeUninit`/`from_raw_parts`/`copy_nonoverlapping` soundness.
- **e2e** (Docker-bridge suite, image built from this branch) — **32/32 cases pass**.