### PR TITLE
Add the WSD (WS-Discovery) reflector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "reflector"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflector"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.93"
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ talk to each other sit on different L2 segments that don't forward each other's 
 multicasts — the classic case being a router with a wired LAN on one side and a Wi-Fi or IoT VLAN on
 the other, where (say) a phone on Wi-Fi can't discover or cast to a TV on the LAN.
 
-It reflects three link-local protocols, and layers an optional DIAL proxy on top of SSDP:
+It reflects four link-local protocols, and layers an optional DIAL proxy on top of SSDP:
 
 - **Wake-on-LAN** — magic packets sent on one interface are re-emitted on another, so a sender can
   wake a host on a different segment.
@@ -17,6 +17,8 @@ It reflects three link-local protocols, and layers an optional DIAL proxy on top
   own subnet; the proxy bridges that gap so a client on the other segment can actually launch apps on
   it. It is not a separate reflector — it augments an SSDP entry, enabled with `dial = true`. See
   [DIAL](#dial).
+- **WS-Discovery (WSD)** — SOAP-over-UDP discovery is relayed both ways, so a client on one segment can
+  discover ONVIF cameras or Windows devices (printers, scanners) on the other.
 
 Each named entry bridges one `source_if` → `target_if` interface pair and enables any combination of
 these. The same shape serves one or a few specific devices (`macs`) or a whole network (omit it).
@@ -203,6 +205,7 @@ wol       = true         # enable Wake-on-LAN, disabled by default
 mdns      = true         # enable mDNS, disabled by default
 ssdp      = true         # enable SSDP, disabled by default
 dial      = true         # enable the DIAL proxy, disabled by default
+wsd       = true         # enable WS-Discovery, disabled by default
 ```
 
 On RouterOS, setting the container's environment variables is usually easier than mounting a file: the
@@ -232,6 +235,7 @@ wol       = true                 # optional; enable Wake-on-LAN reflection (defa
 mdns      = true                 # optional; enable mDNS reflection (default false)
 ssdp      = true                 # optional; enable SSDP reflection (default false)
 dial      = true                 # optional; enable the DIAL app proxy (requires ssdp; IPv4-only; default false)
+wsd       = true                 # optional; enable WS-Discovery reflection (default false)
 wol_ports = [7, 9]               # optional; WoL UDP ports (default [7, 9]); only valid when wol = true
 address_family = "default"       # optional; default | dual | ipv4 | ipv6 (default "default")
 ```
@@ -268,6 +272,7 @@ REFLECTOR_TV_WOL=true
 REFLECTOR_TV_MDNS=true
 REFLECTOR_TV_SSDP=true
 REFLECTOR_TV_DIAL=true
+REFLECTOR_TV_WSD=true
 ```
 
 When a file and environment variables are both given they are merged: each contributes entries to one
@@ -328,11 +333,12 @@ address refresh.
 | mDNS | 5353 | `224.0.0.251` / `ff02::fb` | queries source→target, responses target→source |
 | SSDP | 1900 | `239.255.255.250` / `ff02::c` + `ff05::c` | M-SEARCH source→target, NOTIFY target→source |
 | DIAL | 1900 + ephemeral TCP | (uses SSDP discovery) | terminating HTTP reverse proxy (IPv4 only) |
+| WSD | 3702 | `239.255.255.250` / `ff02::c` | Probe/Resolve source→target, Hello/Bye target→source |
 
 WoL matching requires the magic-packet sequence (six `0xFF` bytes followed by the target MAC repeated 16
 times) at the start of the UDP payload; trailing bytes such as a SecureOn password are ignored when
 matching and forwarded as-is. mDNS responses include unsolicited announcements (so they flow
-target→source too); mDNS/SSDP datagrams are re-emitted verbatim to the same group (SSDP at hop limit 2).
+target→source too); mDNS/SSDP/WSD datagrams are re-emitted verbatim to the same group (SSDP at hop limit 2, WSD at 1).
 A site-local SSDP group (`ff05::c`) is sourced from a routable address, not the interface's link-local.
 
 For SSDP, multicast reflection delivers **passive** discovery — devices' periodic `NOTIFY ssdp:alive`
@@ -343,6 +349,13 @@ The proxy is always on whenever `ssdp` is enabled — it keeps one short-lived s
 search (expiring shortly after the search's `MX` window) and needs no configuration. Reaching a
 device's `LOCATION` URL and driving an app launch across segments is the job of the optional DIAL proxy
 below.
+
+WSD (WS-Discovery) works the same way but on port 3702 with SOAP messages instead of HTTPU: `Hello` /
+`Bye` announcements are relayed target→source, and a client's `Probe` / `Resolve` is relayed
+source→target with the device's unicast `ProbeMatches` / `ResolveMatches` proxied back through a
+per-searcher session — the same machinery as SSDP's `M-SEARCH`, with no DIAL layer. It shares SSDP's
+IPv4 group but uses only the link-local IPv6 scope (`ff02::c`), and covers ONVIF NVR↔camera and Windows
+device/printer discovery across segments.
 
 ### DIAL
 

--- a/e2e/config-wsd.toml
+++ b/e2e/config-wsd.toml
@@ -1,0 +1,10 @@
+log_level = "debug"
+
+# A WSD-only reflector for the WS-Discovery e2e cases: bridges wol_src <-> wol_dst under the default
+# address-family policy, so both IPv4 (239.255.255.250) and IPv6 (ff02::c) announcements and searches
+# on UDP 3702 are exercised.
+
+[reflectors.discovery]
+source_if = "wol_src"
+target_if = "wol_dst"
+wsd = true

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -105,6 +105,108 @@ SSDP_DIAL_MSEARCH_HEX = (
     f"ST: {DIAL_SERVICE_TYPE}\r\n\r\n"
 ).encode().hex()
 DIAL_CLIENT_SOURCE_PORT = 49153
+# --- WSD (WS-Discovery): SOAP-over-UDP. Groups 239.255.255.250 / ff02::c (shared with SSDP) on UDP
+# 3702 -- the port distinguishes it from SSDP. The reflector classifies on the <Action> URI segment and
+# relays the bytes verbatim, so the receiver expects exactly what was sent. Real ONVIF-style envelopes
+# (2005/04 namespace). ---
+WSD_GROUP_V4 = SSDP_GROUP_V4
+WSD_GROUP_V6 = SSDP_GROUP_V6
+WSD_PORT = 3702
+WSD_HELLO_HEX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
+    ' xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"'
+    ' xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">'
+    "<s:Header>"
+    "<a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Hello</a:Action>"
+    "<a:MessageID>urn:uuid:hello-0001</a:MessageID>"
+    "<a:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>"
+    "</s:Header>"
+    "<s:Body><d:Hello>"
+    "<a:EndpointReference><a:Address>urn:uuid:camera-0001</a:Address></a:EndpointReference>"
+    "<d:Types>dn:NetworkVideoTransmitter</d:Types><d:MetadataVersion>1</d:MetadataVersion>"
+    "</d:Hello></s:Body></s:Envelope>"
+).encode().hex()
+WSD_BYE_HEX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
+    ' xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"'
+    ' xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">'
+    "<s:Header>"
+    "<a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Bye</a:Action>"
+    "<a:MessageID>urn:uuid:bye-0001</a:MessageID>"
+    "<a:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>"
+    "</s:Header>"
+    "<s:Body><d:Bye>"
+    "<a:EndpointReference><a:Address>urn:uuid:camera-0001</a:Address></a:EndpointReference>"
+    "</d:Bye></s:Body></s:Envelope>"
+).encode().hex()
+WSD_PROBE_HEX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
+    ' xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"'
+    ' xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">'
+    "<s:Header>"
+    "<a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>"
+    "<a:MessageID>urn:uuid:probe-0001</a:MessageID>"
+    "<a:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>"
+    "</s:Header>"
+    "<s:Body><d:Probe><d:Types>dn:NetworkVideoTransmitter</d:Types></d:Probe></s:Body>"
+    "</s:Envelope>"
+).encode().hex()
+WSD_RESOLVE_HEX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
+    ' xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"'
+    ' xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">'
+    "<s:Header>"
+    "<a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Resolve</a:Action>"
+    "<a:MessageID>urn:uuid:resolve-0001</a:MessageID>"
+    "<a:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>"
+    "</s:Header>"
+    "<s:Body><d:Resolve>"
+    "<a:EndpointReference><a:Address>urn:uuid:camera-0001</a:Address></a:EndpointReference>"
+    "</d:Resolve></s:Body></s:Envelope>"
+).encode().hex()
+# The unicast ProbeMatches a device answers a Probe with; the round-trip responder replies with this and
+# the searcher asserts it arrives verbatim after the reflector proxies it back across segments.
+WSD_PROBEMATCHES_HEX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
+    ' xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"'
+    ' xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">'
+    "<s:Header>"
+    "<a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches</a:Action>"
+    "<a:MessageID>urn:uuid:match-0001</a:MessageID>"
+    "<a:RelatesTo>urn:uuid:probe-0001</a:RelatesTo>"
+    "<a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>"
+    "</s:Header>"
+    "<s:Body><d:ProbeMatches><d:ProbeMatch>"
+    "<a:EndpointReference><a:Address>urn:uuid:camera-0001</a:Address></a:EndpointReference>"
+    "<d:Types>dn:NetworkVideoTransmitter</d:Types>"
+    "<d:XAddrs>http://device.invalid/onvif/device_service</d:XAddrs>"
+    "<d:MetadataVersion>1</d:MetadataVersion>"
+    "</d:ProbeMatch></d:ProbeMatches></s:Body></s:Envelope>"
+).encode().hex()
+# The unicast ResolveMatches a device answers a Resolve with.
+WSD_RESOLVEMATCHES_HEX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
+    ' xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"'
+    ' xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">'
+    "<s:Header>"
+    "<a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/ResolveMatches</a:Action>"
+    "<a:MessageID>urn:uuid:resolvematch-0001</a:MessageID>"
+    "<a:RelatesTo>urn:uuid:resolve-0001</a:RelatesTo>"
+    "<a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>"
+    "</s:Header>"
+    "<s:Body><d:ResolveMatches><d:ResolveMatch>"
+    "<a:EndpointReference><a:Address>urn:uuid:camera-0001</a:Address></a:EndpointReference>"
+    "<d:Types>dn:NetworkVideoTransmitter</d:Types>"
+    "<d:XAddrs>http://device.invalid/onvif/device_service</d:XAddrs>"
+    "<d:MetadataVersion>1</d:MetadataVersion>"
+    "</d:ResolveMatch></d:ResolveMatches></s:Body></s:Envelope>"
+).encode().hex()
 # --- Address-change cases: knock out one (interface, family) source on the reflector, prove
 # reflection of that family stops, then restore it and prove it resumes. The reflector reacts on
 # its own event loop after the netlink notification, so each check polls across that async window.
@@ -494,6 +596,89 @@ SSDP_CASES = [
     ),
 ]
 
+WSD_CASES = [
+    # Hello/Bye announcements reflect device (target) -> client (source). A Hello sent on the target is
+    # relayed verbatim to the source. (Announcement direction = "reverse".)
+    TestCase(
+        name="reflects_wsd_hello",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=WSD_HELLO_HEX,
+        expect_payload_hex=WSD_HELLO_HEX,
+        group=WSD_GROUP_V4,
+        direction="reverse",
+    ),
+    # The IPv6 mirror: WSD uses the link-local ff02::c group.
+    TestCase(
+        name="reflects_wsd_hello_ipv6",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=WSD_HELLO_HEX,
+        expect_payload_hex=WSD_HELLO_HEX,
+        group=WSD_GROUP_V6,
+        family=6,
+        direction="reverse",
+    ),
+    # Bye relays through the same announcement path as Hello (both classify as an announcement).
+    TestCase(
+        name="reflects_wsd_bye",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=WSD_BYE_HEX,
+        expect_payload_hex=WSD_BYE_HEX,
+        group=WSD_GROUP_V4,
+        direction="reverse",
+    ),
+    # A Probe on the target hits the announcement handler, which classifies it as the search direction
+    # and skips it -- never relayed to the source.
+    TestCase(
+        name="ignores_wsd_probe_in_announcement_direction",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=WSD_PROBE_HEX,
+        group=WSD_GROUP_V4,
+        direction="reverse",
+    ),
+    # A Hello on the source hits the search handler, which classifies it as the announcement direction
+    # and skips it -- never relayed to the target.
+    TestCase(
+        name="ignores_wsd_hello_in_search_direction",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=WSD_HELLO_HEX,
+        group=WSD_GROUP_V4,
+        direction="forward",
+    ),
+    # A non-WSD payload on the WSD group (an SSDP M-SEARCH carries no <Action>): classified as junk and
+    # dropped.
+    TestCase(
+        name="ignores_non_wsd_on_wsd_group",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=SSDP_MSEARCH_HEX,
+        group=WSD_GROUP_V4,
+        direction="reverse",
+    ),
+]
+
 
 @dataclasses.dataclass(frozen=True)
 class RoundTripCase:
@@ -502,8 +687,15 @@ class RoundTripCase:
     group: str
     timeout_seconds: float = 8.0
     # When False, no responder is started and the searcher must receive nothing -- the reflector must
-    # not fabricate or loop back a reply to an M-SEARCH no device answered.
+    # not fabricate or loop back a reply to a search no device answered.
     expect_reply: bool = True
+    # Protocol parameters, defaulting to SSDP's M-SEARCH round trip; WSD overrides them (its Probe ->
+    # ProbeMatches uses the same session machinery on a different port / with different payloads).
+    port: int = SSDP_PORT
+    probe_hex: str = SSDP_MSEARCH_HEX
+    reply_hex: str = SSDP_OK_HEX
+    config: str = "config.toml"
+    evict_log: str = "evicted SSDP session"
 
 
 ROUNDTRIP_CASES = [
@@ -515,6 +707,15 @@ ROUNDTRIP_CASES = [
     RoundTripCase(name="ssdp_msearch_roundtrip_ipv6_site_local", family=6, group=SSDP_GROUP_V6_SITE),
     RoundTripCase(name="ssdp_msearch_no_responder_no_reply", family=4, group=SSDP_GROUP_V4,
         timeout_seconds=2.0, expect_reply=False),
+    # WSD Probe -> ProbeMatches: the same per-searcher session machinery on port 3702, replies relayed
+    # verbatim (no DIAL). Eviction fires after the fixed 5s WSD window.
+    RoundTripCase(name="wsd_probe_roundtrip", family=4, group=WSD_GROUP_V4, port=WSD_PORT,
+        probe_hex=WSD_PROBE_HEX, reply_hex=WSD_PROBEMATCHES_HEX, config="config-wsd.toml",
+        evict_log="evicted WSD session"),
+    # Resolve -> ResolveMatches: the same search-session path as Probe (both classify as a search).
+    RoundTripCase(name="wsd_resolve_roundtrip", family=4, group=WSD_GROUP_V4, port=WSD_PORT,
+        probe_hex=WSD_RESOLVE_HEX, reply_hex=WSD_RESOLVEMATCHES_HEX, config="config-wsd.toml",
+        evict_log="evicted WSD session"),
 ]
 
 @dataclasses.dataclass(frozen=True)
@@ -603,8 +804,8 @@ ADDRESS_CHANGE_CASES = [
 ]
 
 ALL_CASES: list[TestCase | RoundTripCase | DialCase | DialAddressChangeCase | AddressChangeCase] = [
-    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *ROUNDTRIP_CASES, *DIAL_CASES, *DIAL_ADDRESS_CHANGE_CASES,
-    *ADDRESS_CHANGE_CASES]
+    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *WSD_CASES, *ROUNDTRIP_CASES, *DIAL_CASES,
+    *DIAL_ADDRESS_CHANGE_CASES, *ADDRESS_CHANGE_CASES]
 
 
 def format_command(command: list[str]) -> str:
@@ -950,9 +1151,9 @@ class DockerRoundTrip(DockerE2E):
     def __init__(self, args: argparse.Namespace, case: RoundTripCase) -> None:
         # The base __init__ only reads case.name and case.direction; a TestCase shim reuses all its
         # network/reflector setup + cleanup with no duplication.
-        shim = TestCase(name=case.name, send_port=SSDP_PORT, receive_port=SSDP_PORT,
+        shim = TestCase(name=case.name, send_port=case.port, receive_port=case.port,
             expect_mac=None, timeout_seconds=case.timeout_seconds, family=case.family,
-            group=case.group, direction="forward")
+            group=case.group, direction="forward", config=case.config)
         super().__init__(args, shim)
         self.rt = case
         self.responder_container = f"{self.prefix}-responder"
@@ -965,22 +1166,22 @@ class DockerRoundTrip(DockerE2E):
             "--network", f"name={self.target_network},driver-opt=com.docker.network.endpoint.ifname={RECEIVER_IFNAME}",
             "--mount", f"type=bind,source={E2E_DIR},target=/e2e,readonly",
             self.args.helper_image, "python3", "/e2e/probe.py", "respond",
-            "--port", str(SSDP_PORT), "--timeout", str(self.rt.timeout_seconds),
+            "--port", str(self.rt.port), "--timeout", str(self.rt.timeout_seconds),
             "--family", str(self.rt.family), "--join-group", self.rt.group,
-            "--interface", RECEIVER_IFNAME, "--reply-hex", SSDP_OK_HEX,
+            "--interface", RECEIVER_IFNAME, "--reply-hex", self.rt.reply_hex,
         ])
         self.wait_for_container_log(self.responder_container, "responder ready", "responder")
 
     def run_searcher(self) -> None:
-        expectation = ["--expect-payload-hex", SSDP_OK_HEX] if self.rt.expect_reply else ["--expect-none"]
+        expectation = ["--expect-payload-hex", self.rt.reply_hex] if self.rt.expect_reply else ["--expect-none"]
         docker([
             "run", "-d", "--name", self.searcher_container,
             "--network", f"name={self.source_network},driver-opt=com.docker.network.endpoint.ifname={REFLECTOR_SOURCE_IFNAME}",
             "--mount", f"type=bind,source={E2E_DIR},target=/e2e,readonly",
             self.args.helper_image, "python3", "/e2e/probe.py", "search",
-            "--source-port", str(SEARCHER_SOURCE_PORT), "--port", str(SSDP_PORT),
+            "--source-port", str(SEARCHER_SOURCE_PORT), "--port", str(self.rt.port),
             "--address", self.rt.group, "--interface", REFLECTOR_SOURCE_IFNAME,
-            "--family", str(self.rt.family), "--payload-hex", SSDP_MSEARCH_HEX,
+            "--family", str(self.rt.family), "--payload-hex", self.rt.probe_hex,
             "--timeout", str(self.rt.timeout_seconds), *expectation,
         ])
 
@@ -1002,10 +1203,10 @@ class DockerRoundTrip(DockerE2E):
             self.start_responder()  # must be listening before the search goes out
         self.run_searcher()
         self.wait_for_searcher()
-        # The per-searcher session must be torn down once it expires (MX 2 + 2s grace ~= 4s): the
-        # deadline timer sweeps it, drops its port reservation, and unregisters its response capture --
-        # logged by the reflector. wait_for_container_log raises if the eviction never fires.
-        self.wait_for_container_log(self.reflector_container, "evicted SSDP session", "session eviction")
+        # The per-searcher session must be torn down once it expires (SSDP: MX 2 + 2s grace ~= 4s; WSD:
+        # a fixed 5s window): the deadline timer sweeps it, drops its port reservation, and unregisters
+        # its response capture -- logged by the reflector. wait_for_container_log raises if it never fires.
+        self.wait_for_container_log(self.reflector_container, self.rt.evict_log, "session eviction")
         print(f"{self.rt.name}: session evicted after expiry", flush=True)
         print(f"PASS {self.rt.name}", flush=True)
         if self.args.show_reflector_logs:

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,8 @@ pub(crate) struct Reflector {
     pub(crate) mdns: bool,
     /// SSDP settings, or `None` when SSDP is disabled.
     pub(crate) ssdp: Option<Ssdp>,
+    /// Whether WS-Discovery (WSD) is enabled.
+    pub(crate) wsd: bool,
 }
 
 impl Reflector {
@@ -90,6 +92,9 @@ impl Reflector {
         if self.ssdp.is_some() && other.ssdp.is_some() {
             return Some(Protocol::Ssdp);
         }
+        if self.wsd && other.wsd {
+            return Some(Protocol::Wsd);
+        }
         None
     }
 }
@@ -114,7 +119,7 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             });
         }
 
-        if !raw.wol && !raw.mdns && !raw.ssdp {
+        if !raw.wol && !raw.mdns && !raw.ssdp && !raw.wsd {
             return Err(ConfigError::NoProtocol { name });
         }
         if raw.wol_ports.is_some() && !raw.wol {
@@ -149,6 +154,7 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             wol,
             mdns: raw.mdns,
             ssdp,
+            wsd: raw.wsd,
         })
     }
 }
@@ -280,6 +286,9 @@ fn protocol_list(reflector: &Reflector) -> String {
             "ssdp".to_owned()
         });
     }
+    if reflector.wsd {
+        protocols.push("wsd".to_owned());
+    }
     protocols.join(", ")
 }
 
@@ -349,6 +358,25 @@ mod tests {
         assert!(r.mdns);
         assert!(r.macs.is_none());
         assert_eq!(r.address_family, AddressFamily::Default);
+        assert!(r.wol.is_none());
+        assert!(r.ssdp.is_none());
+        assert!(!r.wsd);
+    }
+
+    #[test]
+    fn wsd_reflector_parses() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.cameras]
+            source_if = "lan"
+            target_if = "cams"
+            wsd = true
+            "#,
+        )
+        .unwrap();
+        let r = &cfg.reflectors[0];
+        assert!(r.wsd);
+        assert!(!r.mdns);
         assert!(r.wol.is_none());
         assert!(r.ssdp.is_none());
     }
@@ -704,6 +732,28 @@ mod tests {
             err(text),
             ConfigError::ConflictingReflectors {
                 protocol: Protocol::Mdns,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn conflicting_wsd_reflectors_rejected() {
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "cams"
+            wsd = true
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "cams"
+            wsd = true
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Wsd,
                 ..
             }
         ));

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -24,6 +24,7 @@ struct PartialReflector {
     mdns: Option<bool>,
     ssdp: Option<bool>,
     dial: Option<bool>,
+    wsd: Option<bool>,
     wol_ports: Option<WolPorts>,
     address_family: Option<AddressFamily>,
 }
@@ -42,6 +43,7 @@ impl PartialReflector {
             "mdns" => self.mdns = Some(env_bool(value, var)?),
             "ssdp" => self.ssdp = Some(env_bool(value, var)?),
             "dial" => self.dial = Some(env_bool(value, var)?),
+            "wsd" => self.wsd = Some(env_bool(value, var)?),
             _ => {
                 return Err(ConfigError::EnvUnknownParam {
                     var: var.to_owned(),
@@ -69,6 +71,7 @@ impl PartialReflector {
             mdns: self.mdns.unwrap_or(false),
             ssdp: self.ssdp.unwrap_or(false),
             dial: self.dial.unwrap_or(false),
+            wsd: self.wsd.unwrap_or(false),
             wol_ports: self.wol_ports,
             address_family: self.address_family.unwrap_or_default(),
         })
@@ -226,6 +229,17 @@ mod tests {
         let r = &cfg.reflectors[0];
         assert!(r.wol.is_some());
         assert!(!r.mdns);
+    }
+
+    #[test]
+    fn env_wsd_flag() {
+        let cfg = from_env(&[
+            ("REFLECTOR_CAMS_SOURCE_IF", "lan"),
+            ("REFLECTOR_CAMS_TARGET_IF", "cams"),
+            ("REFLECTOR_CAMS_WSD", "true"),
+        ])
+        .unwrap();
+        assert!(cfg.reflectors[0].wsd);
     }
 
     #[test]

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -44,7 +44,7 @@ pub(crate) enum ConfigError {
         value: InterfaceName,
     },
 
-    #[error("reflector \"{name}\" enables no protocol (set wol, mdns, or ssdp)")]
+    #[error("reflector \"{name}\" enables no protocol (set wol, mdns, ssdp, or wsd)")]
     NoProtocol { name: ReflectorName },
 
     #[error("reflector \"{name}\" sets wol_ports but does not enable wol")]
@@ -122,6 +122,7 @@ pub(crate) enum Protocol {
     Wol,
     Mdns,
     Ssdp,
+    Wsd,
 }
 
 impl fmt::Display for Protocol {
@@ -130,6 +131,7 @@ impl fmt::Display for Protocol {
             Self::Wol => "WoL",
             Self::Mdns => "mDNS",
             Self::Ssdp => "SSDP",
+            Self::Wsd => "WSD",
         })
     }
 }

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -37,16 +37,18 @@ pub(super) struct RawReflector {
     pub(super) target_if: InterfaceName,
     pub(super) macs: Option<MacSet>,
     #[serde(default)]
+    pub(super) address_family: AddressFamily,
+    #[serde(default)]
     pub(super) wol: bool,
+    pub(super) wol_ports: Option<WolPorts>,
     #[serde(default)]
     pub(super) mdns: bool,
     #[serde(default)]
     pub(super) ssdp: bool,
     #[serde(default)]
     pub(super) dial: bool,
-    pub(super) wol_ports: Option<WolPorts>,
     #[serde(default)]
-    pub(super) address_family: AddressFamily,
+    pub(super) wsd: bool,
 }
 
 impl RawConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub fn run(args: &[String]) -> Result<()> {
             .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
         crate::reflector::ssdp::build(reflector, &interfaces, &mut dispatcher)
             .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
+        crate::reflector::wsd::build(reflector, &interfaces, &mut dispatcher)
+            .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
     }
 
     let mut reactor = Reactor::new()?;

--- a/src/net.rs
+++ b/src/net.rs
@@ -12,8 +12,6 @@ pub(crate) mod ssdp;
 pub(crate) mod stream_buffer;
 pub(crate) mod tcp;
 pub(crate) mod uninit_buf;
-// The WSD reflector (next step) consumes the group/port/TTL consts; this holds until then.
-#[allow(dead_code)]
 pub(crate) mod wsd;
 
 /// The link-layer framing of a captured or injected frame. The capture layer reports

--- a/src/net.rs
+++ b/src/net.rs
@@ -12,6 +12,9 @@ pub(crate) mod ssdp;
 pub(crate) mod stream_buffer;
 pub(crate) mod tcp;
 pub(crate) mod uninit_buf;
+// The WSD reflector (next step) consumes the group/port/TTL consts; this holds until then.
+#[allow(dead_code)]
+pub(crate) mod wsd;
 
 /// The link-layer framing of a captured or injected frame. The capture layer reports
 /// it per interface; [`frame`] adds the matching link header and [`packet`] strips it

--- a/src/net/wsd.rs
+++ b/src/net/wsd.rs
@@ -1,0 +1,378 @@
+//! WS-Discovery (WSD) wire helpers: the multicast group / port / TTL and a classifier that sorts a
+//! SOAP-over-UDP datagram into an announcement (`Hello` / `Bye`) or a search (`Probe` / `Resolve`) by
+//! its WS-Addressing `Action` URI. WSD is structurally SSDP-without-DIAL: announcements reflect device
+//! → client, searches client → device with unicast `ProbeMatches` / `ResolveMatches` replies routed
+//! back through a per-searcher session.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// WSD runs SOAP-over-UDP on port 3702, re-emitted at TTL 1 — the re-emit is a single hop onto the
+/// egress link, matching the link scope of the groups it serves.
+pub(crate) const WSD_PORT: u16 = 3702;
+pub(crate) const WSD_TTL: u8 = 1;
+/// The WS-Discovery multicast groups: IPv4 `239.255.255.250` (shared with SSDP) and IPv6 `ff02::c`.
+/// Unlike SSDP, WSD uses only the link-local IPv6 scope (no site-local `ff05::c`).
+pub(crate) const WSD_GROUP_V4: Ipv4Addr = Ipv4Addr::new(239, 255, 255, 250);
+pub(crate) const WSD_GROUP_V6: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x0c);
+
+/// What a WSD datagram on the group is, by its `Action` message type. The unicast reply types
+/// (`ProbeMatches` / `ResolveMatches`) never reach the group, so they classify as neither.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WsdKind {
+    /// A device presence announcement — `Hello` or `Bye`.
+    Announcement,
+    /// A client discovery request — `Probe` or `Resolve`.
+    Search,
+}
+
+/// Classify a WSD SOAP-over-UDP datagram by the final path segment of its WS-Addressing `Action` URI
+/// (namespace-agnostic: the 2005/04 and 2009/01 discovery namespaces differ only in the URI prefix).
+/// `None` for a reply type (`ProbeMatches` / `ResolveMatches` — unicast, not expected on the group), a
+/// missing `Action`, or non-WSD junk.
+pub(crate) fn classify(payload: &[u8]) -> Option<WsdKind> {
+    match action_segment(payload)? {
+        b"Hello" | b"Bye" => Some(WsdKind::Announcement),
+        b"Probe" | b"Resolve" => Some(WsdKind::Search),
+        _ => None,
+    }
+}
+
+/// The final `/`-delimited segment of the first `Action` element's URI (the WS-Addressing message
+/// type), or `None` when there is no such element. Walks the payload element by element so the match is
+/// scoped to the `Action` tag — tolerant of the namespace prefix (`a:` / `wsa:` / none) and of tag
+/// attributes (ONVIF sends `mustUnderstand`), and never fooled by the token appearing in the body.
+fn action_segment(payload: &[u8]) -> Option<&[u8]> {
+    let mut rest = payload;
+    while let Some(open) = rest.iter().position(|&b| b == b'<') {
+        rest = &rest[open + 1..];
+        let close = rest.iter().position(|&b| b == b'>')?;
+        let (tag, after) = rest.split_at(close);
+        rest = &after[1..]; // past the '>'
+        // A closing tag (`</…>`), the XML declaration (`<?…`), or a comment/doctype (`<!…`) is not an
+        // opening element.
+        if matches!(tag.first().copied(), Some(b'/' | b'?' | b'!')) {
+            continue;
+        }
+        // The element name runs up to the first whitespace or self-close '/'; drop any `prefix:`.
+        let name = tag
+            .split(|&b| b.is_ascii_whitespace() || b == b'/')
+            .next()
+            .unwrap_or(tag);
+        let local = name.rsplit(|&b| b == b':').next().unwrap_or(name);
+        if local.eq_ignore_ascii_case(b"Action") {
+            let end = rest.iter().position(|&b| b == b'<').unwrap_or(rest.len());
+            let uri = rest[..end].trim_ascii();
+            return uri.rsplit(|&b| b == b'/').next().filter(|s| !s.is_empty());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The WS-Discovery Action namespaces: the 2005/04 draft (ONVIF) and the 2009/01 standard.
+    const NS_2005: &str = "http://schemas.xmlsoap.org/ws/2005/04/discovery";
+    const NS_2009: &str = "http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01";
+
+    /// A minimal SOAP envelope carrying `action` as its WS-Addressing `Action`.
+    fn envelope(action: &str) -> Vec<u8> {
+        format!(
+            "<s:Envelope xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\" \
+             xmlns:a=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\">\
+             <s:Header>\
+             <a:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>\
+             <a:Action>{action}</a:Action>\
+             <a:MessageID>urn:uuid:0a-b</a:MessageID>\
+             </s:Header><s:Body/></s:Envelope>"
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn probe_and_resolve_are_searches() {
+        assert_eq!(
+            classify(&envelope(&format!("{NS_2005}/Probe"))),
+            Some(WsdKind::Search)
+        );
+        assert_eq!(
+            classify(&envelope(&format!("{NS_2009}/Resolve"))),
+            Some(WsdKind::Search)
+        );
+    }
+
+    #[test]
+    fn hello_and_bye_are_announcements() {
+        assert_eq!(
+            classify(&envelope(&format!("{NS_2005}/Hello"))),
+            Some(WsdKind::Announcement)
+        );
+        assert_eq!(
+            classify(&envelope(&format!("{NS_2009}/Bye"))),
+            Some(WsdKind::Announcement)
+        );
+    }
+
+    #[test]
+    fn reply_types_are_not_classified() {
+        // ProbeMatches / ResolveMatches are unicast replies; the segment must not collapse to the
+        // Probe / Resolve prefix it starts with.
+        assert_eq!(
+            classify(&envelope(&format!("{NS_2005}/ProbeMatches"))),
+            None
+        );
+        assert_eq!(
+            classify(&envelope(&format!("{NS_2009}/ResolveMatches"))),
+            None
+        );
+    }
+
+    #[test]
+    fn tolerates_prefixes_attributes_and_whitespace() {
+        // No namespace prefix on the element.
+        assert_eq!(
+            classify(b"<Envelope><Header><Action>http://x/Probe</Action></Header></Envelope>"),
+            Some(WsdKind::Search)
+        );
+        // An attribute on the Action tag (ONVIF sends mustUnderstand).
+        assert_eq!(
+            classify(
+                b"<s:Header><a:Action a:mustUnderstand=\"1\">http://x/Hello</a:Action></s:Header>"
+            ),
+            Some(WsdKind::Announcement)
+        );
+        // Whitespace around the URI.
+        assert_eq!(
+            classify(b"<a:Action>  http://x/Bye  </a:Action>"),
+            Some(WsdKind::Announcement)
+        );
+    }
+
+    #[test]
+    fn scoped_to_the_action_element() {
+        // "Probe" in the body must not turn a Hello announcement into a search.
+        assert_eq!(
+            classify(
+                b"<s:Header><a:Action>http://x/Hello</a:Action></s:Header>\
+                  <s:Body><d:Types>dn:Probe</d:Types></s:Body>"
+            ),
+            Some(WsdKind::Announcement)
+        );
+    }
+
+    #[test]
+    fn junk_and_missing_action_are_none() {
+        assert_eq!(classify(b""), None);
+        assert_eq!(classify(b"not xml at all"), None);
+        // A well-formed envelope with no Action element.
+        assert_eq!(
+            classify(b"<s:Envelope><s:Header><a:To>urn:x</a:To></s:Header></s:Envelope>"),
+            None
+        );
+        // An SSDP M-SEARCH mistakenly on the WSD port carries no Action element.
+        assert_eq!(classify(b"M-SEARCH * HTTP/1.1\r\nMX: 2\r\n\r\n"), None);
+    }
+
+    // --- Real on-the-wire messages, verbatim from captures and specs (see each provenance) ---
+
+    /// OASIS WS-Discovery 1.1 spec (docs.oasis-open.org), 2009/01 namespace, ad hoc Hello. The
+    /// Action URI is wrapped in whitespace, as the spec prints it.
+    const HELLO_OASIS_2009: &str = r#"<s:Envelope
+  xmlns:a="http://www.w3.org/2005/08/addressing"
+  xmlns:d="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"
+  xmlns:s="http://www.w3.org/2003/05/soap-envelope" >
+  <s:Header>
+    <a:Action>
+      http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Hello
+    </a:Action>
+    <a:MessageID>
+      urn:uuid:73948edc-3204-4455-bae2-7c7d0ff6c37c
+    </a:MessageID>
+    <a:To>urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01</a:To>
+    <d:AppSequence InstanceId="1077004800" MessageNumber="1" />
+  </s:Header>
+  <s:Body>
+    <d:Hello>
+      <a:EndpointReference>
+        <a:Address>
+          urn:uuid:98190dc2-0890-4ef8-ac9a-5940995e6119
+        </a:Address>
+      </a:EndpointReference>
+      <d:MetadataVersion>75965</d:MetadataVersion>
+    </d:Hello>
+  </s:Body>
+</s:Envelope>"#;
+
+    /// OASIS WS-Discovery 1.1 spec, 2009/01 namespace, ad hoc Bye.
+    const BYE_OASIS_2009: &str = r#"<s:Envelope
+    xmlns:a="http://www.w3.org/2005/08/addressing"
+    xmlns:d="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"
+    xmlns:s="http://www.w3.org/2003/05/soap-envelope" >
+  <s:Header>
+    <a:Action>
+      http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Bye
+    </a:Action>
+    <a:MessageID>
+      urn:uuid:337497fa-3b10-43a5-95c2-186461d72c9e
+    </a:MessageID>
+    <a:To>urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01</a:To>
+    <d:AppSequence InstanceId="1077004800" MessageNumber="4" />
+  </s:Header>
+  <s:Body>
+    <d:Bye>
+      <a:EndpointReference>
+        <a:Address>
+          urn:uuid:98190dc2-0890-4ef8-ac9a-5940995e6119
+        </a:Address>
+      </a:EndpointReference>
+    </d:Bye>
+  </s:Body>
+</s:Envelope>"#;
+
+    /// Real ONVIF discovery Probe (docs.edgexfoundry.org device-onvif-camera), 2005/04 namespace,
+    /// `soap-env:` envelope, `mustUnderstand="1"` on the Action.
+    const PROBE_ONVIF_EDGEX: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<soap-env:Envelope
+        xmlns:soap-env="http://www.w3.org/2003/05/soap-envelope"
+        xmlns:soap-enc="http://www.w3.org/2003/05/soap-encoding"
+        xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+    <soap-env:Header>
+        <a:Action mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>
+        <a:MessageID>uuid:a86f9421-b764-4256-8762-5ed0d8602a9c</a:MessageID>
+        <a:ReplyTo>
+            <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+        </a:ReplyTo>
+        <a:To mustUnderstand="1">urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>
+    </soap-env:Header>
+    <soap-env:Body>
+        <Probe
+                xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery"/>
+    </soap-env:Body>
+</soap-env:Envelope>"#;
+
+    /// Resolve from Microsoft's `WsdApi` docs (learn.microsoft.com win32). Their docs render the
+    /// namespaces as `https://`; the classifier only reads the final `/Resolve` segment.
+    const RESOLVE_MS_WSDAPI: &str = r#"<?xml version="1.0" encoding="utf-8" ?>
+<soap:Envelope
+    xmlns:soap="https://www.w3.org/2003/05/soap-envelope"
+    xmlns:wsa="https://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:wsd="https://schemas.xmlsoap.org/ws/2005/04/discovery">
+<soap:Header>
+    <wsa:To>
+urn:schemas-xmlsoap-org:ws:2005:04:discovery
+</wsa:To>
+    <wsa:Action>
+        https://schemas.xmlsoap.org/ws/2005/04/discovery/Resolve
+    </wsa:Action>
+    <wsa:MessageID>
+        urn:uuid:38d1c3d9-8d73-4424-8861-6b7ee2af24d3
+    </wsa:MessageID>
+</soap:Header>
+<soap:Body>
+    <wsd:Resolve>
+        <wsa:EndpointReference>
+            <wsa:Address>
+                urn:uuid:37f86d35-e6ac-4241-964f-1d9ae46fb366
+            </wsa:Address>
+        </wsa:EndpointReference>
+    </wsd:Resolve>
+</soap:Body>
+</soap:Envelope>"#;
+
+    /// Real Uniview IP-camera `ProbeMatches` capture (brownfinesecurity.com) — genuine IP/MAC/ONVIF
+    /// scopes, `SOAP-ENV:` prefix, `SOAP-ENV:mustUnderstand="true"`. The final segment is
+    /// `ProbeMatches`, which must NOT collapse to a `Probe` search.
+    const PROBEMATCHES_ONVIF_UNIVIEW: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope
+    xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xop="http://www.w3.org/2004/08/xop/include"
+    xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:tns="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:dn="http://www.onvif.org/ver10/network/wsdl"
+    xmlns:tds="http://www.onvif.org/ver10/device/wsdl"
+    xmlns:wsa5="http://www.w3.org/2005/08/addressing">
+    <SOAP-ENV:Header>
+        <tns:AppSequence MessageNumber="10002" InstanceId="1"></tns:AppSequence>
+        <wsa:MessageID>10002</wsa:MessageID>
+        <wsa:RelatesTo>urn:uuid:a6ab1bb7-7d49-418d-ba2a-a7f930a7dce7</wsa:RelatesTo>
+        <wsa:To SOAP-ENV:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsa:Action SOAP-ENV:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches</wsa:Action>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <tns:ProbeMatches>
+            <tns:ProbeMatch>
+                <wsa:EndpointReference>
+                    <wsa:Address>urn:uuid:00010010-0001-1020-8000-e4f14c776608</wsa:Address>
+                </wsa:EndpointReference>
+                <tns:Types>dn:NetworkVideoTransmitter tds:Device</tns:Types>
+                <tns:Scopes>onvif://www.onvif.org/Profile/G onvif://www.onvif.org/Profile/Streaming onvif://www.onvif.org/Profile/T onvif://www.onvif.org/type/video_encoder onvif://www.onvif.org/type/audio_encoder onvif://www.onvif.org/max_resolution/2688*1520 onvif://www.onvif.org/register_status/offline  onvif://www.onvif.org/register_server/0.0.0.0:5060  onvif://www.onvif.org/regist_id/34020000001320000001  onvif://www.onvif.org/type/IPC onvif://www.onvif.org/manufacturer/NONE onvif://www.onvif.org/VideoSourceNumber/1 onvif://www.onvif.org/version/GIPC-B6215.1.68.NB.240617 onvif://www.onvif.org/serial/210235UEDW3247000013 onvif://www.onvif.org/macaddr/e4f14c776608  onvif://www.onvif.org/hardware/SC-3243-IWPS-F28 onvif://www.onvif.org/location/  onvif://www.onvif.org/name/SC-3243-IWPS-F28 </tns:Scopes>
+                <tns:XAddrs>http://192.168.100.26:80/onvif/device_service</tns:XAddrs>
+                <tns:MetadataVersion>1</tns:MetadataVersion>
+            </tns:ProbeMatch>
+        </tns:ProbeMatches>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"#;
+
+    /// `ResolveMatches` from Microsoft's `WsdApi` docs — the `ResolveMatches` segment must not collapse
+    /// to a `Resolve` search.
+    const RESOLVEMATCHES_MS_WSDAPI: &str = r#"<?xml version="1.0" encoding="utf-8" ?>
+<soap:Envelope
+    xmlns:soap="https://www.w3.org/2003/05/soap-envelope"
+    xmlns:wsa="https://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:wsd="https://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:wsdp="https://schemas.xmlsoap.org/ws/2006/02/devprof">
+<soap:Header>
+    <wsa:To>
+        https://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous
+    </wsa:To>
+    <wsa:Action>
+        https://schemas.xmlsoap.org/ws/2005/04/discovery/ResolveMatches
+    </wsa:Action>
+    <wsa:MessageID>
+        urn:uuid:64ddd01c-b0d6-4afd-aba6-6f1f161ce9d4
+    </wsa:MessageID>
+    <wsa:RelatesTo>
+        urn:uuid:38d1c3d9-8d73-4424-8861-6b7ee2af24d3
+    </wsa:RelatesTo>
+    <wsd:AppSequence InstanceId="1"
+        SequenceId="urn:uuid:369a7d7b-5f87-48a4-aa9a-189edf2a8772"
+        MessageNumber="6">
+    </wsd:AppSequence>
+</soap:Header>
+<soap:Body>
+    <wsd:ResolveMatches>
+        <wsd:ResolveMatch>
+            <wsa:EndpointReference>
+                <wsa:Address>
+                    urn:uuid:37f86d35-e6ac-4241-964f-1d9ae46fb366
+                </wsa:Address>
+            </wsa:EndpointReference>
+            <wsd:Types>wsdp:Device</wsd:Types>
+            <wsd:XAddrs>
+                https://192.168.0.2:5357/37f86d35-e6ac-4241-964f-1d9ae46fb366
+            </wsd:XAddrs>
+            <wsd:MetadataVersion>2</wsd:MetadataVersion>
+        </wsd:ResolveMatch>
+    </wsd:ResolveMatches>
+</soap:Body>
+</soap:Envelope>"#;
+
+    #[test]
+    fn classifies_real_on_the_wire_messages() {
+        let cases: &[(&str, Option<WsdKind>)] = &[
+            (HELLO_OASIS_2009, Some(WsdKind::Announcement)),
+            (BYE_OASIS_2009, Some(WsdKind::Announcement)),
+            (PROBE_ONVIF_EDGEX, Some(WsdKind::Search)),
+            (RESOLVE_MS_WSDAPI, Some(WsdKind::Search)),
+            (PROBEMATCHES_ONVIF_UNIVIEW, None),
+            (RESOLVEMATCHES_MS_WSDAPI, None),
+        ];
+        for (msg, expected) in cases {
+            assert_eq!(classify(msg.as_bytes()), *expected, "misclassified: {msg}");
+        }
+    }
+}

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -6,6 +6,7 @@ pub(crate) mod dial;
 pub(crate) mod mdns;
 pub(crate) mod ssdp;
 pub(crate) mod wol;
