### PR TITLE
Contain the DIAL rewrite scratch in a reusable UninitBuf

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -11,6 +11,7 @@ pub(crate) mod port_reservation;
 pub(crate) mod ssdp;
 pub(crate) mod stream_buffer;
 pub(crate) mod tcp;
+pub(crate) mod uninit_buf;
 
 /// The link-layer framing of a captured or injected frame. The capture layer reports
 /// it per interface; [`frame`] adds the matching link header and [`packet`] strips it

--- a/src/net/uninit_buf.rs
+++ b/src/net/uninit_buf.rs
@@ -1,0 +1,124 @@
+//! A write-only, fixed-capacity byte sink over uninitialized storage: filled front-to-back through
+//! [`io::Write`], then read back as the written prefix via [`filled`](UninitBuf::filled). Backed by a
+//! `Box<[MaybeUninit<u8>]>` allocated on first write and never zero-filled — only the written
+//! `storage[..filled]` region is ever read. A write past the capacity is a short write (so
+//! [`write_all`](io::Write::write_all) returns `WriteZero`), letting the caller treat "didn't fit" as a
+//! signal rather than silently truncating. Reuse across messages with [`clear`](UninitBuf::clear).
+//!
+//! All of the `unsafe` uninitialized-memory handling lives here, behind a safe interface — callers only
+//! see `io::Write`, `clear`, and `filled`.
+
+use std::io;
+use std::mem::MaybeUninit;
+use std::{ptr, slice};
+
+/// A fixed-capacity byte sink over uninitialized, lazily-allocated storage; see the module doc.
+pub(crate) struct UninitBuf {
+    /// The backing store, `None` until the first write; `capacity` bytes once set.
+    storage: Option<Box<[MaybeUninit<u8>]>>,
+    capacity: usize,
+    /// Bytes written; the initialized (and readable) region is `storage[..filled]`.
+    filled: usize,
+}
+
+impl UninitBuf {
+    /// Holds at most `cap` bytes. The backing store is allocated — uninitialized, never zero-filled —
+    /// on the first write, so an unused buffer costs nothing.
+    pub(crate) fn with_capacity(cap: usize) -> Self {
+        Self {
+            storage: None,
+            capacity: cap,
+            filled: 0,
+        }
+    }
+
+    /// Discard the written bytes (keeping the allocation) to build the next message.
+    pub(crate) fn clear(&mut self) {
+        self.filled = 0;
+    }
+
+    /// The bytes written since the last [`clear`](Self::clear).
+    pub(crate) fn filled(&self) -> &[u8] {
+        match &self.storage {
+            // SAFETY: `[..filled]` is exactly the region `write` wrote, so it is initialized;
+            // `MaybeUninit<u8>` and `u8` share layout.
+            Some(storage) => unsafe {
+                slice::from_raw_parts(storage.as_ptr().cast::<u8>(), self.filled)
+            },
+            None => &[],
+        }
+    }
+}
+
+impl io::Write for UninitBuf {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        let n = data.len().min(self.capacity - self.filled);
+        let storage = self
+            .storage
+            .get_or_insert_with(|| Box::new_uninit_slice(self.capacity));
+        // SAFETY: `n <= capacity - filled`, so `storage[filled..filled + n]` is in bounds. `data` is a
+        // shared borrow and `storage` lives behind `&mut self`, so they can't overlap. Layouts match.
+        unsafe {
+            ptr::copy_nonoverlapping(
+                data.as_ptr(),
+                storage.as_mut_ptr().add(self.filled).cast::<u8>(),
+                n,
+            );
+        }
+        self.filled += n;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn writes_then_reads_the_filled_prefix() {
+        let mut b = UninitBuf::with_capacity(8);
+        b.write_all(b"abc").unwrap();
+        assert_eq!(b.filled(), b"abc");
+        write!(b, "{}", 42).unwrap();
+        assert_eq!(b.filled(), b"abc42");
+    }
+
+    #[test]
+    fn clear_resets_but_keeps_writing_from_the_front() {
+        let mut b = UninitBuf::with_capacity(8);
+        b.write_all(b"abc").unwrap();
+        b.clear();
+        assert_eq!(b.filled(), b"");
+        b.write_all(b"xy").unwrap();
+        assert_eq!(b.filled(), b"xy");
+    }
+
+    #[test]
+    fn unwritten_buffer_is_empty_and_unallocated() {
+        let b = UninitBuf::with_capacity(8);
+        assert_eq!(b.filled(), b"");
+    }
+
+    #[test]
+    fn write_past_capacity_is_a_short_write() {
+        let mut b = UninitBuf::with_capacity(4);
+        // The 4 fit-able bytes land before the overflow makes `write_all` fail rather than truncate.
+        assert!(b.write_all(b"abcde").is_err());
+        assert_eq!(b.filled(), b"abcd");
+    }
+
+    #[test]
+    fn writing_to_a_full_buffer_makes_no_progress() {
+        let mut b = UninitBuf::with_capacity(3);
+        b.write_all(b"abc").unwrap();
+        assert_eq!(b.write(b"d").unwrap(), 0);
+        assert!(b.write_all(b"d").is_err());
+        assert_eq!(b.filled(), b"abc");
+    }
+}

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -5,6 +5,7 @@
 //! registry) if none is live for the device, and refreshing its grace either way. Minting is the means;
 //! the rewrite is the purpose.
 
