### PR TITLE
Fill unit-test coverage gaps across the codebase

### DIFF
--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -417,6 +417,17 @@ mod tests {
         assert!(parse_record(&batch).is_err());
     }
 
+    #[test]
+    fn rejects_a_frame_extending_past_the_batch() {
+        // A header whose bh_caplen claims more frame bytes than the batch holds.
+        let hdrlen = u16::try_from(size_of::<libc::bpf_hdr>()).unwrap();
+        let mut batch = vec![0u8; size_of::<libc::bpf_hdr>() + 2];
+        batch[offset_of!(libc::bpf_hdr, bh_hdrlen)..][..2].copy_from_slice(&hdrlen.to_ne_bytes());
+        batch[offset_of!(libc::bpf_hdr, bh_caplen)..][..4].copy_from_slice(&100u32.to_ne_bytes());
+        batch[offset_of!(libc::bpf_hdr, bh_datalen)..][..4].copy_from_slice(&100u32.to_ne_bytes());
+        assert!(parse_record(&batch).is_err());
+    }
+
     /// Send a UDP probe to `bind` (a v4 or v6 loopback address) and confirm the BPF
     /// backend captures it as a `DLT_NULL` frame: a 4-byte host-order `family`, then
     /// an IP header whose version nibble is `version` (so the link header is exactly

--- a/src/config/value.rs
+++ b/src/config/value.rs
@@ -346,4 +346,23 @@ mod tests {
             [7, 9]
         );
     }
+
+    #[test]
+    fn address_family_parses_via_fromstr() {
+        use AddressFamily as F;
+        assert_eq!("default".parse::<F>().unwrap(), F::Default);
+        assert_eq!("DUAL".parse::<F>().unwrap(), F::Dual);
+        assert_eq!("ipv4".parse::<F>().unwrap(), F::Ipv4);
+        assert_eq!("IPv6".parse::<F>().unwrap(), F::Ipv6);
+        assert_eq!("both".parse::<F>(), Err(ParseAddressFamilyError));
+    }
+
+    #[test]
+    fn wol_ports_reject_an_empty_list() {
+        // FromStr can't yield an empty list, so Empty is reachable only via the TryFrom path.
+        assert!(matches!(
+            WolPorts::try_from(Vec::<NonZeroU16>::new()),
+            Err(WolPortsError::Empty)
+        ));
+    }
 }

--- a/src/dispatch/dial_context.rs
+++ b/src/dispatch/dial_context.rs
@@ -185,4 +185,67 @@ mod tests {
                 .map(|p| p.desc_grace)
         }
     }