+pub(crate) mod wsd;
 
 mod search;
 mod simple;

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -7,8 +7,10 @@ pub(crate) mod mdns;
 pub(crate) mod ssdp;
 pub(crate) mod wol;
 
+mod search;
 mod simple;
 
+pub(crate) use search::{NoRewrite, ReplyRewrite, SearchReflector};
 pub(crate) use simple::{SimpleReflector, Verdict};
 
 use std::fmt;

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -1,0 +1,553 @@
+//! The shared search direction for the unicast-reply discovery protocols (SSDP, and next WSD).
+//!
+//! A search (SSDP `M-SEARCH`, WSD `Probe` / `Resolve`) is reflected source → target, and each
+//! searcher's *unicast* reply (SSDP `200 OK`, WSD `ProbeMatches` / `ResolveMatches`) is routed back
+//! through a per-searcher session: a reserved ephemeral port on the target with a dedicated response
+//! capture, so a reply reaches only the searcher that asked. [`SearchReflector`] owns the sessions and
+//! reflects searches; a per-session [`ResponseReflector`] routes each reply back.
+//!
+//! Protocol specifics enter as parameters: the [`Verdict`] classifier (is this payload a search?), the
+//! session-window policy, the re-emit TTL, and a [`ReplyRewrite`] factory — SSDP injects its DIAL
+//! `LOCATION` rewrite, WSD uses the [`NoRewrite`] no-op.
+
+use std::net::{IpAddr, SocketAddr};
+use std::time::{Duration, Instant};
+
+use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler, RegistrationKey};
+use crate::interface::{InterfaceAddresses, Ipv6Scope};
+use crate::net::mac::{MacAddr, MacSet};
+use crate::net::packet::Packet;
+use crate::net::port_reservation::PortReservation;
+use crate::reactor::Reactor;
+
+use super::{Verdict, egress_sources};
+
+/// In-flight session cap, so a burst of searchers can't exhaust ephemeral ports or registrations. At
+/// the cap a new search is dropped (no live session is evicted early).
+const MAX_SESSIONS: usize = 64;
+
+/// Transforms a reply datagram before it is routed back to the searcher. The returned slice is either
+/// `payload` verbatim or a rewrite held in the implementor's own reused scratch — a lending signature
+/// the `Fn` traits can't express, which is why this is a trait and not a closure.
+pub(crate) trait ReplyRewrite {
+    fn rewrite<'a>(
+        &'a mut self,
+        payload: &'a [u8],
+        egress: CaptureKey,
+        dispatcher: &mut PacketDispatcher,
+        reactor: &mut Reactor,
+    ) -> &'a [u8];
+}
+
+/// The identity transform: forward the reply verbatim. A ZST for protocols (WSD) whose replies are
+/// relayed unchanged.
+pub(crate) struct NoRewrite;
+
+impl ReplyRewrite for NoRewrite {
+    fn rewrite<'a>(
+        &'a mut self,
+        payload: &'a [u8],
+        _egress: CaptureKey,
+        _dispatcher: &mut PacketDispatcher,
+        _reactor: &mut Reactor,
+    ) -> &'a [u8] {
+        payload
+    }
+}
+
+/// One in-flight search. The searcher (`ip:port`) is the dedup key; `expiry` is when the session
+/// lapses; `reservation` holds the ephemeral target port the replies arrive on for the session's life
+/// (dropping it frees the port); `response_key` is the per-session response capture. A
+/// `RegistrationKey` is not a RAII guard, so eviction and rollback `unregister` it by hand.
+struct Session {
+    searcher: SocketAddr,
+    expiry: Instant,
+    reservation: PortReservation,
+    response_key: RegistrationKey,
+}
+
+/// One search session's reply path: a standalone leaf that re-emits each unicast reply — captured at
+/// the session's reserved port on the target — onto `egress` (the source), back to the single
+/// `searcher` that searched. It carries everything a reply needs, so no session lookup is required: the
+/// reply goes to the searcher's captured frame MAC (no ARP/ND) and is sourced from the responding
+/// device's own reply port. [`SearchReflector`] creates one per session and drops it on expiry.
+struct ResponseReflector {
+    searcher: SocketAddr,
+    searcher_mac: MacAddr,
+    egress: CaptureKey,
+    /// Protocol label for logs, e.g. `"SSDP"`.
+    name: &'static str,
+    ttl: u8,
+    reply: Box<dyn ReplyRewrite>,
+}
+
+impl PacketHandler for ResponseReflector {
+    fn on_packet(
+        &mut self,
+        packet: &Packet,
+        dispatcher: &mut PacketDispatcher,
+        reactor: &mut Reactor,
+    ) {
+        // The dispatcher's filter already pinned this capture to the reserved port, so every packet
+        // here is a unicast reply for this searcher — nothing to classify. A family the source can't
+        // currently send is a quiet drop (transient address loss).
+        if !egress_sources(dispatcher, self.egress, self.searcher) {
+            log::debug!(
+                "{}: egress has no source for searcher {} yet; dropping response from {}",
+                self.name,
+                self.searcher,
+                packet.source
+            );
+            return;
+        }
+        let payload = self
+            .reply
+            .rewrite(packet.payload, self.egress, dispatcher, reactor);
+        match dispatcher.send_udp(
+            self.egress,
+            self.searcher,
+            self.searcher_mac,
+            packet.source.port(),
+            self.ttl,
+            payload,
+        ) {
+            Ok(()) => log::debug!(
+                "reflected {} response from {} to searcher {}",
+                self.name,
+                packet.source,
+                self.searcher
+            ),
+            Err(e) => log::warn!(
+                "{}: cannot reflect response to searcher {}: {e}",
+                self.name,
+                self.searcher
+            ),
+        }
+    }
+}
+
+/// Reflects searches source → target and routes each unicast reply back to its searcher. Registered
+/// per group on the source and owns the sessions for searches to that group. On a search it dedups
+/// against live sessions (a retransmit refreshes the window and re-reflects from the same reserved
+/// port), else opens a session — reserve an ephemeral port on the target, register a
+/// [`ResponseReflector`] for its replies — and reflects the search from that port. The deadline timer
+/// sweeps expired sessions.
+///
+/// Protocol-specific behaviour is injected: `classify` gates the ingress ([`Verdict::Reflect`] = a
+/// search to handle, [`Verdict::Skip`] = the other direction, [`Verdict::Junk`] = log and drop);
+/// `window` is the per-search session lifetime; `make_reply` mints the per-session reply transform.
+pub(crate) struct SearchReflector {
+    /// The source capture: this reflector's ingress, and the egress its responses leave reply on.
+    source: CaptureKey,
+    /// The target capture: where the search is re-emitted and the replies are captured.
+    target: CaptureKey,
+    /// The target interface's index, for the IPv6 link-local reserved-port bind.
+    target_ifindex: u32,
+    /// The configured device allow-set, scoping the response capture as the announcement direction is.
+    device_macs: Option<MacSet>,
+    /// Protocol label for logs, e.g. `"SSDP"`.
+    name: &'static str,
+    /// The TTL each reflected search and reply is re-emitted at.
+    ttl: u8,
+    /// The ingress gate: is this payload a search for this direction?
+    classify: fn(&[u8]) -> Verdict,
+    /// A search's session lifetime (e.g. SSDP's MX window + grace; a fixed value for WSD).
+    window: fn(&[u8]) -> Duration,
+    /// Mints a fresh reply transform per session (its own scratch, for a rewriting protocol).
+    make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>>,
+    sessions: Vec<Session>,
+}
+
+impl SearchReflector {
+    #[allow(clippy::too_many_arguments)] // each is a distinct protocol parameter; grouping them buys nothing
+    pub(crate) fn new(
+        source: CaptureKey,
+        target: CaptureKey,
+        target_ifindex: u32,
+        device_macs: Option<MacSet>,
+        name: &'static str,
+        ttl: u8,
+        classify: fn(&[u8]) -> Verdict,
+        window: fn(&[u8]) -> Duration,
+        make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>>,
+    ) -> Self {
+        Self {
+            source,
+            target,
+            target_ifindex,
+            device_macs,
+            name,
+            ttl,
+            classify,
+            window,
+            make_reply,
+            sessions: Vec::new(),
+        }
+    }
+
+    /// Open a session for a new searcher: reserve an ephemeral port on the target's own address of the
+    /// search's family and register the reply capture there — before the caller reflects, so a fast
+    /// responder can't beat the capture. `None` (logged) if the cap is hit, the frame carries no
+    /// source MAC to reply to, the target has no address of that family, or the reservation fails.
+    fn make_session(
+        &self,
+        packet: &Packet,
+        dispatcher: &mut PacketDispatcher,
+        expiry: Instant,
+    ) -> Option<Session> {
+        if self.sessions.len() >= MAX_SESSIONS {
+            log::warn!(
+                "{}: dropping search from {}: {MAX_SESSIONS} sessions in flight (cap)",
+                self.name,
+                packet.source
+            );
+            return None;
+        }
+        let Some(searcher_mac) = packet.src_mac else {
+            log::warn!(
+                "{}: cannot reflect search from {}: frame has no source MAC to reply to",
+                self.name,
+                packet.source
+            );
+            return None;
+        };
+        // The replies come to the address the reflected search is sourced from, at the reserved port —
+        // so this must be the same scope-matched pick `build_udp` makes for `packet.dest`, or the
+        // device replies to a source the response capture below isn't watching.
+        let our_addr = match packet.dest.ip() {
+            IpAddr::V4(_) => dispatcher
+                .egress_addrs(self.target)
+                .and_then(InterfaceAddresses::v4)
+                .map(IpAddr::V4),
+            IpAddr::V6(dst6) => dispatcher
+                .egress_addrs(self.target)
+                .and_then(|a| a.v6(Ipv6Scope::of(dst6)))
+                .map(IpAddr::V6),
+        };
+        let Some(our_addr) = our_addr else {
+            log::warn!(
+                "{}: cannot reflect search from {}: target has no source address for {}",
+                self.name,
+                packet.source,
+                packet.dest.ip()
+            );
+            return None;
+        };
+        let reservation = match PortReservation::create(our_addr, self.target_ifindex) {
+            Ok(reservation) => reservation,
+            Err(e) => {
+                log::warn!(
+                    "{}: port reservation for searcher {} failed: {e}",
+                    self.name,
+                    packet.source
+                );
+                return None;
+            }
+        };
+        // Register before the reflect so a fast responder's reply is captured, not ICMP-rejected.
+        let response_key = dispatcher.register(
+            self.target,
+            Filter {
+                dst_ip: Some(our_addr.into()),
+                dst_port: Some(reservation.port().into()),
+                src_mac: self.device_macs.clone(),
+                ..Filter::default()
+            },
+            Box::new(ResponseReflector {
+                searcher: packet.source,
+                searcher_mac,
+                egress: self.source,
+                name: self.name,
+                ttl: self.ttl,
+                reply: (self.make_reply)(),
+            }),
+        );
+        Some(Session {
+            searcher: packet.source,
+            expiry,
+            reservation,
+            response_key,
+        })
+    }
+}
+
+impl PacketHandler for SearchReflector {
+    fn on_packet(
+        &mut self,
+        packet: &Packet,
+        dispatcher: &mut PacketDispatcher,
+        _reactor: &mut Reactor,
+    ) {
+        match (self.classify)(packet.payload) {
+            Verdict::Reflect => {}
+            // A message for the other direction (an announcement) flows through that reflector.
+            Verdict::Skip => return,
+            Verdict::Junk => {
+                log::debug!(
+                    "{}: dropping unrecognized payload ({} B) on the search path from {}",
+                    self.name,
+                    packet.payload.len(),
+                    packet.source
+                );
+                return;
+            }
+        }
+        let expiry = Instant::now() + (self.window)(packet.payload);
+
+        // A retransmit from a known searcher reuses its session: refresh the window and re-reflect from
+        // the same reserved port. A new searcher opens a fresh session.
+        if let Some(session) = self
+            .sessions
+            .iter_mut()
+            .find(|s| s.searcher == packet.source)
+        {
+            let port = session.reservation.port();
+            match dispatcher.send_udp_group(
+                self.target,
+                packet.dest,
+                port,
+                self.ttl,
+                packet.payload,
+            ) {
+                Ok(()) => {
+                    session.expiry = expiry;
+                    log::debug!(
+                        "re-reflected {} search from {} to {} on reserved port {port}",
+                        self.name,
+                        packet.source,
+                        packet.dest
+                    );
+                }
+                Err(e) => log::warn!(
+                    "{}: cannot reflect search from {} to {}: {e}",
+                    self.name,
+                    packet.source,
+                    packet.dest
+                ),
+            }
+            return;
+        }
+
+        let Some(session) = self.make_session(packet, dispatcher, expiry) else {
+            return; // make_session logged the cause
+        };
+        let port = session.reservation.port();
+        match dispatcher.send_udp_group(self.target, packet.dest, port, self.ttl, packet.payload) {
+            Ok(()) => {
+                self.sessions.push(session);
+                log::debug!(
+                    "reflected {} search from {} to {} on reserved port {port}; opened a session, {} active",
+                    self.name,
+                    packet.source,
+                    packet.dest,
+                    self.sessions.len()
+                );
+            }
+            Err(e) => {
+                // Roll back the response capture just registered; the reservation drops with `session`.
+                log::warn!(
+                    "{}: cannot reflect search from {} to {}: {e}",
+                    self.name,
+                    packet.source,
+                    packet.dest
+                );
+                dispatcher.unregister(session.response_key);
+            }
+        }
+    }
+
+    fn next_deadline(&self) -> Option<Instant> {
+        self.sessions.iter().map(|s| s.expiry).min()
+    }
+
+    fn on_deadline(
+        &mut self,
+        now: Instant,
+        dispatcher: &mut PacketDispatcher,
+        _reactor: &mut Reactor,
+    ) {
+        self.sessions.retain(|session| {
+            if session.expiry <= now {
+                dispatcher.unregister(session.response_key);
+                log::debug!(
+                    "evicted {} session for searcher {} on reserved port {}",
+                    self.name,
+                    session.searcher,
+                    session.reservation.port()
+                );
+                false
+            } else {
+                true
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    const TEST_TTL: u8 = 2;
+
+    /// A trivial ingress gate: every payload is a search. The session bookkeeping under test is
+    /// independent of how a protocol classifies.
+    fn always_reflect(_: &[u8]) -> Verdict {
+        Verdict::Reflect
+    }
+
+    /// A fixed session window, standing in for a protocol's window policy.
+    fn fixed_window(_: &[u8]) -> Duration {
+        Duration::from_secs(2)
+    }
+
+    fn test_reflector() -> SearchReflector {
+        SearchReflector::new(
+            CaptureKey::from_u64(1),
+            CaptureKey::from_u64(0),
+            0,
+            None,
+            "TEST",
+            TEST_TTL,
+            always_reflect,
+            fixed_window,
+            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+        )
+    }
+
+    /// Push a session for `searcher` onto `reflector`: a real loopback port reservation plus a
+    /// registered response capture, so eviction has a registration to tear down. (`PortReservation`
+    /// binds a socket directly, so no capture / `CAP_NET_RAW` is needed.)
+    fn push_session(
+        reflector: &mut SearchReflector,
+        dispatcher: &mut PacketDispatcher,
+        searcher: &str,
+        expiry: Instant,
+    ) {
+        let searcher: SocketAddr = searcher.parse().unwrap();
+        let (target, source) = (reflector.target, reflector.source);
+        let reservation = PortReservation::create(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)
+            .expect("reserve a loopback port");
+        let response_key = dispatcher.register(
+            target,
+            Filter::default(),
+            Box::new(ResponseReflector {
+                searcher,
+                searcher_mac: MacAddr::from([0; 6]),
+                egress: source,
+                name: "TEST",
+                ttl: TEST_TTL,
+                reply: Box::new(NoRewrite),
+            }),
+        );
+        reflector.sessions.push(Session {
+            searcher,
+            expiry,
+            reservation,
+            response_key,
+        });
+    }
+
+    #[test]
+    fn next_deadline_is_the_soonest_session_expiry() {
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reflector = test_reflector();
+        assert_eq!(
+            reflector.next_deadline(),
+            None,
+            "no sessions means no timer"
+        );
+        let base = Instant::now();
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.1:5",
+            base + Duration::from_secs(5),
+        );
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.2:5",
+            base + Duration::from_secs(2),
+        );
+        assert_eq!(
+            reflector.next_deadline(),
+            Some(base + Duration::from_secs(2))
+        );
+    }
+
+    #[test]
+    fn on_deadline_evicts_expired_sessions_and_unregisters_their_captures() {
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reactor = Reactor::new().unwrap();
+        let mut reflector = test_reflector();
+        let base = Instant::now();
+        push_session(&mut reflector, &mut dispatcher, "10.0.0.1:5", base); // already due
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.2:5",
+            base + Duration::from_secs(10),
+        ); // live
+        assert_eq!(dispatcher.registration_count(), 2);
+
+        reflector.on_deadline(base + Duration::from_secs(1), &mut dispatcher, &mut reactor);
+
+        assert_eq!(
+            reflector.sessions.len(),
+            1,
+            "the expired session is dropped"
+        );
+        assert_eq!(
+            reflector.sessions[0].searcher,
+            "10.0.0.2:5".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(
+            dispatcher.registration_count(),
+            1,
+            "its response capture is unregistered with it"
+        );
+        assert_eq!(
+            reflector.next_deadline(),
+            Some(base + Duration::from_secs(10))
+        );
+    }
+
+    #[test]
+    fn a_retransmit_reuses_its_session_and_refreshes_the_window() {
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reactor = Reactor::new().unwrap();
+        // A synthetic target: send_udp_group on an unknown egress drops the datagram and returns Ok,
+        // so the re-reflect "succeeds" with no real capture — this exercises only the bookkeeping.
+        let mut reflector = test_reflector();
+        let base = Instant::now();
+        push_session(&mut reflector, &mut dispatcher, "10.0.0.7:50000", base);
+        assert_eq!(dispatcher.registration_count(), 1);
+
+        let packet = Packet {
+            source: "10.0.0.7:50000".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
+            payload: b"a search",
+        };
+        reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
+
+        assert_eq!(
+            reflector.sessions.len(),
+            1,
+            "a retransmit reuses its session, not a new one"
+        );
+        assert_eq!(
+            dispatcher.registration_count(),
+            1,
+            "no second response capture is registered"
+        );
+        assert!(
+            reflector.sessions[0].expiry > base,
+            "the session's window is refreshed"
+        );
+    }
+}

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -1,10 +1,12 @@
 //! The SSDP reflector: reflects Simple Service Discovery Protocol (`UPnP`) between the source and
 //! target interfaces so service discovery crosses the link. Advertisements (`NOTIFY`) reflect
 //! target → source as a plain multicast re-emit (the [`advertisement`] module); searches (`M-SEARCH`)
-//! reflect source → target and each searcher's unicast `200 OK` replies are routed back through a
-//! per-searcher session (the [`search`] module). Re-emits go to the same group at TTL 2, sourced from
-//! the egress interface. With `dial`, a target→source datagram's DIAL `LOCATION` is rewritten to a
-//! source-side proxy ([`dial_rewrite`]).
+//! reflect source → target and each searcher's unicast `200 OK` replies route back through a
+//! per-searcher session (the [`search`] leg over the shared `reflector::search`). Re-emits go to the
+//! same group at TTL 2,
+//! sourced from the egress interface. With `dial`, a target→source datagram's DIAL `LOCATION` is
+//! rewritten to a source-side proxy: [`DialRewrite`] is the SSDP [`ReplyRewrite`], used by both the
+//! advertisement direction and each search session's response.
 
 mod advertisement;
 mod search;
@@ -21,9 +23,8 @@ use crate::net::uninit_buf::UninitBuf;
 use crate::reactor::Reactor;
 
 use self::advertisement::SsdpAdvertisementReflector;
-use self::search::SsdpSearchReflector;
 use super::dial::{ProxyPlacement, REWRITE_BUF_LEN, rewrite_location};
-use super::{BuildError, InterfaceMap, require_bidirectional_families};
+use super::{BuildError, InterfaceMap, ReplyRewrite, require_bidirectional_families};
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
 /// target capture the device sits behind (for its address), that interface's egress-pin ifindex, and a
@@ -32,7 +33,7 @@ use super::{BuildError, InterfaceMap, require_bidirectional_families};
 struct DialRewrite {
     target: CaptureKey,
     target_ifindex: u32,
-    /// Reused sink for the rewritten datagram; see [`dial_rewrite`].
+    /// Reused sink for the rewritten datagram; see the [`ReplyRewrite`] impl.
     scratch: UninitBuf,
 }
 
@@ -48,55 +49,54 @@ impl DialRewrite {
     }
 }
 
-/// Rewrite a target→source SSDP datagram's DIAL `LOCATION` to a source-side description proxy, into
-/// `dial`'s scratch. Returns the rewritten slice when `dial` is set and the rewrite succeeds, else
-/// `payload` (forward verbatim). `egress` is the source capture the datagram reflects onto. Shared by
-/// the advertisement and search-response directions, which both rewrite a device's `LOCATION`.
-fn dial_rewrite<'a>(
-    payload: &'a [u8],
-    egress: CaptureKey,
-    dial: Option<&'a mut DialRewrite>,
-    dispatcher: &mut PacketDispatcher,
-    reactor: &mut Reactor,
-) -> &'a [u8] {
-    let Some(dial) = dial else {
-        return payload;
-    };
-    let (Some(source), Some(target)) = (
-        dispatcher
-            .egress_addrs(egress)
-            .and_then(InterfaceAddresses::v4),
-        dispatcher
-            .egress_addrs(dial.target)
-            .and_then(InterfaceAddresses::v4),
-    ) else {
-        return payload; // a family the proxy can't bridge yet — forward unchanged
-    };
-    let placement = ProxyPlacement {
-        source_capture: egress,
-        source,
-        target_capture: dial.target,
-        target,
-        target_ifindex: dial.target_ifindex,
-    };
-    dial.scratch.clear();
-    if rewrite_location(
-        dispatcher.dial_context(),
-        reactor,
-        payload,
-        placement,
-        &mut dial.scratch,
-    ) {
-        dial.scratch.filled()
-    } else {
-        payload
+impl ReplyRewrite for DialRewrite {
+    /// Rewrite a target→source SSDP datagram's DIAL `LOCATION` to a source-side description proxy, into
+    /// the reused scratch. Returns the rewritten slice on success, else `payload` (forward verbatim).
+    /// `egress` is the source capture the datagram reflects onto. Used by both the advertisement
+    /// direction and each search session's response.
+    fn rewrite<'a>(
+        &'a mut self,
+        payload: &'a [u8],
+        egress: CaptureKey,
+        dispatcher: &mut PacketDispatcher,
+        reactor: &mut Reactor,
+    ) -> &'a [u8] {
+        let (Some(source), Some(target)) = (
+            dispatcher
+                .egress_addrs(egress)
+                .and_then(InterfaceAddresses::v4),
+            dispatcher
+                .egress_addrs(self.target)
+                .and_then(InterfaceAddresses::v4),
+        ) else {
+            return payload; // a family the proxy can't bridge yet — forward unchanged
+        };
+        let placement = ProxyPlacement {
+            source_capture: egress,
+            source,
+            target_capture: self.target,
+            target,
+            target_ifindex: self.target_ifindex,
+        };
+        self.scratch.clear();
+        if rewrite_location(
+            dispatcher.dial_context(),
+            reactor,
+            payload,
+            placement,
+            &mut self.scratch,
+        ) {
+            self.scratch.filled()
+        } else {
+            payload
+        }
     }
 }
 
 /// Build the SSDP reflector for `reflector` and register both directions on `dispatcher` — a no-op
 /// when SSDP isn't enabled. For each address family in use it joins every group on BOTH interfaces and
 /// registers two handlers per group: advertisements target → source ([`SsdpAdvertisementReflector`]),