+use std::io;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::fd::AsRawFd;
 use std::time::{Duration, Instant};
@@ -44,20 +45,20 @@ pub(crate) struct ProxyPlacement {
 
 /// Rewrite a DIAL discovery message's `LOCATION` to a source-side description proxy, minting and
 /// registering the proxy if one isn't already live for this device and refreshing its grace either way.
-/// On a rewrite the datagram is written into `out` and its length returned; `None` means forward
-/// `payload` unchanged — it isn't a DIAL message, its `LOCATION` isn't a rewritable IPv4 `http` URL, the
-/// proxy cap was reached / a mint failed (device stays visible but unproxied), or the rewrite wouldn't
-/// fit `out`. `out` is the caller's reused scratch (size it [`REWRITE_BUF_LEN`]).
+/// On a rewrite the datagram is written to `out` and `true` is returned; `false` means forward `payload`
+/// unchanged — it isn't a DIAL message, its `LOCATION` isn't a rewritable IPv4 `http` URL, the proxy cap
+/// was reached / a mint failed (device stays visible but unproxied), or the rewrite didn't fit `out`.
+/// `out` is the caller's reused sink; a fixed-capacity one (sized [`REWRITE_BUF_LEN`]) makes an
+/// over-long rewrite fail rather than truncate.
 pub(crate) fn rewrite_location(
     ctx: &mut DialContext,
     reactor: &mut Reactor,
     payload: &[u8],
     placement: ProxyPlacement,
-    out: &mut [u8],
-) -> Option<usize> {
-    use std::io::Write;
+    out: &mut impl io::Write,
+) -> bool {
     if !is_dial_service_message(payload) {
-        return None;
+        return false;
     }
     let Some(location) = parse_dial_location_authority(payload) else {
         // DIAL, but LOCATION isn't a rewritable IPv4 http URL (https, a hostname, an IPv6 literal, a
@@ -66,7 +67,7 @@ pub(crate) fn rewrite_location(
             "dial: LOCATION {} is not a rewritable IPv4 http URL; forwarding the message unproxied",
             dial_location_value(payload).map_or_else(|| "(absent)".into(), String::from_utf8_lossy)
         );
-        return None;
+        return false;
     };
     // The grace is refreshed on every advertisement / search response, so a re-advertised device's
     // cached LOCATION keeps resolving for another max-age.
@@ -86,26 +87,25 @@ pub(crate) fn rewrite_location(
             location.endpoint
         );
         addr
+    } else if let Some(addr) = mint_proxy(ctx, reactor, placement, location.endpoint, desc_grace) {
+        addr
     } else {
-        mint_proxy(ctx, reactor, placement, location.endpoint, desc_grace)?
+        return false;
     };
-    // The rewrite can grow the datagram, so a short buffer errors (caller forwards verbatim) rather
-    // than truncating.
-    let capacity = out.len();
-    let mut cursor: &mut [u8] = out;
-    let fits = cursor.write_all(&payload[..location.offset]).is_ok()
-        && write!(cursor, "{desc_addr}").is_ok()
-        && cursor
+    // The rewrite can grow the datagram, so a sink that fills up (the fixed-capacity scratch) makes a
+    // write fail — forward verbatim rather than truncating.
+    let fits = out.write_all(&payload[..location.offset]).is_ok()
+        && write!(out, "{desc_addr}").is_ok()
+        && out
             .write_all(&payload[location.offset + location.len..])
             .is_ok();
     if !fits {
         log::warn!(
-            "dial: rewritten LOCATION for {} exceeds the {capacity} B buffer; forwarding verbatim",
+            "dial: rewritten LOCATION for {} exceeds the scratch buffer; forwarding verbatim",
             location.endpoint
         );
-        return None;
     }
-    Some(capacity - cursor.len())
+    fits
 }
 
 /// Mint a description proxy for `endpoint`, register it on `reactor`, and record it in `ctx`; returns the