+
+    use std::time::Duration;
+
+    use crate::reactor::{Handler, ReadyEvent};
+
+    struct Dummy;
+    impl Handler for Dummy {
+        fn on_readable(&mut self, _event: ReadyEvent, _reactor: &mut Reactor) {}
+    }
+
+    fn ep(n: u8) -> SocketAddrV4 {
+        SocketAddrV4::new(std::net::Ipv4Addr::new(10, 0, 0, n), 8008)
+    }
+
+    #[test]
+    fn next_grace_reports_the_soonest_or_none_when_empty() {
+        let mut reactor = Reactor::new().unwrap();
+        let mut ctx = DialContext::new();
+        assert_eq!(ctx.next_grace(), None);
+
+        let base = Instant::now();
+        let hk1 = reactor.register(Box::new(Dummy));
+        ctx.insert(
+            CaptureKey(0),
+            CaptureKey(1),
+            ep(1),
+            hk1,
+            ep(9),
+            base + Duration::from_secs(10),
+        );
+        let hk2 = reactor.register(Box::new(Dummy));
+        ctx.insert(
+            CaptureKey(0),
+            CaptureKey(1),
+            ep(2),
+            hk2,
+            ep(9),
+            base + Duration::from_secs(5),
+        );
+        assert_eq!(ctx.next_grace(), Some(base + Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn lookup_finds_a_live_proxy_and_prunes_an_evicted_one() {
+        let mut reactor = Reactor::new().unwrap();
+        let mut ctx = DialContext::new();
+        let hk = reactor.register(Box::new(Dummy));
+        let base = Instant::now();
+        ctx.insert(CaptureKey(0), CaptureKey(1), ep(1), hk, ep(9), base);
+
+        // Live: found, and its grace is refreshed to the new deadline.
+        let refreshed = base + Duration::from_secs(30);
+        assert_eq!(
+            ctx.lookup(CaptureKey(0), ep(1), &reactor, refreshed),
+            Some(ep(9))
+        );
+        assert_eq!(ctx.grace_of(CaptureKey(0), ep(1)), Some(refreshed));
+
+        // Evicted: the stale entry is pruned and reported absent.
+        reactor.unregister(hk).unwrap();
+        assert_eq!(ctx.lookup(CaptureKey(0), ep(1), &reactor, base), None);
+        assert_eq!(ctx.proxy_count(), 0);
+    }
 }

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -278,4 +278,25 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn find_or_add_interface_dedups_by_name() -> io::Result<()> {
+        let mut table = InterfaceTable::new();
+        let first = table.find_or_add_interface(LOOPBACK_IFACE)?;
+        let second = table.find_or_add_interface(LOOPBACK_IFACE)?;
+        assert_eq!(first, second, "the same name resolves to one interface key");
+        Ok(())
+    }
+
+    #[test]
+    fn capture_accessors_reject_an_out_of_range_key() {
+        let mut table = InterfaceTable::new();
+        let forged = CaptureKey(0); // nothing added yet
+        assert!(!table.contains(forged));
+        assert!(table.interface_of(forged).is_none());
+        assert!(table.ifindex_of(forged).is_none());
+        assert!(table.capture(forged).is_none());
+        assert!(table.egress_addrs(forged).is_none());
+        assert!(table.take(forged).is_none());
+    }
 }

--- a/src/interface/address_monitor/route.rs
+++ b/src/interface/address_monitor/route.rs
@@ -130,4 +130,13 @@ mod tests {
         for_each_change(&buf, &mut |i| seen.push(i));
         assert!(seen.is_empty());
     }
+
+    #[test]
+    fn stops_at_a_message_claiming_a_length_past_the_buffer() {
+        let mut buf = message(libc::RTM_NEWADDR, 7, 20);
+        buf[0..2].copy_from_slice(&9999u16.to_ne_bytes()); // msglen past the datagram
+        let mut seen = Vec::new();
+        for_each_change(&buf, &mut |i| seen.push(i));
+        assert!(seen.is_empty());
+    }
 }

--- a/src/interface/address_monitor/rtnetlink.rs
+++ b/src/interface/address_monitor/rtnetlink.rs
@@ -178,4 +178,13 @@ mod tests {
         for_each_change(&buf, &mut |i| seen.push(i));
         assert!(seen.is_empty());
     }
