### PR TITLE
CI: add an aggregate Success job as the single required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,3 +311,25 @@ jobs:
           cache-to: type=gha,mode=max,scope=valgrind
       - name: Run e2e under Valgrind memcheck
         run: python3 e2e/run.py --valgrind --skip-build
+
+  # A single aggregate status check: green only when every job above is green (or was legitimately skipped
+  # by `gate` because this tree already passed CI). Make THIS the sole required check in branch protection --
+  # then adding, renaming, or removing a job never means editing the required-checks list; its `needs` below
+  # is the one place that set is maintained. `if: !cancelled()` forces it to run even when upstream jobs were
+  # skipped (a skipped dependency would otherwise skip this job too); the failure step then treats only real
+  # failures / cancellations as fatal, so a gate-driven skip still passes.
+  success:
+    name: Success
+    if: ${{ !cancelled() }}
+    needs: [gate, fmt, lint, test, cross-test, freebsd, docker-e2e, valgrind-e2e]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Report upstream results
+        run: |
+          echo "Upstream job results: ${{ join(needs.*.result, ', ') }}"
+      - name: Fail if any required job did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more required jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
## What

Adds a final `success` job to `ci.yml` that depends on every other job (`gate`, `fmt`, `lint`, `test`, `cross-test`, `freebsd`, `docker-e2e`, `valgrind-e2e`) and is green only when all of them succeeded — or were legitimately skipped by `gate` when this tree already passed CI.

## Why

Make **Success** the *single* required status check in branch protection. Then adding, renaming, or removing a job never means updating the required-checks list — the job's `needs:` becomes the one place that set is maintained.

## How it behaves

- **Normal PR run** — all jobs run → `success` sees all `success` → passes.
- **Any job fails / is cancelled** → the failure step fires → `success` fails.
- **Post-merge re-run where `gate` short-circuits the heavy jobs** — those are `skipped` (not `failure`/`cancelled`), so `success` still passes.

Two details that make the pattern robust:
- `if: ${{ !cancelled() }}` forces the job to run even when its dependencies were skipped — otherwise GitHub would skip `success` itself and leave the required check stuck pending.
- The failure step guards on `contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')`, so a gate-driven `skipped` is not treated as a failure.

Docs/CI-only; no code change, no version bump. Can only be fully exercised once it runs on GitHub.