### PR TITLE
docs: refresh Cargo.lock in the release version-bump step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -432,7 +432,8 @@ The `[package]` version in `Cargo.toml` is the single source of truth: `version.
 `release.sh` (the git tag), the published image tag, and the GitHub release name all derive from it. To
 cut a release:
 
-- Bump the version in `Cargo.toml` and merge it to `origin/main`.
+- Bump the version in `Cargo.toml`, refresh `Cargo.lock` (`cargo build` updates its `reflector`
+  entry — CI builds `--locked`, so a stale lockfile fails the release), and merge it to `origin/main`.
 - From a clean `main` in sync with `origin/main`, run `./release.sh`.
 
 `./release.sh` does only the local half: it waits for CI (`ci.yml`) to pass on the release commit, prints


### PR DESCRIPTION
Two release/CI fixes:

- **docs:** the release steps said to bump `Cargo.toml` only, but `Cargo.lock` carries the `reflector` package's own version and CI/`release.sh` build `--locked`, so a bump that skips the lockfile fails every `--locked` step and blocks the release. Note the lockfile refresh.
- **ci:** drop `paths-ignore: '**.md'`. With it, a Markdown-only PR skipped the whole workflow, so the required `Success` check never posted and the PR stayed blocked (unmergeable). CI now runs on every PR — the full suite on the rare docs-only change.