### PR TITLE
Merge per-group / per-port reflector registrations via set-valued filters

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -26,6 +26,7 @@ pub(crate) use self::dial_context::DialContext;
 
 use std::io;
 use std::net::{IpAddr, SocketAddr};
+use std::ops::Deref;
 use std::os::fd::{AsRawFd, RawFd};
 use std::time::Instant;
 
@@ -89,15 +90,54 @@ impl CaptureKey {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) struct RegistrationKey(Key);
 
+/// A non-empty set of one filter field's accepted values, so a single registration can span several —
+/// mDNS's two multicast groups (`dst_ip`), or `WoL`'s ports (`dst_port`). A one-element set pins a
+/// single value.
+#[derive(Clone)]
+pub(crate) struct FilterSet<T>(Box<[T]>);
+
+impl<T> Deref for FilterSet<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A single value is a valid one-element set.
+impl<T> From<T> for FilterSet<T> {
+    fn from(value: T) -> Self {
+        FilterSet(Box::new([value]))
+    }
+}
+
+/// A fixed array of values (a known set of groups or ports) converts directly.
+impl<T, const N: usize> From<[T; N]> for FilterSet<T> {
+    fn from(values: [T; N]) -> Self {
+        FilterSet(Box::from(values))
+    }
+}
+
+impl<T> FromIterator<T> for FilterSet<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        FilterSet(iter.into_iter().collect())
+    }
+}
+
+/// The `dst_ip` filter set: the multicast groups one handler serves.
+pub(crate) type IpSet = FilterSet<IpAddr>;
+/// The `dst_port` filter set: the ports one handler serves.
+pub(crate) type PortSet = FilterSet<u16>;
+
 /// An optional-field packet filter: an unset field
 /// matches anything. A `src_mac`/`dst_mac` filter never matches a `DLT_NULL` packet,