@@ -187,14 +187,14 @@ mod tests {
         CaptureKey::from_u64(8)
     }
 
-    /// Rewrite `payload` like a reflector would (into a [`REWRITE_BUF_LEN`] stack buffer), returning the
-    /// rewritten datagram, or `None` to forward verbatim.
+    /// Rewrite `payload` like a reflector would (into a `Vec` sink), returning the rewritten datagram,
+    /// or `None` to forward verbatim.
     fn rewrite_advert(
         ctx: &mut DialContext,
         reactor: &mut Reactor,
         payload: &[u8],
     ) -> Option<Vec<u8>> {
-        let mut buf = [0u8; REWRITE_BUF_LEN];
+        let mut buf = Vec::new();
         let placement = ProxyPlacement {
             source_capture: advert_source(),
             source: Ipv4Addr::LOCALHOST,
@@ -202,8 +202,7 @@ mod tests {
             target: Ipv4Addr::LOCALHOST,
             target_ifindex: 0,
         };
-        let n = rewrite_location(ctx, reactor, payload, placement, &mut buf)?;
-        Some(buf[..n].to_vec())
+        rewrite_location(ctx, reactor, payload, placement, &mut buf).then_some(buf)
     }
 
     #[test]

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -17,31 +17,45 @@ use crate::interface::InterfaceAddresses;
 use crate::net::ssdp::{
     SSDP_GROUP_V4, SSDP_GROUP_V6_LINK_LOCAL, SSDP_GROUP_V6_SITE_LOCAL, SSDP_PORT,
 };
+use crate::net::uninit_buf::UninitBuf;
 use crate::reactor::Reactor;
 
 use self::advertisement::SsdpAdvertisementReflector;
 use self::search::SsdpSearchReflector;
-use super::dial::{ProxyPlacement, rewrite_location};
+use super::dial::{ProxyPlacement, REWRITE_BUF_LEN, rewrite_location};
 use super::{BuildError, InterfaceMap, require_bidirectional_families};
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
-/// target capture the device sits behind (for its address) and that interface's egress-pin ifindex. The
-/// source side is the reflector's own egress. `None` on a reflector without `dial`.
-#[derive(Clone, Copy)]
+/// target capture the device sits behind (for its address), that interface's egress-pin ifindex, and a
+/// reused scratch sink the rewritten datagram is built in. Owned per rewriting reflector — the
+/// advertisement direction, and one per M-SEARCH session's response reflector — so it isn't `Copy`.
 struct DialRewrite {
     target: CaptureKey,
     target_ifindex: u32,
+    /// Reused sink for the rewritten datagram; see [`dial_rewrite`].
+    scratch: UninitBuf,
+}
+
+impl DialRewrite {
+    /// A rewriter for the device behind `target` (`target_ifindex` scopes the IPv6 reserved-port bind),
+    /// with a fresh scratch sink.
+    fn new(target: CaptureKey, target_ifindex: u32) -> Self {
+        Self {
+            target,
+            target_ifindex,
+            scratch: UninitBuf::with_capacity(REWRITE_BUF_LEN),
+        }
+    }
 }
 
 /// Rewrite a target→source SSDP datagram's DIAL `LOCATION` to a source-side description proxy, into
-/// `buf`. Returns the rewritten slice when `dial` is set and the rewrite succeeds, else `payload`
-/// (forward verbatim). `egress` is the source capture the datagram reflects onto. Shared by the
-/// advertisement and search-response directions, which both rewrite a device's `LOCATION`.
+/// `dial`'s scratch. Returns the rewritten slice when `dial` is set and the rewrite succeeds, else
+/// `payload` (forward verbatim). `egress` is the source capture the datagram reflects onto. Shared by
+/// the advertisement and search-response directions, which both rewrite a device's `LOCATION`.
 fn dial_rewrite<'a>(
     payload: &'a [u8],
-    buf: &'a mut [u8],
     egress: CaptureKey,
-    dial: Option<DialRewrite>,
+    dial: Option<&'a mut DialRewrite>,
     dispatcher: &mut PacketDispatcher,
     reactor: &mut Reactor,
 ) -> &'a [u8] {