-/// and searches source → target with their unicast 200-OK replies ([`SsdpSearchReflector`]). A
+/// and searches source → target with their unicast 200-OK replies (the [`search`] leg). A
 /// required family must be sendable on BOTH interfaces, since the reflector re-emits on both.
 ///
 /// # Errors
@@ -156,7 +156,7 @@ pub(crate) fn build(
         )),
     );
     // source -> target: searches (unfiltered — any source client may search); each searcher's
-    // unicast 200-OK replies route back through a per-searcher session.
+    // unicast 200-OK replies route back through a per-searcher session (the search leg's glue).
     dispatcher.register(
         source,
         Filter {
@@ -164,7 +164,7 @@ pub(crate) fn build(
             dst_port: Some(SSDP_PORT.into()),
             ..Filter::default()
         },
-        Box::new(SsdpSearchReflector::new(
+        Box::new(search::reflector(
             source,
             target,
             target_ifindex,

--- a/src/reflector/ssdp/advertisement.rs
+++ b/src/reflector/ssdp/advertisement.rs
@@ -4,13 +4,13 @@ use crate::dispatch::{CaptureKey, PacketDispatcher, PacketHandler};
 use crate::net::packet::Packet;
 use crate::net::ssdp::{SSDP_PORT, SSDP_TTL, SsdpKind, classify};
 use crate::reactor::Reactor;
-use crate::reflector::egress_sources;
+use crate::reflector::{ReplyRewrite, egress_sources};
 
-use super::{DialRewrite, dial_rewrite};
+use super::DialRewrite;
 
 /// Reflects SSDP advertisements (`NOTIFY`) target → source, onto `egress`, to the message's own
 /// destination — the dispatcher's filter pins that to the group. Searches (`M-SEARCH`) flow the other
-/// way through `SsdpSearchReflector`, so this handler only ever reflects advertisements.
+/// way through the shared `SearchReflector`, so this handler only ever reflects advertisements.
 pub(super) struct SsdpAdvertisementReflector {
     egress: CaptureKey,
     /// DIAL `LOCATION` rewriting; `None` leaves advertisements verbatim.
@@ -43,13 +43,10 @@ impl PacketHandler for SsdpAdvertisementReflector {
                     );
                     return;
                 }
-                let payload = dial_rewrite(
-                    packet.payload,
-                    self.egress,
-                    self.dial.as_mut(),
-                    dispatcher,
-                    reactor,
-                );
+                let payload = match self.dial.as_mut() {
+                    Some(dial) => dial.rewrite(packet.payload, self.egress, dispatcher, reactor),
+                    None => packet.payload,
+                };
                 match dispatcher.send_udp_group(
                     self.egress,
                     packet.dest,
@@ -69,7 +66,7 @@ impl PacketHandler for SsdpAdvertisementReflector {
                     ),
                 }
             }
-            // Searches flow source → target through SsdpSearchReflector, not this direction.
+            // Searches flow source → target through the search reflector, not this direction.
             Some(SsdpKind::Search) => {}
             // Non-SSDP payload on the group: anomalous but harmless, drop quietly.
             None => log::debug!(

--- a/src/reflector/ssdp/search.rs
+++ b/src/reflector/ssdp/search.rs
@@ -1,488 +1,70 @@
-//! The SSDP search direction: reflect `M-SEARCH` source → target and route each searcher's unicast
-//! `200 OK` replies back through a per-searcher session.
+//! The SSDP search leg: the protocol glue that drives the shared [`SearchReflector`] for `M-SEARCH`.
+//!
+//! The session machinery is shared (`reflector::search`); this module supplies SSDP's specifics — the
+//! directional classifier, the MX-derived session window, and (with `dial`) the per-session DIAL
+//! `LOCATION` rewrite via the parent's [`DialRewrite`].
 
-use std::net::{IpAddr, SocketAddr};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler, RegistrationKey};
-use crate::interface::{InterfaceAddresses, Ipv6Scope};
-use crate::net::mac::{MacAddr, MacSet};
-use crate::net::packet::Packet;
-use crate::net::port_reservation::PortReservation;
+use crate::dispatch::CaptureKey;
+use crate::net::mac::MacSet;
 use crate::net::ssdp::{MSEARCH_MX_DEFAULT, SSDP_TTL, SsdpKind, classify, parse_msearch_mx};
-use crate::reactor::Reactor;
-use crate::reflector::egress_sources;
+use crate::reflector::{NoRewrite, ReplyRewrite, SearchReflector, Verdict};
 
-use super::{DialRewrite, dial_rewrite};
+use super::DialRewrite;
+
+/// The directional gate: an `M-SEARCH` is a search to reflect, a `NOTIFY` belongs to the advertisement
+/// direction, and anything else on the group is junk.
+fn search_verdict(payload: &[u8]) -> Verdict {
+    match classify(payload) {
+        Some(SsdpKind::Search) => Verdict::Reflect,
+        Some(SsdpKind::Advertisement) => Verdict::Skip,
+        None => Verdict::Junk,
+    }
+}
 
 /// A session outlives the searcher's MX window by this grace, since a device's 200-OK may lag the
 /// search (mirrors the C++).
 const SESSION_GRACE: Duration = Duration::from_secs(2);
-/// In-flight session cap, so a burst of searchers can't exhaust ephemeral ports or registrations.
-/// At the cap a new M-SEARCH is dropped (no live session is evicted early).
-const MAX_SESSIONS: usize = 64;
 
-/// One in-flight M-SEARCH. The searcher (`ip:port`) is the dedup key; `expiry` is when the session
-/// lapses; `reservation` holds the ephemeral target port the 200-OKs arrive on for the session's life
-/// (dropping it frees the port); `response_key` is the per-session response capture. A
-/// `RegistrationKey` is not a RAII guard, so eviction and rollback `unregister` it by hand.
-struct Session {
-    searcher: SocketAddr,
-    expiry: Instant,
-    reservation: PortReservation,
-    response_key: RegistrationKey,
-}
-
-/// One M-SEARCH session's reply path: a standalone leaf that re-emits each unicast `200 OK` — captured
-/// at the session's reserved port on the target — onto `egress` (the source), back to the single
-/// `searcher` that searched. It carries everything a reply needs, so no session lookup is required:
-/// the reply goes to the searcher's captured frame MAC (no ARP/ND) and is sourced from the responding
-/// device's own reply port (preserved from the captured packet). The [`SsdpSearchReflector`] creates
-/// one per session and drops it when the session expires.
-struct SsdpResponseReflector {
-    searcher: SocketAddr,
-    searcher_mac: MacAddr,
-    egress: CaptureKey,
-    /// DIAL `LOCATION` rewriting, inherited from the search reflector that opened this session.
-    dial: Option<DialRewrite>,
-}
-
-impl PacketHandler for SsdpResponseReflector {
-    fn on_packet(
-        &mut self,
-        packet: &Packet,
-        dispatcher: &mut PacketDispatcher,
-        reactor: &mut Reactor,
-    ) {
-        // The dispatcher's filter already pinned this capture to the reserved port, so every packet
-        // here is a unicast reply for this searcher — nothing to classify. A family the source can't
-        // currently send is a quiet drop (transient address loss), as in the advertisement direction.
-        if !egress_sources(dispatcher, self.egress, self.searcher) {
-            log::debug!(
-                "SSDP: egress has no source for searcher {} yet; dropping response from {}",
-                self.searcher,
-                packet.source
-            );
-            return;
-        }
-        let payload = dial_rewrite(
-            packet.payload,
-            self.egress,
-            self.dial.as_mut(),
-            dispatcher,
-            reactor,
+/// An `M-SEARCH`'s session window: its MX response window (clamped by [`parse_msearch_mx`]) plus the
+/// reply grace. A search with no usable MX falls back to the protocol default.
+fn window(payload: &[u8]) -> Duration {
+    let mx = parse_msearch_mx(payload).unwrap_or_else(|| {
+        log::info!(
+            "SSDP: M-SEARCH has no usable MX; using the default {MSEARCH_MX_DEFAULT}s window"
         );
-        match dispatcher.send_udp(
-            self.egress,
-            self.searcher,
-            self.searcher_mac,
-            packet.source.port(),
-            SSDP_TTL,
-            payload,
-        ) {
-            Ok(()) => log::debug!(
-                "reflected SSDP response from {} to searcher {}",
-                packet.source,
-                self.searcher
-            ),
-            Err(e) => log::warn!(
-                "SSDP: cannot reflect response to searcher {}: {e}",
-                self.searcher
-            ),
-        }
-    }
+        MSEARCH_MX_DEFAULT
+    });
+    Duration::from_secs(u64::from(mx)) + SESSION_GRACE
 }
 
-/// Reflects M-SEARCH searches source → target and routes each unicast 200-OK reply back to its
-/// searcher. Registered per group on the source and owns the sessions for searches to that group —
-/// one reflector per group, so the cap and table are per-group (our one-handler-per-registration
-/// split, vs the C++'s single shared table). On a search it dedups against live sessions (a
-/// retransmit refreshes the window and re-reflects from the same reserved port), else opens a session
-/// — reserve an ephemeral port on the target, register an [`SsdpResponseReflector`] for its replies —
-/// and reflects the search from that port. The deadline timer sweeps expired sessions.
-pub(super) struct SsdpSearchReflector {
-    /// The source capture: this reflector's ingress, and the egress its response leaves reply on.
+/// The shared [`SearchReflector`] configured for SSDP: source → target `M-SEARCH` reflection with
+/// per-searcher 200-OK sessions. With `dial`, each session's reply rewrites the device's DIAL
+/// `LOCATION` (a fresh [`DialRewrite`] per session); otherwise replies pass through unchanged.
+pub(super) fn reflector(
     source: CaptureKey,
-    /// The target capture: where the search is re-emitted and the 200-OKs are captured.
     target: CaptureKey,
-    /// The target interface's index, for the IPv6 link-local reserved-port bind.
     target_ifindex: u32,
-    /// The configured device allow-set, scoping the response capture as the advertisement direction is.
     device_macs: Option<MacSet>,
-    /// Whether DIAL `LOCATION` rewriting is on; each session's [`SsdpResponseReflector`] gets its own
-    /// [`DialRewrite`] (with its own scratch) when set.
     dial: bool,
-    sessions: Vec<Session>,
-}
-
-impl SsdpSearchReflector {
-    pub(super) fn new(
-        source: CaptureKey,
-        target: CaptureKey,
-        target_ifindex: u32,
-        device_macs: Option<MacSet>,
-        dial: bool,
-    ) -> Self {
-        Self {
-            source,
-            target,
-            target_ifindex,
-            device_macs,
-            dial,
-            sessions: Vec::new(),
-        }
-    }
-
-    /// Open a session for a new searcher: reserve an ephemeral port on the target's own address of the
-    /// search's family and register the 200-OK capture there — before the caller reflects, so a fast
-    /// responder can't beat the capture. `None` (logged) if the cap is hit, the frame carries no
-    /// source MAC to reply to, the target has no address of that family, or the reservation fails.
-    fn make_session(
-        &self,
-        packet: &Packet,
-        dispatcher: &mut PacketDispatcher,
-        expiry: Instant,
-    ) -> Option<Session> {
-        if self.sessions.len() >= MAX_SESSIONS {
-            log::warn!(
-                "SSDP: dropping M-SEARCH from {}: {MAX_SESSIONS} sessions in flight (cap)",
-                packet.source
-            );
-            return None;
-        }
-        let Some(searcher_mac) = packet.src_mac else {
-            log::warn!(
-                "SSDP: cannot reflect M-SEARCH from {}: frame has no source MAC to reply to",
-                packet.source
-            );
-            return None;
-        };
-        // The 200-OKs come to the address the reflected M-SEARCH is sourced from, at the reserved
-        // port — so this must be the same scope-matched pick `build_udp` makes for `packet.dest`,
-        // or the device replies to a source the response capture below isn't watching.
-        let our_addr = match packet.dest.ip() {
-            IpAddr::V4(_) => dispatcher
-                .egress_addrs(self.target)
-                .and_then(InterfaceAddresses::v4)
-                .map(IpAddr::V4),
-            IpAddr::V6(dst6) => dispatcher
-                .egress_addrs(self.target)
-                .and_then(|a| a.v6(Ipv6Scope::of(dst6)))
-                .map(IpAddr::V6),
-        };
-        let Some(our_addr) = our_addr else {
-            log::warn!(
-                "SSDP: cannot reflect M-SEARCH from {}: target has no source address for {}",
-                packet.source,
-                packet.dest.ip()
-            );
-            return None;
-        };
-        let reservation = match PortReservation::create(our_addr, self.target_ifindex) {
-            Ok(reservation) => reservation,
-            Err(e) => {
-                log::warn!(
-                    "SSDP: port reservation for searcher {} failed: {e}",
-                    packet.source
-                );
-                return None;
-            }
-        };
-        // Register before the reflect so a fast responder's reply is captured, not ICMP-rejected.
-        let response_key = dispatcher.register(
-            self.target,
-            Filter {
-                dst_ip: Some(our_addr.into()),
-                dst_port: Some(reservation.port().into()),
-                src_mac: self.device_macs.clone(),
-                ..Filter::default()
-            },
-            Box::new(SsdpResponseReflector {
-                searcher: packet.source,
-                searcher_mac,
-                egress: self.source,
-                dial: self
-                    .dial
-                    .then(|| DialRewrite::new(self.target, self.target_ifindex)),
-            }),
-        );
-        Some(Session {
-            searcher: packet.source,
-            expiry,
-            reservation,
-            response_key,
+) -> SearchReflector {
+    let make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>> = if dial {
+        Box::new(move || {
+            Box::new(DialRewrite::new(target, target_ifindex)) as Box<dyn ReplyRewrite>
         })
-    }
-}
-
-impl PacketHandler for SsdpSearchReflector {
-    fn on_packet(
-        &mut self,
-        packet: &Packet,
-        dispatcher: &mut PacketDispatcher,
-        _reactor: &mut Reactor,
-    ) {
-        match classify(packet.payload) {
-            Some(SsdpKind::Search) => {}
-            // Advertisements flow the other way (the advertisement reflector); only searches here.
-            Some(SsdpKind::Advertisement) => return,
-            None => {
-                log::debug!(
-                    "SSDP: dropping non-SSDP payload ({} B) on the search path from {}",
-                    packet.payload.len(),
-                    packet.source
-                );
-                return;
-            }
-        }
-        let mx = parse_msearch_mx(packet.payload).unwrap_or_else(|| {
-            log::info!(
-                "SSDP: M-SEARCH from {} has no usable MX; using the default {MSEARCH_MX_DEFAULT}s window",
-                packet.source
-            );
-            MSEARCH_MX_DEFAULT
-        });
-        let expiry = Instant::now() + Duration::from_secs(u64::from(mx)) + SESSION_GRACE;
-
-        // A retransmit from a known searcher reuses its session: refresh the window and re-reflect
-        // from the same reserved port. A new searcher opens a fresh session.
-        if let Some(session) = self
-            .sessions
-            .iter_mut()
-            .find(|s| s.searcher == packet.source)
-        {
-            let port = session.reservation.port();
-            match dispatcher.send_udp_group(
-                self.target,
-                packet.dest,
-                port,
-                SSDP_TTL,
-                packet.payload,
-            ) {
-                Ok(()) => {
-                    session.expiry = expiry;
-                    log::debug!(
-                        "re-reflected M-SEARCH from {} to {} on reserved port {port} (MX {mx}s)",
-                        packet.source,
-                        packet.dest
-                    );
-                }
-                Err(e) => log::warn!(
-                    "SSDP: cannot reflect M-SEARCH from {} to {}: {e}",
-                    packet.source,
-                    packet.dest
-                ),
-            }
-            return;
-        }
-
-        let Some(session) = self.make_session(packet, dispatcher, expiry) else {
-            return; // make_session logged the cause
-        };
-        let port = session.reservation.port();
-        match dispatcher.send_udp_group(self.target, packet.dest, port, SSDP_TTL, packet.payload) {
-            Ok(()) => {
-                self.sessions.push(session);
-                log::debug!(
-                    "reflected M-SEARCH from {} to {} on reserved port {port} (MX {mx}s); opened a session, {} active",
-                    packet.source,
-                    packet.dest,
-                    self.sessions.len()
-                );
-            }
-            Err(e) => {
-                // Roll back the response capture just registered; the reservation drops with `session`.
-                log::warn!(
-                    "SSDP: cannot reflect M-SEARCH from {} to {}: {e}",
-                    packet.source,
-                    packet.dest
-                );
-                dispatcher.unregister(session.response_key);
-            }
-        }
-    }
-
-    fn next_deadline(&self) -> Option<Instant> {
-        self.sessions.iter().map(|s| s.expiry).min()
-    }
-
-    fn on_deadline(
-        &mut self,
-        now: Instant,
-        dispatcher: &mut PacketDispatcher,
-        _reactor: &mut Reactor,
-    ) {
-        self.sessions.retain(|session| {
-            if session.expiry <= now {
-                dispatcher.unregister(session.response_key);
-                log::debug!(
-                    "evicted SSDP session for searcher {} on reserved port {}",
-                    session.searcher,
-                    session.reservation.port()
-                );
-                false
-            } else {
-                true
-            }
-        });
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::net::Ipv4Addr;
-
-    use super::*;
-    use crate::net::ssdp::{SSDP_GROUP_V4, SSDP_PORT};
-
-    /// Push a session for `searcher` onto `reflector`: a real loopback port reservation plus a
-    /// registered response capture, so eviction has a registration to tear down. (`PortReservation`
-    /// binds a socket directly, so no capture / `CAP_NET_RAW` is needed.)
-    fn push_session(
-        reflector: &mut SsdpSearchReflector,
-        dispatcher: &mut PacketDispatcher,
-        searcher: &str,
-        expiry: Instant,
-    ) {
-        let searcher: SocketAddr = searcher.parse().unwrap();
-        let (target, source) = (reflector.target, reflector.source);
-        let reservation = PortReservation::create(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)
-            .expect("reserve a loopback port");
-        let response_key = dispatcher.register(
-            target,
-            Filter::default(),
-            Box::new(SsdpResponseReflector {
-                searcher,
-                searcher_mac: MacAddr::from([0; 6]),
-                egress: source,
-                dial: None,
-            }),
-        );
-        reflector.sessions.push(Session {
-            searcher,
-            expiry,
-            reservation,
-            response_key,
-        });
-    }
-
-    #[test]
-    fn next_deadline_is_the_soonest_session_expiry() {
-        let mut dispatcher = PacketDispatcher::new();
-        let mut reflector = SsdpSearchReflector::new(
-            CaptureKey::from_u64(1),
-            CaptureKey::from_u64(0),
-            0,
-            None,
-            false,
-        );
-        assert_eq!(
-            reflector.next_deadline(),
-            None,
-            "no sessions means no timer"
-        );
-        let base = Instant::now();
-        push_session(
-            &mut reflector,
-            &mut dispatcher,
-            "10.0.0.1:5",
-            base + Duration::from_secs(5),
-        );
-        push_session(
-            &mut reflector,
-            &mut dispatcher,
-            "10.0.0.2:5",
-            base + Duration::from_secs(2),
-        );
-        assert_eq!(
-            reflector.next_deadline(),
-            Some(base + Duration::from_secs(2))
-        );
-    }
-
-    #[test]
-    fn on_deadline_evicts_expired_sessions_and_unregisters_their_captures() {
-        let mut dispatcher = PacketDispatcher::new();
-        let mut reactor = Reactor::new().unwrap();
-        let mut reflector = SsdpSearchReflector::new(
-            CaptureKey::from_u64(1),
-            CaptureKey::from_u64(0),
-            0,
-            None,
-            false,
-        );
-        let base = Instant::now();
-        push_session(&mut reflector, &mut dispatcher, "10.0.0.1:5", base); // already due
-        push_session(
-            &mut reflector,
-            &mut dispatcher,
-            "10.0.0.2:5",
-            base + Duration::from_secs(10),
-        ); // live
-        assert_eq!(dispatcher.registration_count(), 2);
-
-        reflector.on_deadline(base + Duration::from_secs(1), &mut dispatcher, &mut reactor);
-
-        assert_eq!(
-            reflector.sessions.len(),
-            1,
-            "the expired session is dropped"
-        );
-        assert_eq!(
-            reflector.sessions[0].searcher,
-            "10.0.0.2:5".parse::<SocketAddr>().unwrap()
-        );
-        assert_eq!(
-            dispatcher.registration_count(),
-            1,
-            "its response capture is unregistered with it"
-        );
-        assert_eq!(
-            reflector.next_deadline(),
-            Some(base + Duration::from_secs(10))
-        );
-    }
-
-    #[test]
-    fn a_retransmit_reuses_its_session_and_refreshes_the_window() {
-        let mut dispatcher = PacketDispatcher::new();
-        let mut reactor = Reactor::new().unwrap();
-        // A synthetic target: send_udp_group on an unknown egress drops the datagram and returns Ok,
-        // so the re-reflect "succeeds" with no real capture — this exercises only the bookkeeping.
-        let mut reflector = SsdpSearchReflector::new(
-            CaptureKey::from_u64(1),
-            CaptureKey::from_u64(0),
-            0,
-            None,
-            false,
-        );
-        let base = Instant::now();
-        push_session(&mut reflector, &mut dispatcher, "10.0.0.7:50000", base);
-        assert_eq!(dispatcher.registration_count(), 1);
-
-        let packet = Packet {
-            source: "10.0.0.7:50000".parse().unwrap(),
-            dest: SocketAddr::from((SSDP_GROUP_V4, SSDP_PORT)),
-            ttl: SSDP_TTL,
-            dst_mac: None,
-            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
-            payload: b"M-SEARCH * HTTP/1.1\r\nMX: 2\r\n\r\n",
-        };
-        reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
-
-        assert_eq!(
-            reflector.sessions.len(),
-            1,
-            "a retransmit reuses its session, not a new one"
-        );
-        assert_eq!(
-            dispatcher.registration_count(),
-            1,
-            "no second response capture is registered"
-        );
-        assert!(
-            reflector.sessions[0].expiry > base,
-            "the session's window is refreshed"
-        );
-    }
+    } else {
+        Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>)
+    };
+    SearchReflector::new(
+        source,
+        target,
+        target_ifindex,
+        device_macs,
+        "SSDP",
+        SSDP_TTL,
+        search_verdict,
+        window,
+        make_reply,
+    )
 }

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -1,0 +1,198 @@
+//! The WSD (WS-Discovery) reflector: reflects WS-Discovery between the source and target interfaces so
+//! ONVIF-camera / Windows-device discovery crosses the link. Structurally SSDP-without-DIAL: `Hello` /
+//! `Bye` announcements reflect device → client as a stateless multicast re-emit (a [`SimpleReflector`],
+//! like mDNS), and `Probe` / `Resolve` searches reflect client → device with their unicast
+//! `ProbeMatches` / `ResolveMatches` replies routed back through a per-searcher session (the shared
+//! [`SearchReflector`]). Re-emits go to the same group at TTL 1, sourced from the egress interface.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use crate::config::{AddressFamily, Reflector};
+use crate::dispatch::{CaptureKey, Filter, IpSet, PacketDispatcher};
+use crate::net::mac::MacSet;
+use crate::net::wsd::{WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT, WSD_TTL, WsdKind, classify};
+
+use super::{
+    BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
+    require_bidirectional_families,
+};
+
+/// The directional gate for the announcement direction: reflect `Hello` / `Bye`, skip a search (it
+/// flows the other way), and treat anything else on the group as junk.
+fn announcement_verdict(payload: &[u8]) -> Verdict {
+    match classify(payload) {
+        Some(WsdKind::Announcement) => Verdict::Reflect,
+        Some(WsdKind::Search) => Verdict::Skip,
+        None => Verdict::Junk,
+    }
+}
+
+/// The directional gate for the search direction: the mirror of [`announcement_verdict`].
+fn search_verdict(payload: &[u8]) -> Verdict {
+    match classify(payload) {
+        Some(WsdKind::Search) => Verdict::Reflect,
+        Some(WsdKind::Announcement) => Verdict::Skip,
+        None => Verdict::Junk,
+    }
+}
+
+/// A `Probe` / `Resolve` carries no MX field, so its reply window is a fixed span — long enough for a
+/// device's unicast match (WS-Discovery caps the reply delay at ~500 ms) plus network slack.
+const SESSION_WINDOW: Duration = Duration::from_secs(5);
+
+fn window(_: &[u8]) -> Duration {
+    SESSION_WINDOW
+}
+
+/// The shared [`SearchReflector`] configured for WSD: source → target `Probe` / `Resolve` reflection
+/// with per-searcher match sessions. WSD replies are relayed verbatim (no DIAL), so [`NoRewrite`].
+fn search_reflector(
+    source: CaptureKey,
+    target: CaptureKey,
+    target_ifindex: u32,
+    device_macs: Option<MacSet>,
+) -> SearchReflector {
+    SearchReflector::new(
+        source,
+        target,
+        target_ifindex,
+        device_macs,
+        "WSD",
+        WSD_TTL,
+        search_verdict,
+        window,
+        Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+    )
+}
+
+/// Build the WSD reflector for `reflector` and register both directions on `dispatcher` — a no-op when
+/// WSD isn't enabled. For each address family in use it joins the group on BOTH interfaces and
+/// registers two handlers: `Hello` / `Bye` announcements target → source (a [`SimpleReflector`]), and
+/// `Probe` / `Resolve` searches source → target with their unicast replies (the shared
+/// [`SearchReflector`]). A required family must be sendable on BOTH interfaces, since both re-emit.
+///
+/// # Errors
+/// [`BuildError::UnknownInterface`] for an unopened source/target, or
+/// [`BuildError::RequiredFamilyUnavailable`] if either interface can't send a required family.
+pub(crate) fn build(
+    reflector: &Reflector,
+    interfaces: &InterfaceMap,
+    dispatcher: &mut PacketDispatcher,
+) -> Result<(), BuildError> {
+    if !reflector.wsd {
+        return Ok(());
+    }
+    let source = interfaces.require(reflector.source_if.as_str())?;
+    let target = interfaces.require(reflector.target_if.as_str())?;
+
+    // Announcements re-emit on source, searches and their replies on target, so a required family must
+    // be sendable on BOTH.
+    require_bidirectional_families(
+        dispatcher,
+        reflector.address_family,
+        source,
+        reflector.source_if.as_str(),
+        target,
+        reflector.target_if.as_str(),
+    )?;
+
+    // The reserved-port bind for an IPv6 link-local target source needs the target's scope id; use the
+    // ifindex the capture already cached (the single source of truth the joiners bake too).
+    let target_ifindex = dispatcher.capture_ifindex(target).unwrap_or(0);
+
+    // Announcements are captured on target, searches on source — join the group on both. A family with
+    // no address yet is recorded and re-attempted on the next address change.
+    let groups = used_groups(reflector.address_family);
+    for group in &groups {
+        if let Err(e) = dispatcher.join_group(target, group.ip()) {
+            log::debug!("WSD: join {} on target deferred: {e}", group.ip());
+        }
+        if let Err(e) = dispatcher.join_group(source, group.ip()) {
+            log::debug!("WSD: join {} on source deferred: {e}", group.ip());
+        }
+    }
+    // One handler per direction spans every group; its filter matches the group set at the WSD port.
+    let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();
+    // target -> source: Hello/Bye announcements, optionally filtered to the configured device's MAC.
+    dispatcher.register(
+        target,
+        Filter {
+            dst_ip: Some(group_ips.clone()),
+            dst_port: Some(WSD_PORT.into()),
+            src_mac: reflector.macs.clone(),
+            ..Filter::default()
+        },
+        Box::new(SimpleReflector::new(
+            source,
+            "WSD announcement",
+            WSD_PORT,
+            WSD_TTL,
+            announcement_verdict,
+        )),
+    );
+    // source -> target: Probe/Resolve searches (unfiltered — any source client may search); each
+    // searcher's unicast matches route back through a per-searcher session.
+    dispatcher.register(
+        source,
+        Filter {
+            dst_ip: Some(group_ips),
+            dst_port: Some(WSD_PORT.into()),
+            ..Filter::default()
+        },
+        Box::new(search_reflector(
+            source,
+            target,
+            target_ifindex,
+            reflector.macs.clone(),
+        )),
+    );
+    log::info!(
+        "WSD reflector \"{}\": {} <-> {} (announcements + searches)",
+        reflector.name.as_str(),
+        reflector.source_if.as_str(),
+        reflector.target_if.as_str()
+    );
+    Ok(())
+}
+
+/// The WSD group socket addresses `family` reflects to: the IPv4 group and the IPv6 link-local group
+/// (WSD, unlike SSDP, uses only the link-local IPv6 scope).
+fn used_groups(family: AddressFamily) -> Vec<SocketAddr> {
+    let mut groups = Vec::with_capacity(2);
+    if family.uses_ipv4() {
+        groups.push(SocketAddr::from((WSD_GROUP_V4, WSD_PORT)));
+    }
+    if family.uses_ipv6() {
+        groups.push(SocketAddr::from((WSD_GROUP_V6, WSD_PORT)));
+    }
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn used_groups_follows_the_address_family() {
+        let v4 = SocketAddr::from((WSD_GROUP_V4, WSD_PORT));
+        let v6 = SocketAddr::from((WSD_GROUP_V6, WSD_PORT));
+        // Default and Dual reflect both families; the single-family policies, only their own.
+        assert_eq!(used_groups(AddressFamily::Default), vec![v4, v6]);
+        assert_eq!(used_groups(AddressFamily::Dual), vec![v4, v6]);
+        assert_eq!(used_groups(AddressFamily::Ipv4), vec![v4]);
+        assert_eq!(used_groups(AddressFamily::Ipv6), vec![v6]);
+    }
+
+    #[test]
+    fn verdicts_gate_by_direction() {
+        let hello = b"<a:Action>http://x/Hello</a:Action>";
+        let probe = b"<a:Action>http://x/Probe</a:Action>";
+        assert_eq!(announcement_verdict(hello), Verdict::Reflect);
+        assert_eq!(announcement_verdict(probe), Verdict::Skip);
+        assert_eq!(announcement_verdict(b"junk"), Verdict::Junk);
+        assert_eq!(search_verdict(probe), Verdict::Reflect);
+        assert_eq!(search_verdict(hello), Verdict::Skip);
+        assert_eq!(search_verdict(b"junk"), Verdict::Junk);
+    }
+}


### PR DESCRIPTION
## What

A WSD (WS-Discovery) reflector — ONVIF-camera / Windows-device discovery across the two interfaces. Structurally SSDP-without-DIAL: `Hello`/`Bye` announcements via a `SimpleReflector` (like mDNS); `Probe`/`Resolve` searches via a per-searcher session with the unicast `ProbeMatches`/`ResolveMatches` routed back. Group `239.255.255.250` / `ff02::c` on UDP 3702, TTL 1. Bumps to 0.10.0.

The SSDP search machinery is extracted into a shared `reflector/search.rs` (`SearchReflector` + a `ReplyRewrite` trait: `DialRewrite` for SSDP, `NoRewrite` for WSD) rather than cloned, so SSDP is refactored onto it here too.

## Testing

364 unit tests, clippy/fmt/doc clean; e2e 45/45 (37 existing + 8 WSD).