+
+    #[test]
+    fn stops_at_a_message_claiming_a_length_past_the_buffer() {
+        let mut buf = message(libc::RTM_NEWADDR, &ifaddrmsg(7));
+        buf[0..4].copy_from_slice(&9999u32.to_ne_bytes()); // len past the datagram
+        let mut seen = Vec::new();
+        for_each_change(&buf, &mut |i| seen.push(i));
+        assert!(seen.is_empty());
+    }
 }

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -332,3 +332,146 @@ fn scan_link(msg: &[u8], if_name: &str, ifindex: u32, addrs: &mut InterfaceAddre
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialize `[len:u16][type:u16][value]` rtattr TLVs, each padded to 4 bytes, onto `buf`.
+    fn push_attrs(buf: &mut Vec<u8>, attrs: &[(u16, &[u8])]) {
+        for &(attr_type, value) in attrs {
+            let len = u16::try_from(size_of::<RtAttr>() + value.len()).unwrap();
+            buf.extend_from_slice(&len.to_ne_bytes());
+            buf.extend_from_slice(&attr_type.to_ne_bytes());
+            buf.extend_from_slice(value);
+            while !buf.len().is_multiple_of(4) {
+                buf.push(0);
+            }
+        }
+    }
+
+    /// An `RTM_NEWADDR` message: a zeroed nlmsghdr, an ifaddrmsg (family/flags/index), then `attrs`.
+    fn addr_msg(family: c_int, index: u32, flags: u8, attrs: &[(u16, &[u8])]) -> Vec<u8> {
+        let mut m = vec![0u8; nl_align(size_of::<NlMsgHdr>())];
+        m.push(u8::try_from(family).unwrap()); // family
+        m.extend_from_slice(&[0, flags, 0]); // prefixlen, flags, scope
+        m.extend_from_slice(&index.to_ne_bytes()); // index
+        push_attrs(&mut m, attrs);
+        m
+    }
+
+    /// An `RTM_NEWLINK` message: a zeroed nlmsghdr, an ifinfomsg (index), then `attrs`.
+    fn link_msg(index: i32, attrs: &[(u16, &[u8])]) -> Vec<u8> {
+        let mut m = vec![0u8; nl_align(size_of::<NlMsgHdr>())];
+        m.extend_from_slice(&[0, 0]); // family, pad
+        m.extend_from_slice(&0u16.to_ne_bytes()); // dev_type
+        m.extend_from_slice(&index.to_ne_bytes()); // index (i32)
+        m.extend_from_slice(&[0u8; 8]); // flags, change
+        push_attrs(&mut m, attrs);
+        m
+    }
+
+    #[test]
+    fn nl_align_rounds_up_to_four() {
+        assert_eq!(nl_align(0), 0);
+        assert_eq!(nl_align(1), 4);
+        assert_eq!(nl_align(4), 4);
+        assert_eq!(nl_align(5), 8);
+    }
+
+    #[test]
+    fn read_at_bounds_checks_the_read() {
+        let buf = [1u8, 2, 3, 4, 5];
+        assert_eq!(
+            read_at::<u32>(&buf, 1),
+            Some(u32::from_ne_bytes([2, 3, 4, 5]))
+        );
+        assert_eq!(read_at::<u32>(&buf, 2), None); // 2 + 4 > 5
+        assert_eq!(read_at::<u16>(&buf, usize::MAX), None); // offset overflow
+    }
+
+    #[test]
+    fn rtattrs_walks_tlvs_and_stops_at_a_bad_length() {
+        let mut buf = Vec::new();
+        push_attrs(&mut buf, &[(1, &[0xaa, 0xbb]), (2, &[0xcc])]);
+        let got: Vec<(u16, Vec<u8>)> = rtattrs(&buf, 0).map(|(t, v)| (t, v.to_vec())).collect();
+        assert_eq!(got, vec![(1, vec![0xaa, 0xbb]), (2, vec![0xcc])]);
+
+        // A final header whose length runs past the buffer ends the walk after the good attrs.
+        let mut bad = buf.clone();
+        bad.extend_from_slice(&[0xff, 0xff, 0x00, 0x00]); // len = 0xffff
+        assert_eq!(rtattrs(&bad, 0).count(), 2);
+    }
+
+    #[test]
+    fn scan_addr_records_a_usable_v4() {
+        let msg = addr_msg(libc::AF_INET, 5, 0, &[(libc::IFA_ADDRESS, &[10, 0, 0, 1])]);
+        let mut addrs = InterfaceAddresses::default();
+        scan_addr(&msg, "eth0", 5, &mut addrs, &mut V6Pick::default());
+        assert_eq!(addrs.v4, Some(Ipv4Addr::new(10, 0, 0, 1)));
+    }
+
+    #[test]
+    fn scan_addr_prefers_ifa_local_over_ifa_address() {
+        // On point-to-point links IFA_ADDRESS is the peer; IFA_LOCAL is ours.
+        let msg = addr_msg(
+            libc::AF_INET,
+            5,
+            0,
+            &[
+                (libc::IFA_ADDRESS, &[10, 0, 0, 2]),
+                (libc::IFA_LOCAL, &[10, 0, 0, 1]),
+            ],
+        );
+        let mut addrs = InterfaceAddresses::default();
+        scan_addr(&msg, "eth0", 5, &mut addrs, &mut V6Pick::default());
+        assert_eq!(addrs.v4, Some(Ipv4Addr::new(10, 0, 0, 1)));
+    }
+
+    #[test]
+    fn scan_addr_skips_an_unusable_v4() {
+        // IFA_FLAGS carrying TENTATIVE (0x40) supersedes the 8-bit flags and disqualifies it.
+        let msg = addr_msg(
+            libc::AF_INET,
+            5,
+            0,
+            &[
+                (libc::IFA_ADDRESS, &[10, 0, 0, 1]),
+                (libc::IFA_FLAGS, &0x40u32.to_ne_bytes()),
+            ],
+        );
+        let mut addrs = InterfaceAddresses::default();
+        scan_addr(&msg, "eth0", 5, &mut addrs, &mut V6Pick::default());
+        assert_eq!(addrs.v4, None);
+    }
+
+    #[test]
+    fn scan_addr_ignores_a_different_ifindex() {
+        let msg = addr_msg(libc::AF_INET, 99, 0, &[(libc::IFA_ADDRESS, &[10, 0, 0, 1])]);
+        let mut addrs = InterfaceAddresses::default();
+        scan_addr(&msg, "eth0", 5, &mut addrs, &mut V6Pick::default());
+        assert_eq!(addrs.v4, None);
+    }
+
+    #[test]
+    fn scan_addr_records_a_usable_v6() {
+        let v6 = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let msg = addr_msg(libc::AF_INET6, 5, 0, &[(libc::IFA_ADDRESS, &v6.octets())]);
+        let mut addrs = InterfaceAddresses::default();
+        scan_addr(&msg, "eth0", 5, &mut addrs, &mut V6Pick::default());
+        assert_eq!(addrs.v6, Some(v6));
+    }
+
+    #[test]
+    fn scan_link_records_the_mac_only_for_the_right_index() {
+        let mac = [0x02, 0, 0, 0, 0, 0x2a];
+        let msg = link_msg(5, &[(libc::IFLA_ADDRESS, &mac)]);
+        let mut addrs = InterfaceAddresses::default();
+        scan_link(&msg, "eth0", 5, &mut addrs);
+        assert_eq!(addrs.mac, Some(MacAddr::from(mac)));
+
+        let mut other = InterfaceAddresses::default();
+        scan_link(&msg, "eth0", 6, &mut other);
+        assert_eq!(other.mac, None);
+    }
+}

