### PR TITLE
Bump version to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "reflector"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflector"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.93"
 


### PR DESCRIPTION
Post-release development bump following the v0.9.0 release (which shipped the breaking `macs` change in #11).