### PR TITLE
e2e: cover single-family (address_family) gating

### DIFF
--- a/e2e/config-family-v6.toml
+++ b/e2e/config-family-v6.toml
@@ -1,0 +1,11 @@
+log_level = "debug"
+
+# An IPv6-only SSDP reflector (address_family = "ipv6"), the mirror of config-family.toml's IPv4-only
+# mDNS reflector: it reflects v6 SSDP but never joins the v4 group or registers a v4 handler, so v4 SSDP
+# is ignored. A lone reflector so it can't conflict with the dual "discovery" one in config.toml.
+# (Different protocol from the IPv4 case on purpose, so single-family gating is covered for both.)
+[reflectors.ssdp-v6]
+source_if = "wol_src"
+target_if = "wol_dst"
+ssdp = true
+address_family = "ipv6"

--- a/e2e/config-family.toml
+++ b/e2e/config-family.toml
@@ -1,0 +1,11 @@
+log_level = "debug"
+
+# An IPv4-only mDNS reflector (address_family = "ipv4"), for the single-family gating cases: it
+# reflects v4 mDNS but never joins the v6 group or registers a v6 handler, so v6 mDNS is ignored.
+# A lone reflector (not sharing the interfaces with the dual "discovery" one in config.toml) so the
+# two mDNS reflectors can't conflict.
+[reflectors.mdns-v4]
+source_if = "wol_src"
+target_if = "wol_dst"
+mdns = true
+address_family = "ipv4"

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -154,6 +154,9 @@ class TestCase:
     # Also require the reflected packet's source to be routable (non-link-local) — the per-scope v6
     # source selection: a site-local group (ff05::c) must not be sourced from a link-local address.
     expect_routable_source: bool = False
+    # Reflector config file (relative to e2e/) mounted into the reflector container. Most cases share
+    # config.toml; a case needing a distinct reflector set (e.g. single-family) names its own.
+    config: str = "config.toml"
 
     @property
     def send_address(self) -> str:
@@ -309,6 +312,33 @@ MDNS_CASES = [
         group=MDNS_GROUP_V4,
         direction="forward",
     ),
+    # Single-family gating (address_family = "ipv4"): the reflector reflects v4 mDNS but never joins
+    # the v6 group or registers a v6 handler, so v6 is ignored. The v4 case is the positive control —
+    # it proves the reflector is live, so the v6 expect-none is a real "gated out", not a dead reflector.
+    TestCase(
+        name="ipv4_only_reflector_reflects_mdns_query",
+        config="config-family.toml",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=MDNS_QUERY_HEX,
+        expect_payload_hex=MDNS_QUERY_HEX,
+        group=MDNS_GROUP_V4,
+        direction="forward",
+    ),
+    TestCase(
+        name="ipv4_only_reflector_ignores_mdns_query_ipv6",
+        config="config-family.toml",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=2.0,
+        send_payload_hex=MDNS_QUERY_HEX,
+        group=MDNS_GROUP_V6,
+        family=6,
+        direction="forward",
+    ),
 ]
 
 # SSDP one-way reflection is directional: M-SEARCH searches relay source->target ("forward"), NOTIFY
@@ -424,6 +454,33 @@ SSDP_CASES = [
         send_payload_hex=SSDP_MSEARCH_HEX,
         group=SSDP_GROUP_V4,
         direction="forward",
+    ),
+    # Single-family gating, the IPv6 mirror of the IPv4-only mDNS cases (a different protocol on
+    # purpose): an address_family = "ipv6" SSDP reflector reflects v6 NOTIFY but never joins the v4
+    # group or registers a v4 handler, so v4 is ignored. The v6 case is the positive control.
+    TestCase(
+        name="ipv6_only_reflector_reflects_ssdp_notify",
+        config="config-family-v6.toml",
+        send_port=SSDP_PORT,
+        receive_port=SSDP_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SSDP_NOTIFY_HEX,
+        expect_payload_hex=SSDP_NOTIFY_HEX,
+        group=SSDP_GROUP_V6,
+        family=6,
+        direction="reverse",
+    ),
+    TestCase(
+        name="ipv6_only_reflector_ignores_ssdp_notify_ipv4",
+        config="config-family-v6.toml",
+        send_port=SSDP_PORT,
+        receive_port=SSDP_PORT,
+        expect_mac=None,
+        timeout_seconds=2.0,
+        send_payload_hex=SSDP_NOTIFY_HEX,
+        group=SSDP_GROUP_V4,
+        direction="reverse",
     ),
 ]
 
@@ -594,7 +651,7 @@ class DockerE2E:
         self.sender_container = f"{self.prefix}-sender"
         self.containers = [self.sender_container, self.receiver_container, self.reflector_container]
         self.networks = [self.source_network, self.target_network]
-        self.config_path = E2E_DIR / "config.toml"
+        self.config_path = E2E_DIR / case.config
 
         self._select_direction(case.direction)
 


### PR DESCRIPTION
## Assessment
The e2e suite was already comprehensive (both directions × both families, rejection cases, SSDP round-trips, DIAL, mDNS address-change). The one genuine gap: no case proved that restricting a reflector to one family **excludes** the other — the negative assertion for the headline `address_family` option.

## Change
Two single-family reflectors, each on its own config (a lone reflector so it can't conflict with the dual `discovery` one in `config.toml`), and for each a positive control plus a negative case. Different protocols on purpose, so gating is covered for both mDNS and SSDP:

- **`config-family.toml` — IPv4-only mDNS**: `ipv4_only_reflector_reflects_mdns_query` (v4 reflects) + `ipv4_only_reflector_ignores_mdns_query_ipv6` (v6 ignored).
- **`config-family-v6.toml` — IPv6-only SSDP**: `ipv6_only_reflector_reflects_ssdp_notify` (v6 reflects) + `ipv6_only_reflector_ignores_ssdp_notify_ipv4` (v4 ignored).

`TestCase` gains a `config` field so a case can mount its own reflector config (the `AddressChangeCase` runner already did this; the standard runner now does too).

## Verification
- Full e2e suite: **36/36 pass** (32 existing + 4 new). Rebased onto current `main` (post-#9).
- **Teeth-checked both directions**: flipping either config to `address_family = "dual"` makes its ignore-case fail (the excluded family gets reflected), confirming each catches a family-gating regression.