--- a/src/net/checksum.rs
+++ b/src/net/checksum.rs
@@ -185,4 +185,16 @@ mod tests {
         let zero = Ipv6Addr::UNSPECIFIED;
         assert_eq!(udp_v6(zero, zero, &[0xff, 0xe6, 0, 0, 0, 0, 0, 0]), 0xffff);
     }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn ipv4_header_panics_on_a_short_header() {
+        let _ = ipv4_header(&[0u8; 11]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn udp_panics_on_a_short_datagram() {
+        let _ = udp_v4(Ipv4Addr::UNSPECIFIED, Ipv4Addr::UNSPECIFIED, &[0u8; 7]);
+    }
 }

--- a/src/net/frame.rs
+++ b/src/net/frame.rs
@@ -475,6 +475,31 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn ethernet_payload_too_large_passes_through_unchanged() {
+        let mac = MacAddr::broadcast();
+        let src = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1);
+        let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 2);
+        let payload = vec![0u8; 65_508];
+        let mut buf = [0u8; 64];
+        // PayloadTooLarge is not rebased onto the L2 header, unlike BufferTooSmall.
+        assert!(matches!(
+            ethernet_ipv4_udp(mac, mac, src, dst, 1, &payload, &mut buf),
+            Err(FrameError::PayloadTooLarge { payload: 65_508 })
+        ));
+    }
+
+    #[test]
+    fn frame_fits_a_buffer_sized_exactly() {
+        let src = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1);
+        let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 2);
+        let mut buf = [0u8; IPV4_HEADER_SIZE + UDP_HEADER_SIZE]; // exactly the empty-payload frame
+        assert_eq!(
+            ipv4_udp(src, dst, 1, &[], &mut buf),
+            Ok(IPV4_HEADER_SIZE + UDP_HEADER_SIZE)
+        );
+    }
+
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     #[test]
     fn dlt_null_ipv4_frame_prefixes_the_host_family() {

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -80,6 +80,19 @@ mod tests {
     }
 
     #[test]
+    fn authority_terminates_at_space_or_cr() {
+        let a = parse_authority(b"http://10.0.0.7:8080 HTTP/1.1", false).unwrap();
+        assert_eq!(a.endpoint, "10.0.0.7:8080".parse().unwrap());
+        assert_eq!(a.len, "10.0.0.7:8080".len());
+        assert_eq!(
+            parse_authority(b"http://10.0.0.7\r", false)
+                .unwrap()
+                .endpoint,
+            "10.0.0.7:80".parse().unwrap()
+        );
+    }
+
+    #[test]
     fn parse_authority_handles_a_bare_host_value() {
         let a = parse_authority(b"192.168.1.5:1900", true).unwrap();
         assert_eq!(a.endpoint, "192.168.1.5:1900".parse().unwrap());

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -749,4 +749,43 @@ mod tests {
             Err(FramingError::MalformedChunkSize)
         ));
     }