@@ -65,9 +79,17 @@ fn dial_rewrite<'a>(
         target,
         target_ifindex: dial.target_ifindex,
     };
-    match rewrite_location(dispatcher.dial_context(), reactor, payload, placement, buf) {
-        Some(n) => &buf[..n],
-        None => payload,
+    dial.scratch.clear();
+    if rewrite_location(
+        dispatcher.dial_context(),
+        reactor,
+        payload,
+        placement,
+        &mut dial.scratch,
+    ) {
+        dial.scratch.filled()
+    } else {
+        payload
     }
 }
 
@@ -106,13 +128,6 @@ pub(crate) fn build(
     // the ifindex the capture already cached (the single source of truth the joiners bake too).
     let target_ifindex = dispatcher.capture_ifindex(target).unwrap_or(0);
 
-    // With `dial`, target→source reflectors rewrite a device's DIAL `LOCATION` to a source-side proxy
-    // (IPv4 only; a non-rewritable LOCATION passes through). The device sits behind `target`.
-    let dial = ssdp.dial.then_some(DialRewrite {
-        target,
-        target_ifindex,
-    });
-
     // Advertisements are captured on target, searches on source — join every group on both. A family
     // with no address yet is recorded and re-attempted on the next address change.
     let groups = used_groups(reflector.address_family);
@@ -135,7 +150,10 @@ pub(crate) fn build(
             src_mac: reflector.macs.clone(),
             ..Filter::default()
         },
-        Box::new(SsdpAdvertisementReflector::new(source, dial)),
+        Box::new(SsdpAdvertisementReflector::new(
+            source,
+            ssdp.dial.then(|| DialRewrite::new(target, target_ifindex)),
+        )),
     );
     // source -> target: searches (unfiltered — any source client may search); each searcher's
     // unicast 200-OK replies route back through a per-searcher session.
@@ -151,7 +169,7 @@ pub(crate) fn build(
             target,
             target_ifindex,
             reflector.macs.clone(),
-            dial,
+            ssdp.dial,
         )),
     );
     log::info!(
@@ -159,7 +177,7 @@ pub(crate) fn build(
         reflector.name.as_str(),
         reflector.source_if.as_str(),
         reflector.target_if.as_str(),
-        if dial.is_some() { " + DIAL" } else { "" }
+        if ssdp.dial { " + DIAL" } else { "" }
     );
     Ok(())
 }

--- a/src/reflector/ssdp/advertisement.rs
+++ b/src/reflector/ssdp/advertisement.rs
@@ -4,7 +4,6 @@ use crate::dispatch::{CaptureKey, PacketDispatcher, PacketHandler};
 use crate::net::packet::Packet;
 use crate::net::ssdp::{SSDP_PORT, SSDP_TTL, SsdpKind, classify};
 use crate::reactor::Reactor;
-use crate::reflector::dial::REWRITE_BUF_LEN;
 use crate::reflector::egress_sources;
 
 use super::{DialRewrite, dial_rewrite};
@@ -44,12 +43,10 @@ impl PacketHandler for SsdpAdvertisementReflector {
                     );
                     return;
                 }
-                let mut buf = [0u8; REWRITE_BUF_LEN];
                 let payload = dial_rewrite(
                     packet.payload,
-                    &mut buf,
                     self.egress,
-                    self.dial,
+                    self.dial.as_mut(),
                     dispatcher,
                     reactor,
                 );

