### PR TITLE
Reuse a scratch buffer for the reactor deadline sweep

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -125,6 +125,10 @@ struct Registration {
 pub(crate) struct Reactor {
     handlers: Arena<HandlerEntry>,
     registrations: Arena<Registration>,
+    /// Reused across deadline sweeps: the due handlers' keys, snapshotted so a handler firing
+    /// mid-sweep can touch the reactor without the buffer aliasing `&mut self`. Kept allocated so a
+    /// sweep doesn't allocate.
+    deadline_keys: Vec<Key>,
     poll: Poller,
     shutdown: bool,
 }
@@ -138,6 +142,7 @@ impl Reactor {
         Ok(Self {
             handlers: Arena::new(),
             registrations: Arena::new(),
+            deadline_keys: Vec::new(),
             poll: Poller::new(EVENT_CAPACITY)?,
             shutdown: false,
         })
@@ -400,19 +405,26 @@ impl Reactor {
     /// is taken out for its call (as in [`dispatch`](Self::dispatch)) so it can touch the reactor;
     /// one that removes itself mid-call is simply not restored.
     fn dispatch_deadlines(&mut self, now: Instant) {
-        let due: Vec<Key> = self
-            .handlers
-            .iter()
-            .filter(|(_, entry)| {
-                entry
-                    .handler
-                    .as_ref()
-                    .and_then(|h| h.next_deadline())
-                    .is_some_and(|d| d <= now)
-            })
-            .map(|(key, _)| key)
-            .collect();
-        for key in due {
+        // Snapshot the due handlers into the reused buffer, then fire them with the same take-and-
+        // restore as `dispatch` so each can touch the reactor. Indexing by `Key` (Copy) drops the
+        // buffer borrow before the `&mut self` call; a handler that removes itself (or another due
+        // handler) mid-sweep leaves a stale key, and the `get_mut` miss makes take and restore no-ops.
+        // Deadline sweeps never nest, so one shared buffer suffices.
+        self.deadline_keys.clear();
+        self.deadline_keys.extend(
+            self.handlers
+                .iter()
+                .filter(|(_, entry)| {
+                    entry
+                        .handler
+                        .as_ref()
+                        .and_then(|h| h.next_deadline())
+                        .is_some_and(|d| d <= now)
+                })
+                .map(|(key, _)| key),
+        );
+        for i in 0..self.deadline_keys.len() {
+            let key = self.deadline_keys[i];
             // Gone if an earlier sweep in this pass removed it (its key went stale) — benign.
             let Some(mut handler) = self
                 .handlers


### PR DESCRIPTION
## Problem

`Reactor::dispatch_deadlines` collected the due handlers' keys into a **fresh `Vec<Key>` on every sweep**. The sweep runs whenever a handler deadline comes due (SSDP M-SEARCH session expiry, DIAL connect/idle timeouts), so under steady timer traffic that's a recurring allocation in the reactor loop.

The two phases can't be fused: collecting the keys borrows `self.handlers` immutably, while firing each handler needs `&mut self` (`on_deadline` can touch the reactor) — so the keys must be snapshotted first.

## Change

Snapshot into a **reused `Reactor` field** (`deadline_keys: Vec<Key>`) instead of a fresh `Vec`: `clear()` + `extend(...)` per sweep, so the allocation stabilizes after the first few sweeps and the buffer is kept for the reactor's life.

This mirrors the existing `PacketDispatcher::route` pattern one-for-one. The key detail that resolves the "can't dispatch while iterating" borrow: iterate the buffer **by index and copy the `Key` out** (`let key = self.deadline_keys[i];`) — `Key` is `Copy`, so that read ends the buffer borrow on the same line, freeing `&mut self` for the `on_deadline` call. (`for key in &self.deadline_keys` would hold the borrow across the body and not compile.)

Safety carries over from the `route` idiom: a handler that removes itself (or another due handler) mid-sweep leaves a stale generational key, and the `get_mut` miss makes both the take and the restore no-ops. Deadline sweeps never nest, so one shared buffer suffices.

## Verification

- `cargo fmt --check`, `clippy --all-targets -- -D warnings` — clean on host **and** Linux (docker).
- `cargo test --lib` — 295 (host) / 286 (Linux) passing, incl. `dispatch_deadlines_fires_only_the_handlers_that_are_due`.
- **e2e** (Docker-bridge, image built from this branch) — **32/32 pass** (the deadline path drives the SSDP session-expiry and DIAL timeout cases).