+
+    #[test]
+    fn chunk_extensions_are_dropped_from_the_size() {
+        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        let msgs = drain(
+            &mut f,
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5;name=value\r\nhello\r\n0\r\n\r\n",
+        );
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].1, b"5;name=value\r\nhello\r\n0\r\n\r\n");
+    }
+
+    #[test]
+    fn chunked_takes_precedence_over_content_length() {
+        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        f.scan_and_rewrite_header(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\nTransfer-Encoding: chunked\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(f.phase, Phase::BodyChunked);
+    }
+
+    #[test]
+    fn streams_a_chunked_body_across_feeds() {
+        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        // First feed: header, the chunk-size line, and only part of the chunk data.
+        let first = f
+            .feed(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhel")
+            .unwrap();
+        assert_eq!(
+            first.header,
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+        );
+        assert_eq!(first.body, b"5\r\nhel");
+        // Second feed: the rest of the chunk (data + CRLF) then the terminating chunk.
+        let second = f.feed(b"lo\r\n0\r\n\r\n").unwrap();
+        assert_eq!(second.header, b"");
+        assert_eq!(second.body, b"lo\r\n0\r\n\r\n");
+    }
 }

--- a/src/net/mac.rs
+++ b/src/net/mac.rs
@@ -152,4 +152,43 @@ mod tests {
         let mac = MacAddr::multicast_for(IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb)));
         assert_eq!(mac.octets(), [0x33, 0x33, 0x00, 0x00, 0x00, 0xfb]);
     }
+
+    #[test]
+    fn ipv6_multicast_maps_the_low_32_bits() {
+        // Distinct bytes 12..16 pin the mapping (ff02::fb alone can't).
+        let mac = MacAddr::multicast_for(IpAddr::V6(Ipv6Addr::new(
+            0xff02, 0, 0, 0, 0, 0, 0xdead, 0xbeef,
+        )));
+        assert_eq!(mac.octets(), [0x33, 0x33, 0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(debug_assertions),
+        ignore = "multicast_for's guard is a debug_assert!, compiled out in release"
+    )]
+    #[should_panic(expected = "multicast_for requires a multicast address")]
+    fn multicast_for_panics_on_a_non_multicast_address() {
+        let _ = MacAddr::multicast_for(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+    }
+
+    #[test]
+    fn from_str_rejects_malformed() {
+        for s in [
+            "",
+            "01:02:03",             // too few
+            "01:02:03:04:05:06:07", // too many
+            "1:2:3:4:5:6",          // one-digit octets
+            "100:02:03:04:05:06",   // three-digit octet
+            "01::03:04:05:06",      // empty octet
+        ] {
+            assert_eq!(s.parse::<MacAddr>(), Err(ParseMacAddrError), "{s:?}");
+        }
+    }
+
+    #[test]
+    fn mac_display_zero_pads_octets() {
+        let mac = MacAddr::from([0x01, 0x02, 0x03, 0x04, 0x05, 0x0a]);
+        assert_eq!(mac.to_string(), "01:02:03:04:05:0a");
+    }
 }

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -505,4 +505,34 @@ mod tests {
             Err(ParseError::BadLength)
         );
     }