--- a/src/reflector/ssdp/search.rs
+++ b/src/reflector/ssdp/search.rs
@@ -11,7 +11,6 @@ use crate::net::packet::Packet;
 use crate::net::port_reservation::PortReservation;
 use crate::net::ssdp::{MSEARCH_MX_DEFAULT, SSDP_TTL, SsdpKind, classify, parse_msearch_mx};
 use crate::reactor::Reactor;
-use crate::reflector::dial::REWRITE_BUF_LEN;
 use crate::reflector::egress_sources;
 
 use super::{DialRewrite, dial_rewrite};
@@ -66,12 +65,10 @@ impl PacketHandler for SsdpResponseReflector {
             );
             return;
         }
-        let mut buf = [0u8; REWRITE_BUF_LEN];
         let payload = dial_rewrite(
             packet.payload,
-            &mut buf,
             self.egress,
-            self.dial,
+            self.dial.as_mut(),
             dispatcher,
             reactor,
         );
@@ -112,8 +109,9 @@ pub(super) struct SsdpSearchReflector {
     target_ifindex: u32,
     /// The configured device allow-set, scoping the response capture as the advertisement direction is.
     device_macs: Option<MacSet>,
-    /// DIAL `LOCATION` rewriting, stamped into each session's [`SsdpResponseReflector`].
-    dial: Option<DialRewrite>,
+    /// Whether DIAL `LOCATION` rewriting is on; each session's [`SsdpResponseReflector`] gets its own
+    /// [`DialRewrite`] (with its own scratch) when set.
+    dial: bool,
     sessions: Vec<Session>,
 }
 
@@ -123,7 +121,7 @@ impl SsdpSearchReflector {
         target: CaptureKey,
         target_ifindex: u32,
         device_macs: Option<MacSet>,
-        dial: Option<DialRewrite>,
+        dial: bool,
     ) -> Self {
         Self {
             source,
@@ -203,7 +201,9 @@ impl SsdpSearchReflector {
                 searcher: packet.source,
                 searcher_mac,
                 egress: self.source,
-                dial: self.dial,
+                dial: self
+                    .dial
+                    .then(|| DialRewrite::new(self.target, self.target_ifindex)),
             }),
         );
         Some(Session {
@@ -374,7 +374,7 @@ mod tests {
             CaptureKey::from_u64(0),
             0,
             None,
-            None,
+            false,
         );
         assert_eq!(
             reflector.next_deadline(),
@@ -409,7 +409,7 @@ mod tests {
             CaptureKey::from_u64(0),
             0,
             None,
-            None,
+            false,
         );
         let base = Instant::now();
         push_session(&mut reflector, &mut dispatcher, "10.0.0.1:5", base); // already due
@@ -454,7 +454,7 @@ mod tests {
             CaptureKey::from_u64(0),
             0,
             None,
-            None,
+            false,
         );
         let base = Instant::now();
         push_session(&mut reflector, &mut dispatcher, "10.0.0.7:50000", base);


### PR DESCRIPTION
## What

The SSDP advertisement and M-SEARCH response directions each zeroed a 2 KB stack buffer per reflected datagram to rewrite a DIAL `LOCATION`, even though the buffer is fully written before it is read.

- **`net/uninit_buf.rs` — `UninitBuf`**: a fixed-capacity byte sink over a lazily-allocated `Box<[MaybeUninit<u8>]>`, written through `io::Write` and read back as its `filled()` prefix. All uninitialized-memory `unsafe` is contained here behind a safe interface (`io::Write` + `clear` + `filled`); a write past capacity is a short write, so callers see `WriteZero` rather than a silent truncation.
- **`rewrite_location`** now writes into a generic `&mut impl io::Write` and returns a `bool`, decoupling it from the buffer — its tests use a `Vec` sink.
- **`DialRewrite`** owns the reused `UninitBuf` (now non-`Copy`) and is minted per rewriting reflector: one for the advertisement direction, one per M-SEARCH session (the search reflector holds a `dial: bool`).
- `StreamBuffer` is untouched; no per-packet zeroing remains on the DIAL rewrite path.

This is an internal, behavior-preserving refactor — no version bump.

## Testing

- `cargo test --lib` — 352 pass (adds 5 `UninitBuf` tests).
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo doc --no-deps --document-private-items` — clean.
- e2e suite — 37/37 pass (the DIAL cases, incl. `dial_launch_roundtrip`, exercise the rewrite path end to end).