-/// which has no L2 addresses.
+/// which has no L2 addresses. `dst_ip`/`dst_port` match membership in their [`FilterSet`].
 #[derive(Clone, Default)]
 pub(crate) struct Filter {
     pub(crate) src_ip: Option<IpAddr>,
-    pub(crate) dst_ip: Option<IpAddr>,
+    pub(crate) dst_ip: Option<IpSet>,
     pub(crate) src_port: Option<u16>,
-    pub(crate) dst_port: Option<u16>,
+    pub(crate) dst_port: Option<PortSet>,
     /// Allow-set on the source MAC: the packet's source must be a member.
     pub(crate) src_mac: Option<MacSet>,
     pub(crate) dst_mac: Option<MacAddr>,
@@ -107,9 +147,15 @@ impl Filter {
     /// Whether `p` satisfies every set field (an unset field matches anything).
     fn matches(&self, p: &Packet) -> bool {
         self.src_ip.is_none_or(|ip| p.source.ip() == ip)
-            && self.dst_ip.is_none_or(|ip| p.dest.ip() == ip)
+            && self
+                .dst_ip
+                .as_ref()
+                .is_none_or(|set| set.contains(&p.dest.ip()))
             && self.src_port.is_none_or(|port| p.source.port() == port)
-            && self.dst_port.is_none_or(|port| p.dest.port() == port)
+            && self
+                .dst_port
+                .as_ref()
+                .is_none_or(|set| set.contains(&p.dest.port()))
             && self
                 .src_mac
                 .as_ref()
@@ -666,14 +712,48 @@ mod tests {
     #[test]
     fn filter_matches_destination_group_and_port() {
         let f = Filter {
-            dst_ip: Some("224.0.0.251".parse().unwrap()),
-            dst_port: Some(5353),
+            dst_ip: Some("224.0.0.251".parse::<IpAddr>().unwrap().into()),
+            dst_port: Some(5353.into()),
             ..Filter::default()
         };
         assert!(f.matches(&packet("10.0.0.1:5353", "224.0.0.251:5353", None, None)));
         // Wrong group, and wrong port, each miss.
         assert!(!f.matches(&packet("10.0.0.1:5353", "224.0.0.252:5353", None, None)));
         assert!(!f.matches(&packet("10.0.0.1:5353", "224.0.0.251:1900", None, None)));
+    }
+
+    #[test]
+    fn filter_dst_ip_set_matches_any_group() {
+        // One handler spanning the v4 and v6 mDNS groups: either destination matches.
+        let f = Filter {
+            dst_ip: Some(
+                [
+                    "224.0.0.251".parse::<IpAddr>().unwrap(),
+                    "ff02::fb".parse().unwrap(),
+                ]
+                .into(),
+            ),
+            dst_port: Some(5353.into()),
+            ..Filter::default()
+        };
+        assert!(f.matches(&packet("10.0.0.1:5353", "224.0.0.251:5353", None, None)));
+        assert!(f.matches(&packet("[fe80::1]:5353", "[ff02::fb]:5353", None, None)));
+        // A group outside the set, and a member on the wrong port, each miss.
+        assert!(!f.matches(&packet("10.0.0.1:5353", "239.255.255.250:5353", None, None)));
+        assert!(!f.matches(&packet("10.0.0.1:5353", "224.0.0.251:1900", None, None)));
+    }
+
+    #[test]
+    fn filter_dst_port_set_matches_any_port() {
+        // One handler spanning WoL ports 7 and 9: either destination port matches.
+        let f = Filter {
+            dst_port: Some([7u16, 9].into()),
+            ..Filter::default()
+        };
+        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:7", None, None)));
+        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:9", None, None)));
+        // A port outside the set misses.
+        assert!(!f.matches(&packet("10.0.0.1:1", "255.255.255.255:8", None, None)));
     }
 
     #[test]
@@ -733,12 +813,12 @@ mod tests {
     #[test]
     fn filter_ip_does_not_match_across_families() {
         let v4 = Filter {
-            dst_ip: Some("224.0.0.251".parse().unwrap()),
+            dst_ip: Some("224.0.0.251".parse::<IpAddr>().unwrap().into()),
             ..Filter::default()
         };
         assert!(!v4.matches(&packet("[fe80::1]:5353", "[ff02::fb]:5353", None, None)));
         let v6 = Filter {
-            dst_ip: Some("ff02::fb".parse().unwrap()),
+            dst_ip: Some("ff02::fb".parse::<IpAddr>().unwrap().into()),
             ..Filter::default()
         };
         assert!(!v6.matches(&packet("10.0.0.1:5353", "224.0.0.251:5353", None, None)));
@@ -815,7 +895,7 @@ mod tests {
         dispatcher.register(
             ingress,
             Filter {
-                dst_port: Some(target.port()),
+                dst_port: Some(target.port().into()),
                 ..Filter::default()
             },
             Box::new(Echo {
@@ -1032,7 +1112,7 @@ mod tests {
         dispatcher.register(
             ingress,
             Filter {
-                dst_port: Some(target.port()),
+                dst_port: Some(target.port().into()),
                 ..Filter::default()
             },
             Box::new(Reentrant {
@@ -1085,7 +1165,7 @@ mod tests {
         dispatcher.register(
             ingress,
             Filter {
-                dst_port: Some(target.port()),
+                dst_port: Some(target.port().into()),
                 ..Filter::default()
             },
             Box::new(Echo {
@@ -1179,7 +1259,7 @@ mod tests {
         dispatcher.register(
             ingress,
             Filter {
-                dst_port: Some(target.port()),
+                dst_port: Some(target.port().into()),
                 ..Filter::default()
             },
             Box::new(MidDrainProbe {

--- a/src/net/mac.rs
+++ b/src/net/mac.rs
@@ -108,7 +108,7 @@ impl<'de> Deserialize<'de> for MacAddr {
 /// "match any device" is expressed by an absent (`None`) filter at the use site,
 /// not by an empty set.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct MacSet(Vec<MacAddr>);
+pub(crate) struct MacSet(Box<[MacAddr]>);
 
 impl Deref for MacSet {
     type Target = [MacAddr];
@@ -133,7 +133,7 @@ pub(crate) enum MacSetError {
 /// A single address is a valid one-element set.
 impl From<MacAddr> for MacSet {
     fn from(mac: MacAddr) -> Self {
-        MacSet(vec![mac])
+        MacSet(Box::from([mac]))
     }
 }
 
@@ -149,7 +149,7 @@ impl TryFrom<Vec<MacAddr>> for MacSet {
                 return Err(MacSetError::Duplicate(*mac));
             }
         }
-        Ok(Self(macs))
+        Ok(Self(macs.into_boxed_slice()))
     }
 }
 

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -8,7 +8,7 @@
 use std::net::SocketAddr;
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{Filter, PacketDispatcher};
+use crate::dispatch::{Filter, IpSet, PacketDispatcher};
 use crate::net::mdns::{MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT, MDNS_TTL, MdnsKind, classify};
 
 use super::{BuildError, InterfaceMap, SimpleReflector, Verdict, require_bidirectional_families};
@@ -63,49 +63,51 @@ pub(crate) fn build(
         reflector.target_if.as_str(),
     )?;
 
-    for group in used_groups(reflector.address_family) {
-        let group_ip = group.ip();
-        // Join on both interfaces. A family with no address yet is recorded and re-attempted on
-        // the next address change, so a deferred join logs rather than fails the build.
+    // Join every group on both interfaces. A family with no address yet is recorded and re-attempted
+    // on the next address change, so a deferred join logs rather than fails the build.
+    let groups = used_groups(reflector.address_family);
+    for group in &groups {
         for capture in [source, target] {
-            if let Err(e) = dispatcher.join_group(capture, group_ip) {
-                log::debug!("mDNS: join {group_ip} deferred: {e}");
+            if let Err(e) = dispatcher.join_group(capture, group.ip()) {
+                log::debug!("mDNS: join {} deferred: {e}", group.ip());
             }
         }
-        // source → target: reflect queries (any client on source may ask).
-        dispatcher.register(
-            source,
-            Filter {
-                dst_ip: Some(group_ip),
-                dst_port: Some(MDNS_PORT),
-                ..Filter::default()
-            },
-            Box::new(SimpleReflector::new(
-                target,
-                "mDNS query",
-                MDNS_PORT,
-                MDNS_TTL,
-                query_verdict,
-            )),
-        );
-        // target → source: reflect responses, optionally only from the configured device's MAC.
-        dispatcher.register(
-            target,
-            Filter {
-                dst_ip: Some(group_ip),
-                dst_port: Some(MDNS_PORT),
-                src_mac: reflector.macs.clone(),
-                ..Filter::default()
-            },
-            Box::new(SimpleReflector::new(
-                source,
-                "mDNS response",
-                MDNS_PORT,
-                MDNS_TTL,
-                response_verdict,
-            )),
-        );
     }
+    // One handler per direction spans every group; its filter matches the group set at the mDNS port.
+    let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();
+    // source → target: reflect queries (any client on source may ask).
+    dispatcher.register(
+        source,
+        Filter {
+            dst_ip: Some(group_ips.clone()),
+            dst_port: Some(MDNS_PORT.into()),
+            ..Filter::default()
+        },
+        Box::new(SimpleReflector::new(
+            target,
+            "mDNS query",
+            MDNS_PORT,
+            MDNS_TTL,
+            query_verdict,
+        )),
+    );
+    // target → source: reflect responses, optionally only from the configured device's MAC.
+    dispatcher.register(
+        target,
+        Filter {
+            dst_ip: Some(group_ips),
+            dst_port: Some(MDNS_PORT.into()),
+            src_mac: reflector.macs.clone(),
+            ..Filter::default()
+        },
+        Box::new(SimpleReflector::new(
+            source,
+            "mDNS response",
+            MDNS_PORT,
+            MDNS_TTL,
+            response_verdict,
+        )),
+    );
     log::info!(
         "mDNS reflector \"{}\": {} <-> {}",
         reflector.name.as_str(),

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -12,7 +12,7 @@ mod search;
 use std::net::SocketAddr;
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{CaptureKey, Filter, PacketDispatcher};
+use crate::dispatch::{CaptureKey, Filter, IpSet, PacketDispatcher};
 use crate::interface::InterfaceAddresses;
 use crate::net::ssdp::{
     SSDP_GROUP_V4, SSDP_GROUP_V6_LINK_LOCAL, SSDP_GROUP_V6_SITE_LOCAL, SSDP_PORT,
@@ -113,45 +113,47 @@ pub(crate) fn build(
         target_ifindex,
     });
 
-    for group in used_groups(reflector.address_family) {
-        let group_ip = group.ip();
-        // Advertisements are captured on target, searches on source — join both. A family with no
-        // address yet is recorded and re-attempted on the next address change.
-        if let Err(e) = dispatcher.join_group(target, group_ip) {
-            log::debug!("SSDP: join {group_ip} on target deferred: {e}");
+    // Advertisements are captured on target, searches on source — join every group on both. A family
+    // with no address yet is recorded and re-attempted on the next address change.
+    let groups = used_groups(reflector.address_family);
+    for group in &groups {
+        if let Err(e) = dispatcher.join_group(target, group.ip()) {
+            log::debug!("SSDP: join {} on target deferred: {e}", group.ip());
         }
-        if let Err(e) = dispatcher.join_group(source, group_ip) {
-            log::debug!("SSDP: join {group_ip} on source deferred: {e}");
+        if let Err(e) = dispatcher.join_group(source, group.ip()) {
+            log::debug!("SSDP: join {} on source deferred: {e}", group.ip());
         }
-        // target -> source: advertisements, optionally filtered to the configured device's MAC.
-        dispatcher.register(
-            target,
-            Filter {
-                dst_ip: Some(group_ip),
-                dst_port: Some(SSDP_PORT),
-                src_mac: reflector.macs.clone(),
-                ..Filter::default()
-            },
-            Box::new(SsdpAdvertisementReflector::new(source, dial)),
-        );
-        // source -> target: searches (unfiltered — any source client may search); each searcher's
-        // unicast 200-OK replies route back through a per-searcher session.
-        dispatcher.register(
-            source,
-            Filter {
-                dst_ip: Some(group_ip),
-                dst_port: Some(SSDP_PORT),
-                ..Filter::default()
-            },
-            Box::new(SsdpSearchReflector::new(
-                source,
-                target,
-                target_ifindex,
-                reflector.macs.clone(),
-                dial,
-            )),
-        );
     }
+    // One handler per direction spans every group; its filter matches the group set at the SSDP port.
+    let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();
+    // target -> source: advertisements, optionally filtered to the configured device's MAC.
+    dispatcher.register(
+        target,
+        Filter {
+            dst_ip: Some(group_ips.clone()),
+            dst_port: Some(SSDP_PORT.into()),
+            src_mac: reflector.macs.clone(),
+            ..Filter::default()
+        },
+        Box::new(SsdpAdvertisementReflector::new(source, dial)),
+    );
+    // source -> target: searches (unfiltered — any source client may search); each searcher's
+    // unicast 200-OK replies route back through a per-searcher session.
+    dispatcher.register(
+        source,
+        Filter {
+            dst_ip: Some(group_ips),
+            dst_port: Some(SSDP_PORT.into()),
+            ..Filter::default()
+        },
+        Box::new(SsdpSearchReflector::new(
+            source,
+            target,
+            target_ifindex,
+            reflector.macs.clone(),
+            dial,
+        )),
+    );
     log::info!(
         "SSDP reflector \"{}\": {} <-> {} (advertisements + searches{})",
         reflector.name.as_str(),

--- a/src/reflector/ssdp/search.rs
+++ b/src/reflector/ssdp/search.rs
@@ -21,7 +21,7 @@ use super::{DialRewrite, dial_rewrite};
 const SESSION_GRACE: Duration = Duration::from_secs(2);
 /// In-flight session cap, so a burst of searchers can't exhaust ephemeral ports or registrations.
 /// At the cap a new M-SEARCH is dropped (no live session is evicted early).
-const MAX_SESSIONS: usize = 32;
+const MAX_SESSIONS: usize = 64;
 
 /// One in-flight M-SEARCH. The searcher (`ip:port`) is the dedup key; `expiry` is when the session
 /// lapses; `reservation` holds the ephemeral target port the 200-OKs arrive on for the session's life
@@ -194,8 +194,8 @@ impl SsdpSearchReflector {
         let response_key = dispatcher.register(
             self.target,
             Filter {
-                dst_ip: Some(our_addr),
-                dst_port: Some(reservation.port()),
+                dst_ip: Some(our_addr.into()),
+                dst_port: Some(reservation.port().into()),
                 src_mac: self.device_macs.clone(),
                 ..Filter::default()
             },

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -9,7 +9,7 @@
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler};
+use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler, PortSet};
 use crate::net::mac::MacSet;
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
@@ -146,20 +146,21 @@ pub(crate) fn build(
         });
     }
 
-    for port in wol.ports.iter() {
-        dispatcher.register(
-            ingress,
-            Filter {
-                dst_port: Some(port.get()),
-                ..Filter::default()
-            },
-            Box::new(WolReflector {
-                egress,
-                target_macs: reflector.macs.clone(),
-                family: reflector.address_family,
-            }),
-        );
-    }
+    // One handler spans every configured port; its filter matches the port set. The re-emit uses the
+    // captured destination port, so a single reflector serves them all.
+    let ports: PortSet = wol.ports.iter().map(|port| port.get()).collect();
+    dispatcher.register(
+        ingress,
+        Filter {
+            dst_port: Some(ports),
+            ..Filter::default()
+        },
+        Box::new(WolReflector {
+            egress,
+            target_macs: reflector.macs.clone(),
+            family: reflector.address_family,
+        }),
+    );
     log::info!(
         "WoL reflector \"{}\": {} -> {} on {} port(s)",
         reflector.name.as_str(),


### PR DESCRIPTION
## What

Refactor — behavior-preserving apart from one intentional cap change. `Filter`'s `dst_ip` and `dst_port` become `FilterSet<T>` — a `Box`-backed set that `Deref`s to a slice, aliased `IpSet` / `PortSet` — so one handler can span several multicast groups or ports instead of registering one per group/port:

- **mDNS** 4 → 2 (query + response each span v4+v6)
- **SSDP advertisement** 3 → 1, **search** 3 → 1
- **WoL** N → 1 (one handler spans all configured ports)

Multicast joins stay per-group.

Since the SSDP search reflector is now a single instance, its in-flight M-SEARCH session cap is one total rather than incidentally per-scope; `MAX_SESSIONS` 32 → 64.

Also unifies `MacSet` on `Box<[MacAddr]>` (was `Vec`) so all three filter sets (`src_mac` / `dst_ip` / `dst_port`) share the same leaner immutable representation.

## Testing

- 347 unit tests (incl. new `filter_dst_ip_set_matches_any_group` / `filter_dst_port_set_matches_any_port`), clippy `-D warnings`, `fmt --check`, rustdoc — all clean.
- Full Docker e2e suite: **37/37 pass**.

No version bump (internal; behavior-preserving apart from the session cap).