+
+    #[test]
+    fn rejects_udp_length_below_minimum() {
+        let mut buf = [0u8; 64];
+        let n = valid_ethernet_ipv4(&mut buf);
+        buf[38..40].copy_from_slice(&4u16.to_be_bytes()); // UDP length below the 8-byte header
+        assert_eq!(
+            Packet::parse(LinkType::Ethernet, &buf[..n]),
+            Err(ParseError::BadLength)
+        );
+    }
+
+    #[test]
+    fn rejects_l4_region_smaller_than_the_udp_header() {
+        let mut buf = [0u8; 64];
+        let n = valid_ethernet_ipv4(&mut buf);
+        buf[16..18].copy_from_slice(&24u16.to_be_bytes()); // total length leaves 4 bytes for L4
+        assert_eq!(
+            Packet::parse(LinkType::Ethernet, &buf[..n]),
+            Err(ParseError::Truncated)
+        );
+    }
+
+    #[test]
+    fn rejects_ethernet_frame_with_no_l3_bytes() {
+        assert_eq!(
+            Packet::parse(LinkType::Ethernet, &[0u8; ETHERNET_HEADER_SIZE]),
+            Err(ParseError::Truncated)
+        );
+    }
 }

--- a/src/net/ssdp.rs
+++ b/src/net/ssdp.rs
@@ -162,4 +162,13 @@ mod tests {
             None
         );
     }
+
+    #[test]
+    fn mx_reads_leading_digits_then_rejects_u32_overflow() {
+        // A trailing non-digit doesn't void a valid leading number.
+        assert_eq!(parse_msearch_mx(&msearch("3 seconds")), Some(3));
+        assert_eq!(parse_msearch_mx(&msearch("2x")), Some(2));
+        // Too large for u32 is present-but-unparseable (None), not clamped to 5 like a large-but-fits value.
+        assert_eq!(parse_msearch_mx(&msearch("99999999999999")), None);
+    }
 }

--- a/src/net/ssdp/dial.rs
+++ b/src/net/ssdp/dial.rs
@@ -173,4 +173,10 @@ mod tests {
             None // non-numeric
         );
     }
+
+    #[test]
+    fn empty_location_value_is_none() {
+        assert!(parse_dial_location_authority(b"NOTIFY * HTTP/1.1\r\nLOCATION:\r\n\r\n").is_none());
+        assert!(dial_location_value(b"NOTIFY * HTTP/1.1\r\nLOCATION:   \r\n\r\n").is_none());
+    }
 }

--- a/src/net/stream_buffer.rs
+++ b/src/net/stream_buffer.rs
@@ -224,6 +224,16 @@ mod tests {
     }
 
     #[test]
+    fn append_of_empty_data_is_a_noop() {
+        let mut b = StreamBuffer::with_capacity(4);
+        b.append(b"").unwrap();
+        assert!(b.is_empty());
+        b.append(b"ab").unwrap();
+        b.append(b"").unwrap();
+        assert_eq!(b.pending(), b"ab");
+    }
+
+    #[test]
     fn free_tail_mut_offers_the_spare_capacity_and_commit_fills_it() {
         let mut b = StreamBuffer::with_capacity(8);
         b.append(b"ab").unwrap();

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -908,6 +908,47 @@ mod tests {
         );
     }
 
