### PR TITLE
BREAKING: Replace per-reflector mac with a macs allow-set (v0.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "reflector"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflector"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.93"
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ It reflects three link-local protocols, and layers an optional DIAL proxy on top
   [DIAL](#dial).
 
 Each named entry bridges one `source_if` → `target_if` interface pair and enables any combination of
-these. The same shape serves a single device (pin its `mac`) or a whole network (omit it).
+these. The same shape serves one or a few specific devices (`macs`) or a whole network (omit it).
 
 ## Contents
 
 - [Platform support](#platform-support)
 - [Build](#build)
 - [Run](#run) — [privileges](#runtime-privileges), [Docker](#run-in-docker), [MikroTik](#on-mikrotik-routeros)
-- [Configuration](#configuration) — [env vars](#environment-variables), [`mac`](#the-mac-field), [`address_family`](#address_family), [per-protocol behavior](#per-protocol-behavior), [DIAL](#dial), [duplicate detection](#duplicate-detection)
+- [Configuration](#configuration) — [env vars](#environment-variables), [`macs`](#the-macs-field), [`address_family`](#address_family), [per-protocol behavior](#per-protocol-behavior), [DIAL](#dial), [duplicate detection](#duplicate-detection)
 - [Tests](#tests)
 - [Release](#release)
 - [License](#license)
@@ -198,7 +198,7 @@ them as the entry's `source_if` / `target_if`:
 [reflectors.livingroom-tv]
 source_if = "veth-lan"   # veth bridged into the LAN VLAN
 target_if = "veth-iot"   # veth bridged into the IoT VLAN
-mac       = "B0:37:95:C5:60:BE"   # optional; target a specific device (omit for the whole VLAN)
+macs      = ["B0:37:95:C5:60:BE"] # optional; scope to specific device(s) (omit for the whole VLAN)
 wol       = true         # enable Wake-on-LAN, disabled by default
 mdns      = true         # enable mDNS, disabled by default
 ssdp      = true         # enable SSDP, disabled by default
@@ -207,7 +207,7 @@ dial      = true         # enable the DIAL proxy, disabled by default
 
 On RouterOS, setting the container's environment variables is usually easier than mounting a file: the
 entry above becomes `REFLECTOR_TV_SOURCE_IF=veth-lan`, `REFLECTOR_TV_TARGET_IF=veth-iot`,
-`REFLECTOR_TV_MAC=B0:37:95:C5:60:BE`, `REFLECTOR_TV_WOL=true`, and so on (see
+`REFLECTOR_TV_MACS=B0:37:95:C5:60:BE`, `REFLECTOR_TV_WOL=true`, and so on (see
 [Environment variables](#environment-variables)). To use the file instead, mount it to
 `/etc/reflector/config.toml` and set that path as the container's command argument. For the RouterOS
 side — enabling container mode, creating the `veth`s, and attaching each to its VLAN — see MikroTik's
@@ -227,7 +227,7 @@ debug_memory = false             # optional; periodically log RSS + heap stats f
 [reflectors.tv]
 source_if = "en0"                # required; interface to listen on (must differ from target_if)
 target_if = "lo0"                # required; interface to emit reflected traffic on
-mac       = "B0:37:95:C5:60:BE"  # optional; the device's MAC (see below). Omit for a whole network.
+macs      = ["B0:37:95:C5:60:BE"] # optional; device(s) to scope to (see below). Omit for a whole network.
 wol       = true                 # optional; enable Wake-on-LAN reflection (default false)
 mdns      = true                 # optional; enable mDNS reflection (default false)
 ssdp      = true                 # optional; enable SSDP reflection (default false)
@@ -237,8 +237,9 @@ address_family = "default"       # optional; default | dual | ipv4 | ipv6 (defau
 ```
 
 An entry must enable at least one protocol and expands into one reflector per enabled protocol, all
-sharing the entry's interfaces, `mac`, and `address_family`. The same shape serves a single device (set
-`mac`) or a whole network (omit `mac`). No IP addresses ever appear in the config. `dial` is not a
+sharing the entry's interfaces, MAC selection, and `address_family`. The same shape serves one or a few
+specific devices (set `macs`) or a whole network (omit it). No IP addresses ever
+appear in the config. `dial` is not a
 separate reflector — it augments the entry's SSDP reflector with the DIAL application proxy (so it
 requires `ssdp`; see [DIAL](#dial)).
 
@@ -250,18 +251,19 @@ then optional; with none, the environment is the whole configuration. Variables 
 
 - `<TAG>` ties one entry's parameters together — any alphanumeric string (`1`, `2`, `TV`, …). It also
   becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
-- `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MAC`, `WOL`,
-  `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
+- `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
+  `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
 
 The globals are `REFLECTOR_LOG_LEVEL` and `REFLECTOR_DEBUG_MEMORY`, so `LOG` and `DEBUG` are reserved
-tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` is comma-separated (`7,9`). The
+tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` and `MACS` are comma-separated (`7,9` /
+`B0:...,C4:...`). The
 `[reflectors.tv]` entry above looks like this in the environment:
 
 ```sh
 REFLECTOR_LOG_LEVEL=info
 REFLECTOR_TV_SOURCE_IF=en0
 REFLECTOR_TV_TARGET_IF=lo0
-REFLECTOR_TV_MAC=B0:37:95:C5:60:BE
+REFLECTOR_TV_MACS=B0:37:95:C5:60:BE
 REFLECTOR_TV_WOL=true
 REFLECTOR_TV_MDNS=true
 REFLECTOR_TV_SSDP=true
@@ -274,19 +276,22 @@ combined configuration, and `REFLECTOR_LOG_LEVEL` / `REFLECTOR_DEBUG_MEMORY` ove
 sources. An unknown `<PARAM>`, a non-alphanumeric or reserved tag, and a tag with no parameter are all
 rejected at startup.
 
-### The `mac` field
+### The `macs` field
 
-`mac` is optional and, when set, names a single device — coherently across WoL, mDNS, and SSDP, because
-a device's NIC MAC is both the target of its Wake-on-LAN magic packet and the L2 source of its mDNS/SSDP
-advertisements:
+`macs` is an optional list naming the device(s) an entry is scoped to — coherently across WoL, mDNS,
+and SSDP, because a device's NIC MAC is both the target of its Wake-on-LAN magic packet and the L2
+source of its mDNS/SSDP advertisements. A single device is just a one-entry list
+(`macs = ["B0:37:95:C5:60:BE"]`); list several to scope one entry to a set of devices
+(`macs = ["B0:37:95:C5:60:BE", "C4:9D:8F:11:22:33"]`). Below, "the allow-set" means the configured
+devices:
 
-- **WoL** re-emits only magic packets whose payload targets `mac`.
-- **mDNS / SSDP** relay, in the target→source direction, only frames whose L2 source MAC is `mac`
-  (exposing just that device); the source→target direction is never MAC-filtered. For SSDP the same
-  filter scopes the proxied unicast `200 OK` replies — only `mac`'s responses are carried back to a
-  searcher.
+- **WoL** re-emits only magic packets whose payload targets a device in the allow-set.
+- **mDNS / SSDP** relay, in the target→source direction, only frames whose L2 source MAC is in the
+  allow-set (exposing just those devices); the source→target direction is never MAC-filtered. For SSDP
+  the same filter scopes the proxied unicast `200 OK` replies — only the allow-set's responses are
+  carried back to a searcher.
 
-Omit `mac` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP reflect all
+Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP reflect all
 traffic in both directions.
 
 ### `address_family`
@@ -367,8 +372,8 @@ Entry names must be unique across the file and the environment — a name that a
 same name from both sources) is rejected at startup. Beyond that, two entries that enable the same
 protocol are rejected as a duplicate of that protocol only when they could reflect the same packet
 twice: same `source_if`, same `target_if`, overlapping MAC selection, overlapping address-family
-handling, and — for WoL — at least one shared port. MAC selection overlaps when both entries set the
-same `mac`, or when either omits `mac` (any device). Address-family handling overlaps when both can
+handling, and — for WoL — at least one shared port. MAC selection overlaps when the entries' allow-sets
+share at least one device, or when either omits its MAC filter (any device). Address-family handling overlaps when both can
 handle the same IP version: an `ipv4`-only and an `ipv6`-only entry never overlap, while `default`/`dual`
 overlap with either. Entries that differ in interface, MAC, address family (or WoL ports), or that
 enable *different* protocols, coexist.

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -7,7 +7,7 @@ log_level = "debug"
 [reflectors.wol-mac]
 source_if = "wol_src"
 target_if = "wol_dst"
-mac = "02:42:ac:11:00:09"
+macs = ["02:42:ac:11:00:09", "02:42:ac:11:00:0c"]
 wol = true
 wol_ports = [40009]
 

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -36,6 +36,8 @@ DEFAULT_REFLECTOR_IMAGE = "reflector:e2e"
 VALGRIND_REFLECTOR_IMAGE = "reflector:e2e-valgrind"
 DEFAULT_HELPER_IMAGE = "python:3.13-alpine"
 CONFIGURED_MAC = "02:42:ac:11:00:09"
+# A second address in wol-mac's `macs` allow-set, to prove the list admits every member, not just the first.
+SECOND_CONFIGURED_MAC = "02:42:ac:11:00:0c"
 WRONG_MAC = "02:42:ac:11:00:0a"
 CONFIGURED_PORT = 40009
 UNCONFIGURED_PORT = 40010
@@ -182,6 +184,14 @@ TEST_CASES = [
         timeout_seconds=5.0,
         send_mac=CONFIGURED_MAC,
         family=6,
+    ),
+    TestCase(
+        name="reflects_second_configured_mac",
+        send_port=CONFIGURED_PORT,
+        receive_port=CONFIGURED_PORT,
+        expect_mac=SECOND_CONFIGURED_MAC,
+        timeout_seconds=5.0,
+        send_mac=SECOND_CONFIGURED_MAC,
     ),
     TestCase(
         name="ignores_wrong_mac",

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ use std::str::FromStr;
 use serde::Deserialize;
 
 use self::raw::{RawConfig, RawReflector};
-use crate::net::mac::MacAddr;
+use crate::net::mac::MacSet;
 
 /// Wake-on-LAN settings (present only when `WoL` is enabled for the reflector).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,8 +55,8 @@ pub(crate) struct Reflector {
     pub(crate) source_if: InterfaceName,
     /// Interface to emit on (always different from `source_if`).
     pub(crate) target_if: InterfaceName,
-    /// Optional MAC filter; `None` matches any device.
-    pub(crate) mac: Option<MacAddr>,
+    /// Optional device allow-filter; `None` matches any device, `Some` a non-empty set.
+    pub(crate) macs: Option<MacSet>,
     /// IP-version policy for this reflector.
     pub(crate) address_family: AddressFamily,
     /// Wake-on-LAN settings, or `None` when `WoL` is disabled.
@@ -74,7 +74,7 @@ impl Reflector {
         if self.source_if != other.source_if || self.target_if != other.target_if {
             return None;
         }
-        if !macs_overlap(self.mac, other.mac)
+        if !macs_overlap(self.macs.as_ref(), other.macs.as_ref())
             || !families_overlap(self.address_family, other.address_family)
         {
             return None;
@@ -144,7 +144,7 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             name,
             source_if,
             target_if,
-            mac: raw.mac,
+            macs: raw.macs,
             address_family: raw.address_family,
             wol,
             mdns: raw.mdns,
@@ -283,11 +283,11 @@ fn protocol_list(reflector: &Reflector) -> String {
     protocols.join(", ")
 }
 
-/// Two MAC selections overlap when both name the same address or either is
+/// Two MAC selections overlap when they share at least one address, or either is
 /// absent (an absent filter matches any device).
-fn macs_overlap(a: Option<MacAddr>, b: Option<MacAddr>) -> bool {
+fn macs_overlap(a: Option<&MacSet>, b: Option<&MacSet>) -> bool {
     match (a, b) {
-        (Some(a), Some(b)) => a == b,
+        (Some(a), Some(b)) => a.iter().any(|mac| b.contains(mac)),
         _ => true,
     }
 }
@@ -347,7 +347,7 @@ mod tests {
         assert_eq!(r.source_if.as_str(), "lan");
         assert_eq!(r.target_if.as_str(), "iot");
         assert!(r.mdns);
-        assert!(r.mac.is_none());
+        assert!(r.macs.is_none());
         assert_eq!(r.address_family, AddressFamily::Default);
         assert!(r.wol.is_none());
         assert!(r.ssdp.is_none());
@@ -363,7 +363,7 @@ mod tests {
             [reflectors.tv]
             source_if = "en0"
             target_if = "lo0"
-            mac = "B0:37:95:C5:60:BE"
+            macs = ["B0:37:95:C5:60:BE"]
             wol = true
             mdns = true
             ssdp = true
@@ -380,7 +380,9 @@ mod tests {
         assert_eq!(r.name.as_str(), "tv");
         assert_eq!(r.source_if.as_str(), "en0");
         assert_eq!(r.target_if.as_str(), "lo0");
-        assert_eq!(r.mac.unwrap().to_string(), "b0:37:95:c5:60:be");
+        let macs = r.macs.as_ref().unwrap();
+        assert_eq!(macs.len(), 1);
+        assert_eq!(macs[0].to_string(), "b0:37:95:c5:60:be");
         let wol = r.wol.as_ref().unwrap();
         assert!(r.mdns);
         let ssdp = r.ssdp.unwrap();
@@ -609,7 +611,7 @@ mod tests {
             source_if = "a"
             target_if = "b"
             mdns = true
-            mac = "zz:zz:zz:zz:zz:zz"
+            macs = ["zz:zz:zz:zz:zz:zz"]
         "#;
         assert!(matches!(err(text), ConfigError::Parse(_)));
     }
@@ -747,26 +749,26 @@ mod tests {
             source_if = "lan"
             target_if = "iot"
             mdns = true
-            mac = "00:00:00:00:00:01"
+            macs = ["00:00:00:00:00:01"]
 
             [reflectors.b]
             source_if = "lan"
             target_if = "iot"
             mdns = true
-            mac = "00:00:00:00:00:02"
+            macs = ["00:00:00:00:00:02"]
         "#;
         assert!(from_toml(text).is_ok());
     }
 
     #[test]
-    fn omitted_mac_conflicts_with_any() {
+    fn omitted_macs_conflicts_with_any() {
         // An absent MAC filter matches any device, so it overlaps a specific one.
         let text = r#"
             [reflectors.a]
             source_if = "lan"
             target_if = "iot"
             mdns = true
-            mac = "00:00:00:00:00:01"
+            macs = ["00:00:00:00:00:01"]
 
             [reflectors.b]
             source_if = "lan"
@@ -780,6 +782,92 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn macs_list_parses() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.tv]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            macs = ["00:00:00:00:00:01", "00:00:00:00:00:02"]
+            "#,
+        )
+        .unwrap();
+        let macs = cfg.reflectors[0].macs.as_ref().unwrap();
+        assert_eq!(macs.len(), 2);
+        assert!(macs.contains(&"00:00:00:00:00:01".parse().unwrap()));
+        assert!(macs.contains(&"00:00:00:00:00:02".parse().unwrap()));
+    }
+
+    #[test]
+    fn legacy_mac_field_is_now_unknown() {
+        // `mac` was replaced by `macs` in 0.9.0; deny_unknown_fields rejects the old key.
+        let text = r#"
+            [reflectors.tv]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            mac = "02:42:ac:11:00:09"
+        "#;
+        assert!(matches!(err(text), ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn empty_macs_list_rejected() {
+        let text = r#"
+            [reflectors.tv]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            macs = []
+        "#;
+        assert!(matches!(err(text), ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn overlapping_macs_sets_conflict() {
+        // The two allow-sets share 00:..:02, so both would reflect that device's mDNS.
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            macs = ["00:00:00:00:00:01", "00:00:00:00:00:02"]
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            macs = ["00:00:00:00:00:02", "00:00:00:00:00:03"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Mdns,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn disjoint_macs_sets_do_not_conflict() {
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            macs = ["00:00:00:00:00:01", "00:00:00:00:00:02"]
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            macs = ["00:00:00:00:00:03", "00:00:00:00:00:04"]
+        "#;
+        assert!(from_toml(text).is_ok());
     }
 
     #[test]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::error::{ConfigError, ParseBoolError, ParseValueError, RequiredField};
 use super::raw::{RawConfig, RawReflector};
 use super::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
-use crate::net::mac::MacAddr;
+use crate::net::mac::MacSet;
 
 /// Accumulates a reflector's fields across its `REFLECTOR_<tag>_<param>` variables,
 /// then converts to a [`RawReflector`] once all are seen.
@@ -19,7 +19,7 @@ struct PartialReflector {
     name: Option<ReflectorName>,
     source_if: Option<InterfaceName>,
     target_if: Option<InterfaceName>,
-    mac: Option<MacAddr>,
+    macs: Option<MacSet>,
     wol: Option<bool>,
     mdns: Option<bool>,
     ssdp: Option<bool>,
@@ -35,7 +35,7 @@ impl PartialReflector {
             "name" => self.name = Some(env_value(value, var)?),
             "source_if" => self.source_if = Some(env_value(value, var)?),
             "target_if" => self.target_if = Some(env_value(value, var)?),
-            "mac" => self.mac = Some(env_value(value, var)?),
+            "macs" => self.macs = Some(env_value(value, var)?),
             "wol_ports" => self.wol_ports = Some(env_value(value, var)?),
             "address_family" => self.address_family = Some(env_value(value, var)?),
             "wol" => self.wol = Some(env_bool(value, var)?),
@@ -64,7 +64,7 @@ impl PartialReflector {
                 name: name.to_owned(),
                 field: RequiredField::TargetIf,
             })?,
-            mac: self.mac,
+            macs: self.macs,
             wol: self.wol.unwrap_or(false),
             mdns: self.mdns.unwrap_or(false),
             ssdp: self.ssdp.unwrap_or(false),
@@ -261,6 +261,36 @@ mod tests {
     }
 
     #[test]
+    fn env_macs_csv() {
+        let cfg = from_env(&[
+            ("REFLECTOR_TV_SOURCE_IF", "a"),
+            ("REFLECTOR_TV_TARGET_IF", "b"),
+            ("REFLECTOR_TV_MDNS", "true"),
+            ("REFLECTOR_TV_MACS", "00:00:00:00:00:01, 00:00:00:00:00:02"),
+        ])
+        .unwrap();
+        let macs = cfg.reflectors[0].macs.as_ref().unwrap();
+        // The two addresses parse, in order, with the surrounding CSV whitespace trimmed.
+        let addrs: Vec<String> = macs.iter().map(ToString::to_string).collect();
+        assert_eq!(addrs, ["00:00:00:00:00:01", "00:00:00:00:00:02"]);
+    }
+
+    #[test]
+    fn env_legacy_mac_param_is_now_unknown() {
+        // `mac` was replaced by `macs` in 0.9.0; the old singular param is no longer recognized.
+        assert!(matches!(
+            from_env(&[
+                ("REFLECTOR_TV_SOURCE_IF", "a"),
+                ("REFLECTOR_TV_TARGET_IF", "b"),
+                ("REFLECTOR_TV_MDNS", "true"),
+                ("REFLECTOR_TV_MAC", "02:42:ac:11:00:09"),
+            ])
+            .unwrap_err(),
+            ConfigError::EnvUnknownParam { param, .. } if param == "mac"
+        ));
+    }
+
+    #[test]
     fn env_reuses_cross_field_validation() {
         let e = from_env(&[
             ("REFLECTOR_TV_SOURCE_IF", "a"),
@@ -408,9 +438,9 @@ mod tests {
             }
         ));
         assert!(matches!(
-            from_env(&[("REFLECTOR_TV_MAC", "zz")]).unwrap_err(),
+            from_env(&[("REFLECTOR_TV_MACS", "zz")]).unwrap_err(),
             ConfigError::EnvBadValue {
-                source: ParseValueError::Mac(_),
+                source: ParseValueError::Macs(_),
                 ..
             }
         ));

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -12,7 +12,7 @@ use super::value::{
     InterfaceName, ParseAddressFamilyError, ParseInterfaceNameError, ParseLogLevelError,
     ParseReflectorNameError, ReflectorName, WolPortsError,
 };
-use crate::net::mac::ParseMacAddrError;
+use crate::net::mac::MacSetError;
 
 /// Everything that can make a configuration invalid.
 ///
@@ -146,9 +146,9 @@ pub(crate) enum ParseValueError {
     /// `ADDRESS_FAMILY`.
     #[error(transparent)]
     AddressFamily(#[from] ParseAddressFamilyError),
-    /// `MAC`.
+    /// `MACS`.
     #[error(transparent)]
-    Mac(#[from] ParseMacAddrError),
+    Macs(#[from] MacSetError),
     /// `SOURCE_IF`/`TARGET_IF`.
     #[error(transparent)]
     Interface(#[from] ParseInterfaceNameError),

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 
 use super::error::ConfigError;
 use super::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
-use crate::net::mac::MacAddr;
+use crate::net::mac::MacSet;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -35,7 +35,7 @@ pub(super) struct RawReflector {
     pub(super) name: Option<ReflectorName>,
     pub(super) source_if: InterfaceName,
     pub(super) target_if: InterfaceName,
-    pub(super) mac: Option<MacAddr>,
+    pub(super) macs: Option<MacSet>,
     #[serde(default)]
     pub(super) wol: bool,
     #[serde(default)]

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -32,7 +32,7 @@ use std::time::Instant;
 use crate::capture::Capture;
 use crate::interface::{AddressMonitor, InterfaceAddresses};
 use crate::net::LinkType;
-use crate::net::mac::MacAddr;
+use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
 use crate::reactor::{Arena, Handler, Key, Reactor, ReadyEvent};
 
@@ -92,13 +92,14 @@ pub(crate) struct RegistrationKey(Key);
 /// An optional-field packet filter: an unset field
 /// matches anything. A `src_mac`/`dst_mac` filter never matches a `DLT_NULL` packet,
 /// which has no L2 addresses.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub(crate) struct Filter {
     pub(crate) src_ip: Option<IpAddr>,
     pub(crate) dst_ip: Option<IpAddr>,
     pub(crate) src_port: Option<u16>,
     pub(crate) dst_port: Option<u16>,
-    pub(crate) src_mac: Option<MacAddr>,
+    /// Allow-set on the source MAC: the packet's source must be a member.
+    pub(crate) src_mac: Option<MacSet>,
     pub(crate) dst_mac: Option<MacAddr>,
 }
 
@@ -109,7 +110,10 @@ impl Filter {
             && self.dst_ip.is_none_or(|ip| p.dest.ip() == ip)
             && self.src_port.is_none_or(|port| p.source.port() == port)
             && self.dst_port.is_none_or(|port| p.dest.port() == port)
-            && self.src_mac.is_none_or(|mac| p.src_mac == Some(mac))
+            && self
+                .src_mac
+                .as_ref()
+                .is_none_or(|set| p.src_mac.is_some_and(|mac| set.contains(&mac)))
             && self.dst_mac.is_none_or(|mac| p.dst_mac == Some(mac))
     }
 }
@@ -676,7 +680,7 @@ mod tests {
     fn filter_matches_source_mac_and_excludes_others() {
         let device = MacAddr::from([0x02, 0, 0, 0, 0, 0x01]);
         let f = Filter {
-            src_mac: Some(device),
+            src_mac: Some(MacSet::from(device)),
             ..Filter::default()
         };
         assert!(f.matches(&packet(
@@ -689,6 +693,21 @@ mod tests {
         let other = MacAddr::from([0x02, 0, 0, 0, 0, 0x02]);
         assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(other))));
         assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, None)));
+    }
+
+    #[test]
+    fn filter_source_mac_set_matches_any_member() {
+        let a = MacAddr::from([0x02, 0, 0, 0, 0, 0x01]);
+        let b = MacAddr::from([0x02, 0, 0, 0, 0, 0x02]);
+        let f = Filter {
+            src_mac: Some(MacSet::try_from(vec![a, b]).unwrap()),
+            ..Filter::default()
+        };
+        assert!(f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(a))));
+        assert!(f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(b))));
+        // A device outside the set misses.
+        let other = MacAddr::from([0x02, 0, 0, 0, 0, 0x03]);
+        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(other))));
     }
 
     #[test]

--- a/src/net/mac.rs
+++ b/src/net/mac.rs
@@ -3,6 +3,7 @@
 
 use std::fmt;
 use std::net::IpAddr;
+use std::ops::Deref;
 use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer};
@@ -101,6 +102,82 @@ impl<'de> Deserialize<'de> for MacAddr {
     }
 }
 
+/// A non-empty, duplicate-free set of MAC addresses: a device allow-filter.
+///
+/// The set is always non-empty (mirroring [`WolPorts`](crate::config::WolPorts));
+/// "match any device" is expressed by an absent (`None`) filter at the use site,
+/// not by an empty set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MacSet(Vec<MacAddr>);
+
+impl Deref for MacSet {
+    type Target = [MacAddr];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Error returned when a value is not a valid [`MacSet`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum MacSetError {
+    #[error("macs must not be empty")]
+    Empty,
+    #[error("macs contains duplicate address {0}")]
+    Duplicate(MacAddr),
+    /// A comma-separated token was not a valid MAC address.
+    #[error("macs has an invalid address \"{0}\"")]
+    BadMac(String),
+}
+
+/// A single address is a valid one-element set.
+impl From<MacAddr> for MacSet {
+    fn from(mac: MacAddr) -> Self {
+        MacSet(vec![mac])
+    }
+}
+
+impl TryFrom<Vec<MacAddr>> for MacSet {
+    type Error = MacSetError;
+
+    fn try_from(macs: Vec<MacAddr>) -> Result<Self, Self::Error> {
+        if macs.is_empty() {
+            return Err(MacSetError::Empty);
+        }
+        for (i, mac) in macs.iter().enumerate() {
+            if macs[..i].contains(mac) {
+                return Err(MacSetError::Duplicate(*mac));
+            }
+        }
+        Ok(Self(macs))
+    }
+}
+
+impl FromStr for MacSet {
+    type Err = MacSetError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let macs = s
+            .split(',')
+            .map(|token| {
+                let token = token.trim();
+                token
+                    .parse::<MacAddr>()
+                    .map_err(|_| MacSetError::BadMac(token.to_owned()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        MacSet::try_from(macs)
+    }
+}
+
+impl<'de> Deserialize<'de> for MacSet {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Vec::<MacAddr>::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,5 +267,40 @@ mod tests {
     fn mac_display_zero_pads_octets() {
         let mac = MacAddr::from([0x01, 0x02, 0x03, 0x04, 0x05, 0x0a]);
         assert_eq!(mac.to_string(), "01:02:03:04:05:0a");
+    }
+
+    #[test]
+    fn mac_set_parses_a_csv_via_fromstr() {
+        let set = "aa:bb:cc:dd:ee:01, aa:bb:cc:dd:ee:02"
+            .parse::<MacSet>()
+            .unwrap();
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&MacAddr::from([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01])));
+        assert!(set.contains(&MacAddr::from([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x02])));
+        assert!(!set.contains(&MacAddr::from([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x03])));
+    }
+
+    #[test]
+    fn mac_set_from_a_single_address() {
+        let mac = MacAddr::from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        let set = MacSet::from(mac);
+        assert_eq!(&*set, &[mac]);
+    }
+
+    #[test]
+    fn mac_set_rejects_duplicates_and_bad_and_empty() {
+        assert!(matches!(
+            "aa:bb:cc:dd:ee:01,aa:bb:cc:dd:ee:01".parse::<MacSet>(),
+            Err(MacSetError::Duplicate(_))
+        ));
+        assert!(matches!(
+            "aa:bb:cc:dd:ee:01,zz".parse::<MacSet>(),
+            Err(MacSetError::BadMac(bad)) if bad == "zz"
+        ));
+        // FromStr can't yield an empty list, so Empty is reachable only via TryFrom.
+        assert!(matches!(
+            MacSet::try_from(Vec::<MacAddr>::new()),
+            Err(MacSetError::Empty)
+        ));
     }
 }

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -135,7 +135,7 @@ pub(crate) fn build(
             Filter {
                 dst_ip: Some(group_ip),
                 dst_port: Some(MDNS_PORT),
-                src_mac: reflector.mac,
+                src_mac: reflector.macs.clone(),
                 ..Filter::default()
             },
             Box::new(MdnsReflector {

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -129,7 +129,7 @@ pub(crate) fn build(
             Filter {
                 dst_ip: Some(group_ip),
                 dst_port: Some(SSDP_PORT),
-                src_mac: reflector.mac,
+                src_mac: reflector.macs.clone(),
                 ..Filter::default()
             },
             Box::new(SsdpAdvertisementReflector::new(source, dial)),
@@ -147,7 +147,7 @@ pub(crate) fn build(
                 source,
                 target,
                 target_ifindex,
-                reflector.mac,
+                reflector.macs.clone(),
                 dial,
             )),
         );

--- a/src/reflector/ssdp/search.rs
+++ b/src/reflector/ssdp/search.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler, RegistrationKey};
 use crate::interface::{InterfaceAddresses, Ipv6Scope};
-use crate::net::mac::MacAddr;
+use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
 use crate::net::port_reservation::PortReservation;
 use crate::net::ssdp::{MSEARCH_MX_DEFAULT, SSDP_TTL, SsdpKind, classify, parse_msearch_mx};
@@ -110,8 +110,8 @@ pub(super) struct SsdpSearchReflector {
     target: CaptureKey,
     /// The target interface's index, for the IPv6 link-local reserved-port bind.
     target_ifindex: u32,
-    /// The configured device MAC, scoping the response capture as the advertisement direction is.
-    device_mac: Option<MacAddr>,
+    /// The configured device allow-set, scoping the response capture as the advertisement direction is.
+    device_macs: Option<MacSet>,
     /// DIAL `LOCATION` rewriting, stamped into each session's [`SsdpResponseReflector`].
     dial: Option<DialRewrite>,
     sessions: Vec<Session>,
@@ -122,14 +122,14 @@ impl SsdpSearchReflector {
         source: CaptureKey,
         target: CaptureKey,
         target_ifindex: u32,
-        device_mac: Option<MacAddr>,
+        device_macs: Option<MacSet>,
         dial: Option<DialRewrite>,
     ) -> Self {
         Self {
             source,
             target,
             target_ifindex,
-            device_mac,
+            device_macs,
             dial,
             sessions: Vec::new(),
         }
@@ -196,7 +196,7 @@ impl SsdpSearchReflector {
             Filter {
                 dst_ip: Some(our_addr),
                 dst_port: Some(reservation.port()),
-                src_mac: self.device_mac,
+                src_mac: self.device_macs.clone(),
                 ..Filter::default()
             },
             Box::new(SsdpResponseReflector {

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -10,7 +10,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler};
-use crate::net::mac::MacAddr;
+use crate::net::mac::MacSet;
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
 
@@ -32,8 +32,8 @@ const V6_ALL_NODES: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
 /// One is registered per configured port.
 struct WolReflector {
     egress: CaptureKey,
-    /// Optional device filter; `None` reflects a wake for any device.
-    target_mac: Option<MacAddr>,
+    /// Optional device allow-set; `None` reflects a wake for any device.
+    target_macs: Option<MacSet>,
     /// IP-version policy: which families this reflector re-emits.
     family: AddressFamily,
 }
@@ -45,7 +45,7 @@ impl PacketHandler for WolReflector {
         dispatcher: &mut PacketDispatcher,
         _reactor: &mut Reactor,
     ) {
-        if !is_magic_packet(packet.payload, self.target_mac) {
+        if !is_magic_packet(packet.payload, self.target_macs.as_ref()) {
             log::debug!("WoL: ignoring non-magic packet from {}", packet.source);
             return;
         }
@@ -84,9 +84,9 @@ impl PacketHandler for WolReflector {
 /// Whether `payload` opens with a Wake-on-LAN magic packet for an acceptable target: the
 /// `6×0xFF` prefix followed by one MAC repeated 16 times. Trailing bytes (a `SecureOn` password)
 /// are ignored — only the leading [`MAGIC_LEN`] are inspected — and the caller forwards them
-/// as-is. When `target_mac` is set, the repeated MAC must equal it, so only that one device's
+/// as-is. When `targets` is set, the repeated MAC must be a member, so only those devices'
 /// wakes are reflected.
-fn is_magic_packet(payload: &[u8], target_mac: Option<MacAddr>) -> bool {
+fn is_magic_packet(payload: &[u8], targets: Option<&MacSet>) -> bool {
     let Some(magic) = payload.get(..MAGIC_LEN) else {
         return false;
     };
@@ -101,8 +101,8 @@ fn is_magic_packet(payload: &[u8], target_mac: Option<MacAddr>) -> bool {
     {
         return false;
     }
-    // A configured target narrows the reflector to that device's wake.
-    target_mac.is_none_or(|target| mac == target.octets())
+    // A configured allow-set narrows the reflector to those devices' wakes.
+    targets.is_none_or(|targets| targets.iter().any(|target| mac == target.octets()))
 }
 
 /// The link-wide destination a magic packet captured as `packet` re-emits to under `family`: the
@@ -155,7 +155,7 @@ pub(crate) fn build(
             },
             Box::new(WolReflector {
                 egress,
-                target_mac: reflector.mac,
+                target_macs: reflector.macs.clone(),
                 family: reflector.address_family,
             }),
         );
@@ -173,6 +173,7 @@ pub(crate) fn build(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::net::mac::MacAddr;
 
     const DEVICE: [u8; 6] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
 
@@ -201,8 +202,20 @@ mod tests {
     #[test]
     fn filters_to_the_configured_device() {
         let packet = magic_packet(DEVICE, &[]);
-        assert!(is_magic_packet(&packet, Some(MacAddr::from(DEVICE))));
-        assert!(!is_magic_packet(&packet, Some(MacAddr::from([0xaa; 6]))));
+        let allowed = MacSet::from(MacAddr::from(DEVICE));
+        assert!(is_magic_packet(&packet, Some(&allowed)));
+        let others = MacSet::from(MacAddr::from([0xaa; 6]));
+        assert!(!is_magic_packet(&packet, Some(&others)));
+    }
+
+    #[test]
+    fn filters_to_any_of_several_configured_devices() {
+        let packet = magic_packet(DEVICE, &[]);
+        let set = MacSet::try_from(vec![MacAddr::from([0xaa; 6]), MacAddr::from(DEVICE)]).unwrap();
+        assert!(is_magic_packet(&packet, Some(&set)));
+        let disjoint =
+            MacSet::try_from(vec![MacAddr::from([0xaa; 6]), MacAddr::from([0xbb; 6])]).unwrap();
+        assert!(!is_magic_packet(&packet, Some(&disjoint)));
     }
 
     #[test]


### PR DESCRIPTION
## What

Scope a reflector entry to several devices, not just one. The scalar `mac` field is replaced by `macs`, a non-empty list of MAC addresses; a single device is a one-entry list (`macs = ["aa:bb:cc:dd:ee:ff"]`). An absent `macs` still matches any device.

- New `MacSet` value type (non-empty, duplicate-free), parsed from a TOML array or an env CSV, mirroring `WolPorts`.
- `Filter.src_mac` matches "source MAC ∈ set"; WoL checks the magic-packet target against the set. mDNS, SSDP advertisement, SSDP search-response, and WoL all honor the whole set.
- Duplicate detection compares sets: two entries overlap when their sets share an address, or either is absent.

## Breaking change

The `mac` key and `REFLECTOR_<tag>_MAC` env var are no longer accepted. Migrate to `macs` / `REFLECTOR_<tag>_MACS` (a single device becomes a one-entry list / a single CSV token). Version bumped to **0.9.0**.

## Testing

- 344 unit/integration tests, `clippy -D warnings`, `fmt --check`, and the rustdoc gate — all clean.
- Full Docker e2e suite: **37/37 pass**, including a new `reflects_second_configured_mac` case proving every member of a multi-entry `macs` list reflects (while a non-member is dropped).