+    #[test]
+    fn watch_on_a_stale_handler_errors() {
+        let mut reactor = Reactor::new().unwrap();
+        let (a, _pa) = pair();
+        let hk = reactor.register(TestHandler::read(a, |_, _| {}));
+        assert!(reactor.unregister(hk).unwrap());
+        // A live fd, so the rejection is due to the stale handler key, not a bad fd.
+        let (b, _pb) = pair();
+        assert!(reactor.watch(hk, b.as_raw_fd(), 0).is_err());
+    }
+
+    #[test]
+    fn watch_failure_errors_and_leaves_the_handler_usable() {
+        let mut reactor = Reactor::new().unwrap();
+        let (a, _pa) = pair();
+        let hk = reactor.register(TestHandler::read(a, |_, _| {}));
+        // A closed (but non-negative) fd fails the kernel add; nothing allocates an fd between the
+        // close and the watch, so the number isn't reused.
+        let closed = {
+            let (c, _pc) = pair();
+            c.as_raw_fd()
+        };
+        assert!(reactor.watch(hk, closed, 0).is_err());
+        // The handler is intact and can still watch a good fd afterward.
+        assert!(reactor.is_registered(hk));
+        let (b, _pb) = pair();
+        assert!(reactor.watch(hk, b.as_raw_fd(), 0).is_ok());
+    }
+
+    #[test]
+    fn setting_interest_on_a_stale_reg_is_a_benign_false() {
+        let mut reactor = Reactor::new().unwrap();
+        let (a, _peer) = pair();
+        let raw = a.as_raw_fd();
+        let (hk, rk) = watch1(&mut reactor, TestHandler::read(a, |_, _| {}), raw);
+        assert!(reactor.unwatch(rk).unwrap());
+        assert!(!reactor.set_write_interest(rk, true).unwrap());
+        assert!(!reactor.set_read_interest(rk, true).unwrap());
+        assert!(reactor.is_registered(hk)); // the handler itself is untouched
+    }
+
     /// A handler with no fd that only carries a timer: it reports `deadline` and runs `on_fire`
     /// when the reactor sweeps it. Lets the deadline path be tested without a real clock or fds.
     struct TimerHandler {

--- a/src/reactor/arena.rs
+++ b/src/reactor/arena.rs
@@ -329,4 +329,76 @@ mod tests {
             assert_eq!(Key::from_u64(key.to_u64()), key);
         }
     }
+
+    #[test]
+    fn remove_with_a_stale_key_spares_the_reused_slots_occupant() {
+        let mut arena = Arena::new();
+        let a = arena.insert("a");
+        arena.remove(a);
+        let b = arena.insert("b");
+        assert_eq!(a.index, b.index);
+        assert_eq!(arena.remove(a), None);
+        assert_eq!(arena.get(b), Some(&"b"));
+        assert!(arena.contains(b));
+    }
+
+    #[test]
+    fn removing_a_stale_key_does_not_double_free() {
+        let mut arena = Arena::new();
+        let a = arena.insert("a");
+        arena.remove(a);
+        assert_eq!(arena.remove(a), None);
+        let b = arena.insert("b");
+        let c = arena.insert("c");
+        assert_ne!(
+            b.index, c.index,
+            "a double-freed slot would be handed out twice"
+        );
+        assert_eq!(arena.get(b), Some(&"b"));
+        assert_eq!(arena.get(c), Some(&"c"));
+    }
+
+    #[test]
+    fn get_mut_misses_on_out_of_range_wrong_generation_and_removed_keys() {
+        let mut arena = Arena::new();
+        let key = arena.insert(1);
+
+        let out_of_range = Key {
+            index: 999,
+            generation: 0,
+        };
+        assert!(arena.get_mut(out_of_range).is_none());
+
+        let wrong_generation = Key {
+            index: key.index,
+            generation: key.generation.wrapping_add(1),
+        };
+        assert!(arena.get_mut(wrong_generation).is_none());
+
+        arena.remove(key);
+        assert!(arena.get_mut(key).is_none());
+    }
+
+    #[test]
+    fn insert_reuses_freed_slots_before_growing() {
+        let mut arena = Arena::new();
+        let freed_lo = arena.insert("lo");
+        let freed_hi = arena.insert("hi");
+        arena.remove(freed_lo);
+        arena.remove(freed_hi);
+        let reused_a = arena.insert("a");
+        let reused_b = arena.insert("b");
+        assert!(reused_a.index == freed_lo.index || reused_a.index == freed_hi.index);
+        assert!(reused_b.index == freed_lo.index || reused_b.index == freed_hi.index);
+        assert_ne!(reused_a.index, reused_b.index);
+        let grown = arena.insert("grown");
+        assert_ne!(grown.index, freed_lo.index);
+        assert_ne!(grown.index, freed_hi.index);
+    }
+
+    #[test]
+    fn iter_on_an_empty_arena_yields_nothing() {
+        let arena: Arena<i32> = Arena::new();
+        assert_eq!(arena.iter().count(), 0);
+    }
 }

--- a/src/reactor/signal.rs
+++ b/src/reactor/signal.rs
@@ -232,6 +232,9 @@ mod tests {
         let n = unsafe { libc::read(pipe.read_fd(), buf.as_mut_ptr().cast(), buf.len()) };
         assert!(n >= 1);
 
+        // A second install while the first guard holds the write fd is refused.
+        assert!(ShutdownPipe::install().is_err());
+
         drop(guard); // restores the previous SIGINT/SIGTERM dispositions
     }
 }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -210,4 +210,24 @@ mod tests {
         assert_eq!(sin6.sin6_addr.s6_addr, v6.octets());
         assert_eq!(sin6.sin6_scope_id, 7);
     }
+
+    #[test]
+    fn would_block_matches_only_eagain_and_ewouldblock() {
+        assert!(would_block(&io::Error::from_raw_os_error(libc::EAGAIN)));
+        assert!(would_block(&io::Error::from_raw_os_error(
+            libc::EWOULDBLOCK
+        )));
+        assert!(!would_block(&io::Error::from_raw_os_error(libc::EPERM)));
+    }
+
+    #[test]
+    fn from_syscall_maps_a_nonnegative_count_to_ready() {
+        assert!(matches!(IoStatus::from_syscall(0), Ok(IoStatus::Ready(0))));
+        assert!(matches!(IoStatus::from_syscall(7), Ok(IoStatus::Ready(7))));
+    }
+
+    #[test]
+    fn owned_fd_from_rejects_a_negative_return() {
+        assert!(owned_fd_from(-1).is_err());
+    }
 }


### PR DESCRIPTION
A module-by-module pass filling genuine unit-test gaps. For each module: enumerated the behaviors/invariants (derived from intent), mapped them to existing tests, and added only the missing high/medium-value ones — no padding of already-well-covered modules.

## Added (14 commits, ~37 tests)
- **reactor/arena** — generational safety: `remove`/`get_mut` reject stale keys (a stale key can't evict a reused slot), no double-free, free-list reuse, empty `iter`. *(These were a real gap — the 12 pre-existing arena tests all passed with the generation check removed; the new ones catch it.)*
- **interface/rtnetlink** — the biggest gap (334 loc, **0 tests**): the netlink parsers (`nl_align`, `read_at`, `rtattrs`, `scan_addr`, `scan_link`) against synthetic messages — address selection (`IFA_LOCAL` over `IFA_ADDRESS`, `IFA_FLAGS` filtering, ifindex match, v4/v6), MAC extraction.
- **net**: mac (parse rejection, IPv6 low-32-bit mapping, Display padding), checksum (short-input panics), frame (Ethernet `PayloadTooLarge` passthrough, exact-fit buffer), packet (UDP-length-below-min, short L4 region, empty L3), ssdp (MX u32-overflow / trailing digits), ssdp/dial (empty LOCATION), http (authority terminators, chunk extensions, TE-over-CL precedence, chunked-across-feeds), stream_buffer (empty append).
- **reactor/signal** (double-install refused), **sys** (`would_block`/`from_syscall`/`owned_fd_from`), **capture/bpf** (over-long frame), **config/value** (`AddressFamily` FromStr, empty `WolPorts`), **address-monitor** parsers (malformed length), **dispatch** (interface-table key handling, DIAL registry pruning + `next_grace`).

## Audited, no additions
Well-covered or e2e-covered orchestration: config.rs/env, dispatch.rs/datagram/multicast, tcp, poll/epoll/kqueue, capture/filter/af_packet, all reflector handlers (mdns/ssdp/advertisement/proxy/search/dial), logging, memory_report, and the intentionally-opaque `error.rs`.

## Teeth verification
Mutation-checked the trickiest/safety-critical tests (new **and** pre-existing): breaking arena's generation filter, rtnetlink's `IFA_F_UNUSABLE` filter, and the pre-existing packet fragment check each fails exactly the guarding test while its positive control still passes. Caught and fixed one no-teeth test (a reactor test that reused a closed fd, so it errored for the wrong reason).

## Verification
- Host + Linux (docker): fmt, clippy `-D warnings`, doc, full test suite — clean (332 macOS / 331 Linux, the `cfg` split).
- e2e (Docker-bridge): 32/32 pass.