### PR TITLE
Observability: per-interface packet counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,12 @@ side — enabling container mode, creating the `veth`s, and attaching each to it
 `config.toml` contains optional top-level settings plus at least one reflector entry. Entries are tables
 under `reflectors`, keyed by name (`[reflectors.<name>]`) — the name is the label used in logs — each
 describing one `source_if` → `target_if` bridge that enables any combination of the protocols. The
-top-level settings are `log_level` and `debug_memory`:
+top-level settings are `log_level`, `debug_memory`, and `counters_interval_secs`:
 
 ```toml
 log_level = "info"               # optional; one of debug | info | warning | error (default: info)
 debug_memory = false             # optional; periodically log RSS + heap stats for footprint debugging (default false)
+counters_interval_secs = 0       # optional; seconds between per-interface packet-counter summaries; 0 disables (default 0)
 
 [reflectors.tv]
 source_if = "en0"                # required; interface to listen on (must differ from target_if)
@@ -258,10 +259,10 @@ then optional; with none, the environment is the whole configuration. Variables 
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
   `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
 
-The globals are `REFLECTOR_LOG_LEVEL` and `REFLECTOR_DEBUG_MEMORY`, so `LOG` and `DEBUG` are reserved
-tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS` and `MACS` are comma-separated (`7,9` /
-`B0:...,C4:...`). The
-`[reflectors.tv]` entry above looks like this in the environment:
+The globals are `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY`, and `REFLECTOR_COUNTERS_INTERVAL_SECS`,
+so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS`
+and `MACS` are comma-separated (`7,9` / `B0:...,C4:...`). The `[reflectors.tv]` entry above looks like
+this in the environment:
 
 ```sh
 REFLECTOR_LOG_LEVEL=info
@@ -276,8 +277,9 @@ REFLECTOR_TV_WSD=true
 ```
 
 When a file and environment variables are both given they are merged: each contributes entries to one
-combined configuration, and `REFLECTOR_LOG_LEVEL` / `REFLECTOR_DEBUG_MEMORY` override the file's
-`log_level` / `debug_memory`. The [duplicate detection](#duplicate-detection) below applies across both
+combined configuration, and each global variable (`REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY`,
+`REFLECTOR_COUNTERS_INTERVAL_SECS`) overrides its file counterpart. The
+[duplicate detection](#duplicate-detection) below applies across both
 sources. An unknown `<PARAM>`, a non-alphanumeric or reserved tag, and a tag with no parameter are all
 rejected at startup.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Releases publish that multi-arch manifest to GHCR automatically (see [Release](#
 Configuration comes from a TOML file, from environment variables, or from both. With a path argument
 the file is read and merged with any `REFLECTOR_*` environment variables; with **no argument** the
 configuration comes entirely from the environment (see [Environment variables](#environment-variables)).
-The process logs to stderr with UTC timestamps and shuts down cleanly on `SIGINT` / `SIGTERM`.
+The process logs to stderr with UTC timestamps, shuts down cleanly on `SIGINT` / `SIGTERM`, and on
+`SIGUSR1` dumps the per-interface [packet counters](#configuration) to the log on demand (regardless of
+`counters_interval_secs`).
 
 ### Runtime privileges
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub(crate) use self::error::{ConfigError, Protocol};
 pub(crate) use self::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
 
 use std::str::FromStr;
+use std::time::Duration;
 
 use serde::Deserialize;
 
@@ -166,6 +167,8 @@ pub(crate) struct Config {
     pub(crate) log_level: LogLevel,
     /// Whether to periodically log memory-footprint diagnostics.
     pub(crate) debug_memory: bool,
+    /// How often to log per-interface packet counters, or `None` to disable them.
+    pub(crate) counter_interval: Option<Duration>,
     pub(crate) reflectors: Vec<Reflector>,
 }
 
@@ -218,6 +221,11 @@ impl TryFrom<RawConfig> for Config {
         Ok(Config {
             log_level: raw.log_level.unwrap_or_default(),
             debug_memory: raw.debug_memory.unwrap_or_default(),
+            // 0 or absent disables the summary; any positive count is its period.
+            counter_interval: raw
+                .counters_interval_secs
+                .filter(|&s| s > 0)
+                .map(Duration::from_secs),
             reflectors,
         })
     }
@@ -420,6 +428,35 @@ mod tests {
             [7, 9, 4000]
         );
         assert_eq!(r.address_family, AddressFamily::Dual);
+    }
+
+    #[test]
+    fn counter_interval_parses_and_zero_disables() {
+        // A positive interval becomes a Duration; 0 disables it, as does omitting the key.
+        let toml = |secs: &str| {
+            format!(
+                r#"
+                {secs}
+                [reflectors.d]
+                source_if = "a"
+                target_if = "b"
+                mdns = true
+                "#
+            )
+        };
+        assert_eq!(
+            from_toml(&toml("counters_interval_secs = 30"))
+                .unwrap()
+                .counter_interval,
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(
+            from_toml(&toml("counters_interval_secs = 0"))
+                .unwrap()
+                .counter_interval,
+            None
+        );
+        assert_eq!(from_toml(&toml("")).unwrap().counter_interval, None);
     }
 
     #[test]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -80,14 +80,15 @@ impl PartialReflector {
 
 /// Parse `REFLECTOR_*` variables into the raw configuration they describe.
 ///
-/// `REFLECTOR_LOG_LEVEL` and `REFLECTOR_DEBUG_MEMORY` set the globals; every other
-/// `REFLECTOR_<tag>_<param>` contributes to the reflector keyed by the lowercased
-/// `tag`. Unprefixed variables are ignored.
+/// `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY`, and `REFLECTOR_COUNTERS_INTERVAL_SECS` set
+/// the globals; every other `REFLECTOR_<tag>_<param>` contributes to the reflector keyed by the
+/// lowercased `tag`. Unprefixed variables are ignored.
 pub(super) fn parse_env(
     vars: impl IntoIterator<Item = (String, String)>,
 ) -> Result<RawConfig, ConfigError> {
     let mut log_level = None;
     let mut debug_memory = None;
+    let mut counters_interval_secs = None;
     let mut partials: BTreeMap<String, PartialReflector> = BTreeMap::new();
 
     for (key, value) in vars {
@@ -105,6 +106,11 @@ pub(super) fn parse_env(
                 debug_memory = Some(env_bool(&value, &key)?);
                 continue;
             }
+            "COUNTERS_INTERVAL_SECS" => {
+                log::trace!("env {key} = {value}");
+                counters_interval_secs = Some(env_value(&value, &key)?);
+                continue;
+            }
             _ => {}
         }
 
@@ -118,7 +124,7 @@ pub(super) fn parse_env(
             });
         }
         let tag = tag.to_ascii_lowercase();
-        if tag == "log" || tag == "debug" {
+        if tag == "log" || tag == "debug" || tag == "counters" {
             return Err(ConfigError::EnvReservedTag { var: key.clone() });
         }
         let param = param.to_ascii_lowercase();
@@ -134,6 +140,7 @@ pub(super) fn parse_env(
     Ok(RawConfig {
         log_level,
         debug_memory,
+        counters_interval_secs,
         reflectors,
     })
 }
@@ -218,6 +225,7 @@ mod tests {
         let cfg = from_env(&[
             ("REFLECTOR_LOG_LEVEL", "debug"),
             ("REFLECTOR_DEBUG_MEMORY", "1"),
+            ("REFLECTOR_COUNTERS_INTERVAL_SECS", "45"),
             ("REFLECTOR_TV_SOURCE_IF", "a"),
             ("REFLECTOR_TV_TARGET_IF", "b"),
             ("REFLECTOR_TV_WOL", "1"),
@@ -226,6 +234,10 @@ mod tests {
         .unwrap();
         assert_eq!(cfg.log_level, LogLevel::Debug);
         assert!(cfg.debug_memory);
+        assert_eq!(
+            cfg.counter_interval,
+            Some(std::time::Duration::from_secs(45))
+        );
         let r = &cfg.reflectors[0];
         assert!(r.wol.is_some());
         assert!(!r.mdns);
@@ -419,10 +431,16 @@ mod tests {
 
     #[test]
     fn env_reserved_tag_rejected() {
-        assert!(matches!(
-            from_env(&[("REFLECTOR_LOG_SOMETHING", "x")]).unwrap_err(),
-            ConfigError::EnvReservedTag { .. }
-        ));
+        for var in [
+            "REFLECTOR_LOG_SOMETHING",
+            "REFLECTOR_DEBUG_SOMETHING",
+            "REFLECTOR_COUNTERS_SOURCE_IF",
+        ] {
+            assert!(matches!(
+                from_env(&[(var, "x")]).unwrap_err(),
+                ConfigError::EnvReservedTag { .. }
+            ));
+        }
     }
 
     #[test]
@@ -465,6 +483,13 @@ mod tests {
                 source: ParseValueError::Bool(_),
                 ..
             } if value == "maybe"
+        ));
+        assert!(matches!(
+            from_env(&[("REFLECTOR_COUNTERS_INTERVAL_SECS", "soon")]).unwrap_err(),
+            ConfigError::EnvBadValue {
+                source: ParseValueError::Integer(_),
+                ..
+            }
         ));
     }
 

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -162,6 +162,9 @@ pub(crate) enum ParseValueError {
     ReflectorName(#[from] ParseReflectorNameError),
     #[error(transparent)]
     Bool(#[from] ParseBoolError),
+    /// A whole-number setting, e.g. `COUNTERS_INTERVAL_SECS`.
+    #[error(transparent)]
+    Integer(#[from] std::num::ParseIntError),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -18,6 +18,8 @@ use crate::net::mac::MacSet;
 pub(super) struct RawConfig {
     pub(super) log_level: Option<LogLevel>,
     pub(super) debug_memory: Option<bool>,
+    /// Seconds between periodic counter summaries; `0` or absent disables them.
+    pub(super) counters_interval_secs: Option<u64>,
     #[serde(default)]
     pub(super) reflectors: BTreeMap<String, RawReflector>,
 }
@@ -57,6 +59,7 @@ impl RawConfig {
     pub(super) fn merge_env(&mut self, env: RawConfig) -> Result<(), ConfigError> {
         self.log_level = env.log_level.or(self.log_level);
         self.debug_memory = env.debug_memory.or(self.debug_memory);
+        self.counters_interval_secs = env.counters_interval_secs.or(self.counters_interval_secs);
         for (name, reflector) in env.reflectors {
             // Compare folded: an env tag is already lowercase and unpadded, but a TOML table key is
             // stored verbatim, so `[reflectors.TV]` (or `"  tv  "`) and env `REFLECTOR_TV_*` name the

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -23,6 +23,7 @@ mod dial_context;
 mod interface_table;
 mod multicast;
 
+pub(crate) use self::counters::{MessageType, Outcome};
 pub(crate) use self::dial_context::DialContext;
 
 use std::io;
@@ -174,7 +175,7 @@ pub(crate) trait PacketHandler {
         packet: &Packet,
         dispatcher: &mut PacketDispatcher,
         reactor: &mut Reactor,
-    );
+    ) -> Outcome;
 
     /// The earliest instant this handler wants [`on_deadline`](Self::on_deadline) called, or `None`
     /// (the default) if it keeps no timer. The dispatcher reports the soonest of these to the reactor,
@@ -491,6 +492,7 @@ impl PacketDispatcher {
                 .iter()
                 .map(|(key, _)| RegistrationKey(key)),
         );
+        let mut final_outcome: Option<Outcome> = None;
         for i in 0..self.route_keys.len() {
             let key = self.route_keys[i];
             let applies = self
@@ -511,10 +513,37 @@ impl PacketDispatcher {
                 .handler
                 .take()
                 .expect("a matching registration has its handler present");
-            handler.on_packet(packet, self, reactor);
+            let outcome = handler.on_packet(packet, self, reactor);
             if let Some(reg) = self.registrations.get_mut(key.0) {
                 reg.handler = Some(handler);
             }
+            // Fold this handler's outcome into the packet's running result (highest disposition wins),
+            // logging the "can't happen under a valid config" anomalies the fold surfaces.
+            final_outcome = Some(match final_outcome {
+                None => outcome,
+                Some(prev) => {
+                    let (merged, anomalies) = prev.combine(outcome);
+                    if anomalies.double_reflect {
+                        log::error!(
+                            "two handlers reflected one packet on {ingress:?} ({prev:?} + {outcome:?}) \
+                             — a duplicate-direction config the conflict check should have caught"
+                        );
+                    }
+                    if anomalies.type_mismatch {
+                        log::error!(
+                            "handlers disagree on a packet's message type on {ingress:?} \
+                             ({prev:?} vs {outcome:?})"
+                        );
+                    }
+                    merged
+                }
+            });
+        }
+        // One packet, one tally: record the folded outcome on the ingress capture's row. The row
+        // always exists — `route` is reached only via the drain, whose take-out guard admits only a
+        // real, in-range ingress key.
+        if let Some(outcome) = final_outcome {
+            self.table.record(ingress, outcome);
         }
     }
 
@@ -846,9 +875,9 @@ mod tests {
             packet: &Packet,
             dispatcher: &mut PacketDispatcher,
             _reactor: &mut Reactor,
-        ) {
+        ) -> Outcome {
             let (SocketAddr::V4(src), SocketAddr::V4(dst)) = (packet.source, packet.dest) else {
-                return;
+                return Outcome::Filtered;
             };
             let dst = SocketAddr::V4(SocketAddrV4::new(*dst.ip(), ECHO_DST_PORT));
             // Re-emit through the real link-aware send so the framing matches the egress link type
@@ -865,6 +894,7 @@ mod tests {
                 )
                 .is_ok();
             self.seen.borrow_mut().push((packet.payload.to_vec(), sent));
+            Outcome::Reflected(MessageType::MdnsQuery)
         }
     }
 
@@ -927,8 +957,14 @@ mod tests {
     }
 
     impl PacketHandler for Recorder {
-        fn on_packet(&mut self, packet: &Packet, _: &mut PacketDispatcher, _: &mut Reactor) {
+        fn on_packet(
+            &mut self,
+            packet: &Packet,
+            _: &mut PacketDispatcher,
+            _: &mut Reactor,
+        ) -> Outcome {
             self.seen.borrow_mut().push(packet.payload.to_vec());
+            Outcome::Reflected(MessageType::MdnsQuery)
         }
     }
 
@@ -948,7 +984,7 @@ mod tests {
     fn unregister_stops_routing_to_a_handler() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
-        let ingress = CaptureKey::from_u64(0);
+        let ingress = dispatcher.add_test_capture();
         let seen = Rc::new(RefCell::new(Vec::new()));
         let key = dispatcher.register(
             ingress,
@@ -969,6 +1005,75 @@ mod tests {
         Ok(())
     }
 
+    /// A reflector that returns a preset [`Outcome`] — drives `route`'s outcome fold and per-capture
+    /// recording without a real egress.
+    struct Outcomer(Outcome);
+
+    impl PacketHandler for Outcomer {
+        fn on_packet(&mut self, _: &Packet, _: &mut PacketDispatcher, _: &mut Reactor) -> Outcome {
+            self.0
+        }
+    }
+
+    impl PacketDispatcher {
+        /// Add a capture-less table entry so a routing test can mint a valid `CaptureKey` and
+        /// exercise `route`'s record path without opening a real capture; read the row back with
+        /// [`tally`](Self::tally).
+        fn add_test_capture(&mut self) -> CaptureKey {
+            self.table.add_test_capture()
+        }
+
+        /// The `(reflected, skipped, dropped, stalled)` tally recorded for `ty` on `key`'s row.
+        fn tally(&self, key: CaptureKey, ty: MessageType) -> (u64, u64, u64, u64) {
+            self.table.typed_counts(key, ty)
+        }
+    }
+
+    // route folds every matched handler's outcome into one and records it once on the ingress row:
+    // a reflect and its mirror skip (both matching) tally a single reflect, and a handler whose filter
+    // misses doesn't contribute at all.
+    #[test]
+    fn route_folds_matched_outcomes_and_records_once() -> io::Result<()> {
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reactor = Reactor::new()?;
+        let ingress = dispatcher.add_test_capture();
+
+        // Mirrored a->b / b->a reflectors both match here: one reflects the query, its mirror skips it.
+        dispatcher.register(
+            ingress,
+            Filter::default(),
+            Box::new(Outcomer(Outcome::Reflected(MessageType::MdnsQuery))),
+        );
+        dispatcher.register(
+            ingress,
+            Filter::default(),
+            Box::new(Outcomer(Outcome::Skipped(MessageType::MdnsQuery))),
+        );
+        // A third handler whose filter never matches (wrong dst port) must not reach the tally.
+        dispatcher.register(
+            ingress,
+            Filter {
+                dst_port: Some(4242.into()),
+                ..Filter::default()
+            },
+            Box::new(Outcomer(Outcome::Reflected(MessageType::SsdpSearch))),
+        );
+
+        dispatcher.route(ingress, &probe_packet(b"q"), &mut reactor);
+
+        // The reflect wins the fold and is counted once; the skip is shadowed, not a second tally.
+        assert_eq!(
+            dispatcher.tally(ingress, MessageType::MdnsQuery),
+            (1, 0, 0, 0)
+        );
+        // The unmatched handler contributed nothing.
+        assert_eq!(
+            dispatcher.tally(ingress, MessageType::SsdpSearch),
+            (0, 0, 0, 0)
+        );
+        Ok(())
+    }
+
     /// A reflector carrying only a timer: reports `deadline` and counts each `on_deadline` sweep —
     /// for the dispatcher's deadline aggregation/dispatch, with no packets involved.
     struct Ticker {
@@ -977,7 +1082,9 @@ mod tests {
     }
 
     impl PacketHandler for Ticker {
-        fn on_packet(&mut self, _: &Packet, _: &mut PacketDispatcher, _: &mut Reactor) {}
+        fn on_packet(&mut self, _: &Packet, _: &mut PacketDispatcher, _: &mut Reactor) -> Outcome {
+            Outcome::Filtered
+        }
         fn next_deadline(&self) -> Option<Instant> {
             self.deadline
         }
@@ -1029,7 +1136,12 @@ mod tests {
     }
 
     impl PacketHandler for Registrar {
-        fn on_packet(&mut self, _: &Packet, dispatcher: &mut PacketDispatcher, _: &mut Reactor) {
+        fn on_packet(
+            &mut self,
+            _: &Packet,
+            dispatcher: &mut PacketDispatcher,
+            _: &mut Reactor,
+        ) -> Outcome {
             if !std::mem::replace(&mut self.done, true) {
                 dispatcher.register(
                     self.ingress,
@@ -1039,6 +1151,7 @@ mod tests {
                     }),
                 );
             }
+            Outcome::Filtered
         }
     }
 
@@ -1049,7 +1162,7 @@ mod tests {
     fn a_mid_route_registration_is_not_fed_the_in_flight_frame() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
-        let ingress = CaptureKey::from_u64(0);
+        let ingress = dispatcher.add_test_capture();
         let late = Rc::new(RefCell::new(Vec::new()));
         dispatcher.register(
             ingress,
@@ -1088,9 +1201,10 @@ mod tests {
             _packet: &Packet,
             dispatcher: &mut PacketDispatcher,
             reactor: &mut Reactor,
-        ) {
+        ) -> Outcome {
             *self.calls.borrow_mut() += 1;
             dispatcher.drain_and_route(self.ingress, reactor);
+            Outcome::Filtered
         }
     }
 
@@ -1232,12 +1346,13 @@ mod tests {
             _packet: &Packet,
             dispatcher: &mut PacketDispatcher,
             _reactor: &mut Reactor,
-        ) {
+        ) -> Outcome {
             let addrs = dispatcher
                 .egress_addrs(self.ingress)
                 .and_then(InterfaceAddresses::v4);
             let sent_ok = dispatcher.send(self.ingress, b"x").is_ok();
             *self.result.borrow_mut() = Some((addrs, sent_ok));
+            Outcome::Filtered
         }
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -30,7 +30,7 @@ use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::ops::Deref;
 use std::os::fd::{AsRawFd, RawFd};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::capture::Capture;
 use crate::interface::{AddressMonitor, InterfaceAddresses};
@@ -39,6 +39,7 @@ use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
 use crate::reactor::{Arena, Handler, Key, Reactor, ReadyEvent};
 
+use self::counters::log_counters;
 use self::datagram::{build_udp, ethernet_dst};
 use self::interface_table::InterfaceTable;
 
@@ -205,6 +206,13 @@ struct Registration {
     handler: Option<Box<dyn PacketHandler>>,
 }
 
+/// The periodic counter-summary schedule: log every capture's tallies every `interval`. Held as an
+/// `Option` on the dispatcher — `None` disables reporting, and the counters accrue regardless.
+struct CounterReport {
+    interval: Duration,
+    next: Instant,
+}
+
 /// Owns the interface table and the routing registrations. The sole owner of capture fds:
 /// egress goes through [`send`](Self::send), keyed.
 pub(crate) struct PacketDispatcher {
@@ -222,6 +230,8 @@ pub(crate) struct PacketDispatcher {
     dial: DialContext,
     /// The reused frame-build buffer shared by every reflector's send (see [`SCRATCH_LEN`]).
     scratch: Box<[u8]>,
+    /// The periodic counter-summary schedule, or `None` when the summary is disabled.
+    report: Option<CounterReport>,
 }
 
 impl PacketDispatcher {
@@ -236,7 +246,18 @@ impl PacketDispatcher {
             monitor: Self::open_monitor(),
             dial: DialContext::new(),
             scratch: vec![0u8; SCRATCH_LEN].into_boxed_slice(),
+            report: None,
         }
+    }
+
+    /// Enable the periodic counter summary: log each capture's tallies every `interval`, first firing
+    /// `interval` after `now`. Called from [`run`](crate::run) when the config sets a positive
+    /// interval; the counters accrue regardless, so this controls only whether they are reported.
+    pub(crate) fn enable_counter_report(&mut self, interval: Duration, now: Instant) {
+        self.report = Some(CounterReport {
+            interval,
+            next: now + interval,
+        });
     }
 
     /// Open the address-change monitor. Best-effort: a failure logs and yields `None` — the
@@ -640,6 +661,7 @@ impl Handler for PacketDispatcher {
             .iter()
             .filter_map(|(_, reg)| reg.handler.as_ref().and_then(|h| h.next_deadline()))
             .chain(self.dial.next_grace()) // and the soonest DIAL proxy grace, for its eviction sweep
+            .chain(self.report.as_ref().map(|r| r.next)) // and the next counter summary, if enabled
             .min()
     }
 
@@ -675,6 +697,14 @@ impl Handler for PacketDispatcher {
             }
         }
         self.dial.sweep(now, reactor); // evict DIAL proxies whose advertisement grace has lapsed
+
+        // The periodic counter summary, when enabled and due.
+        if let Some(report) = &mut self.report
+            && now >= report.next
+        {
+            log_counters(self.table.counter_rows());
+            report.next = now + report.interval;
+        }
     }
 }
 
@@ -1071,6 +1101,27 @@ mod tests {
             dispatcher.tally(ingress, MessageType::SsdpSearch),
             (0, 0, 0, 0)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn counter_report_fires_on_its_interval() -> io::Result<()> {
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reactor = Reactor::new()?;
+        let now = Instant::now();
+        assert_eq!(
+            dispatcher.next_deadline(),
+            None,
+            "no deadline until enabled"
+        );
+
+        let interval = Duration::from_secs(30);
+        dispatcher.enable_counter_report(interval, now);
+        assert_eq!(dispatcher.next_deadline(), Some(now + interval));
+
+        // Firing the report at its deadline reschedules it exactly one interval out.
+        dispatcher.on_deadline(now + interval, &mut reactor);
+        assert_eq!(dispatcher.next_deadline(), Some(now + interval + interval));
         Ok(())
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -17,6 +17,7 @@
 //! [`drain_and_route`]: PacketDispatcher::drain_and_route
 //! [`send`]: PacketDispatcher::send
 
+mod counters;
 mod datagram;
 mod dial_context;
 mod interface_table;

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -37,7 +37,7 @@ use crate::interface::{AddressMonitor, InterfaceAddresses};
 use crate::net::LinkType;
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
-use crate::reactor::{Arena, Handler, Key, Reactor, ReadyEvent};
+use crate::reactor::{Arena, ControlEvent, Handler, Key, Reactor, ReadyEvent};
 
 use self::counters::log_counters;
 use self::datagram::{build_udp, ethernet_dst};
@@ -704,6 +704,14 @@ impl Handler for PacketDispatcher {
         {
             log_counters(self.table.counter_rows());
             report.next = now + report.interval;
+        }
+    }
+
+    /// A SIGUSR1 diagnostics dump: log the per-interface counter summary on demand. Independent of the
+    /// periodic report's interval (the counters accrue regardless), so it works even when unconfigured.
+    fn on_control(&mut self, event: ControlEvent, _reactor: &mut Reactor) {
+        match event {
+            ControlEvent::Dump => log_counters(self.table.counter_rows()),
         }
     }
 }

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -1,0 +1,337 @@
+//! Observability counters: what the reflector did with each packet, tallied per message type and
+//! interface.
+//!
+//! A single packet can match several handlers — e.g. mirrored `a→b` and `b→a` reflectors both put a
+//! handler on the same interface, one that reflects it and one that skips it. Each handler returns an
+//! [`Outcome`]; the dispatcher folds them with [`Outcome::combine`] into the single highest-precedence
+//! disposition and records that once, so one packet is counted once (the reflecting handler wins; the
+//! other's skip is shadowed). The fold also surfaces "can't happen under a valid config" [`Anomalies`]
+//! for the dispatcher to log.
+//!
+//! The interface dimension is the ingress [`CaptureKey`](super::CaptureKey), which the dispatcher
+//! supplies; a [`CaptureCounters`] row per interface holds the tallies.
+
+// Nothing here is used until the module is wired into the dispatcher's `route()` (the next build step),
+// so the whole module reads as dead in a non-test build. Allow it module-wide meanwhile rather than
+// scattering per-item attributes; remove this once `combine`/`record` are called from `route()`.
+#![allow(dead_code)]
+
+use std::fmt;
+
+/// Declare [`MessageType`] from a single `Variant => (protocol, direction)` list, deriving its report
+/// labels, the `ALL` roster, and [`MESSAGE_TYPE_COUNT`] from that one list. Because the count and the
+/// counter-row order both come from the variant list, reordering variants is harmless and adding or
+/// removing one can't leave the count (the counter-array width) stale.
+macro_rules! message_types {
+    ($($variant:ident => ($protocol:literal, $direction:literal)),+ $(,)?) => {
+        /// A protocol and direction — the flat set of reflector legs the counters key on, one variant
+        /// per direction of each protocol. Handlers report the packet's *intrinsic* type (what it is),
+        /// not the leg they serve, so every handler that sees one packet agrees on it (a disagreement
+        /// is a bug — see [`Anomalies::type_mismatch`]).
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub(crate) enum MessageType {
+            $($variant),+
+        }
+
+        impl MessageType {
+            /// Every variant, in declaration (counter-row) order — the source of truth for the count.
+            const ALL: &'static [MessageType] = &[$(Self::$variant),+];
+
+            /// The protocol and direction words for the report, e.g. `("mDNS", "query")`. A type with
+            /// no direction pair (Wake-on-LAN) leaves the second word empty.
+            fn labels(self) -> (&'static str, &'static str) {
+                match self {
+                    $(Self::$variant => ($protocol, $direction)),+
+                }
+            }
+        }
+
+        /// The number of [`MessageType`] variants — the width of a per-interface counter row. Derived
+        /// from the variant list, so it can never drift from the enum.
+        pub(crate) const MESSAGE_TYPE_COUNT: usize = MessageType::ALL.len();
+    };
+}
+
+message_types! {
+    MdnsQuery => ("mDNS", "query"),
+    MdnsResponse => ("mDNS", "response"),
+    SsdpAdvertisement => ("SSDP", "advertisement"),
+    SsdpSearch => ("SSDP", "search"),
+    SsdpResponse => ("SSDP", "response"),
+    WsdAnnouncement => ("WSD", "announcement"),
+    WsdSearch => ("WSD", "search"),
+    WsdResponse => ("WSD", "response"),
+    WakeOnLan => ("WoL", ""),
+}
+
+impl fmt::Display for MessageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.labels() {
+            (protocol, "") => f.write_str(protocol),
+            (protocol, direction) => write!(f, "{protocol} {direction}"),
+        }
+    }
+}
+
+/// Fold precedence for [`Outcome`], ordered worst-to-best so the higher variant wins when several
+/// handlers see one packet (the derived `Ord` follows declaration order). `Reflected` dominates (the
+/// packet crossed); a reflect that failed (`Dropped`/`Stalled`) outranks a `Skipped` (a correct
+/// non-forward); `Filtered` (junk) is last. Fieldless, so precedence is a property of the disposition
+/// alone — `MessageType` needn't be `Ord`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum Disposition {
+    Filtered,
+    Skipped,
+    Stalled,
+    Dropped,
+    Reflected,
+}
+
+/// Invariants an [`Outcome::combine`] fold can violate — never expected under a valid config, so the
+/// dispatcher logs them rather than silently miscounting.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct Anomalies {
+    /// Two handlers both tried to reflect one packet — duplicate same-direction reflectors, which the
+    /// config's conflict check should have rejected.
+    pub(crate) double_reflect: bool,
+    /// Two handlers classified one packet to different message types — a classifier or config bug.
+    pub(crate) type_mismatch: bool,
+}
+
+/// What a handler did with a packet — its `on_packet` return, folded by the dispatcher. The carried
+/// [`MessageType`] is the packet's intrinsic type (present on every disposition but junk).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Outcome {
+    /// Re-emitted on the egress interface.
+    Reflected(MessageType),
+    /// Recognized, but the wrong direction for this leg — the loop-breaker; not ours to forward.
+    Skipped(MessageType),
+    /// The right direction, but the re-emit failed (a send error or a resource cap).
+    Dropped(MessageType),
+    /// The right direction, but the egress has no source address of the family yet (transient).
+    Stalled(MessageType),
+    /// Not a message we handle — unrecognized junk on the group, or an unhandled address family.
+    Filtered,
+}
+
+impl Outcome {
+    /// This outcome's fold-precedence key (see [`Disposition`]).
+    fn disposition(self) -> Disposition {
+        match self {
+            Self::Reflected(_) => Disposition::Reflected,
+            Self::Dropped(_) => Disposition::Dropped,
+            Self::Stalled(_) => Disposition::Stalled,
+            Self::Skipped(_) => Disposition::Skipped,
+            Self::Filtered => Disposition::Filtered,
+        }
+    }
+
+    /// The packet's message type, or `None` for `Filtered` — junk has no direction to attribute.
+    fn message_type(self) -> Option<MessageType> {
+        match self {
+            Self::Reflected(t) | Self::Skipped(t) | Self::Dropped(t) | Self::Stalled(t) => Some(t),
+            Self::Filtered => None,
+        }
+    }
+
+    /// Whether the handler *tried* to reflect (a right-direction disposition, whether it succeeded,
+    /// failed, or stalled). At most one handler may per packet; a second is a duplicate-reflector bug.
+    fn is_reflect_attempt(self) -> bool {
+        matches!(
+            self,
+            Self::Reflected(_) | Self::Dropped(_) | Self::Stalled(_)
+        )
+    }
+
+    /// Fold another handler's outcome for the *same* packet into this running one: keep the
+    /// higher-precedence disposition, and report any invariant [`Anomalies`]. Order-independent (a max
+    /// over [`disposition`](Self::disposition)), so handler visitation order doesn't change the result.
+    pub(crate) fn combine(self, other: Outcome) -> (Outcome, Anomalies) {
+        let anomalies = Anomalies {
+            double_reflect: self.is_reflect_attempt() && other.is_reflect_attempt(),
+            type_mismatch: matches!(
+                (self.message_type(), other.message_type()),
+                (Some(a), Some(b)) if a != b
+            ),
+        };
+        let merged = if other.disposition() > self.disposition() {
+            other
+        } else {
+            self
+        };
+        (merged, anomalies)
+    }
+}
+
+/// The four typed tallies for one message type on one interface.
+#[derive(Clone, Copy, Default)]
+struct TypeCounters {
+    reflected: u64,
+    skipped: u64,
+    dropped: u64,
+    stalled: u64,
+}
+
+/// Every tally for one interface (capture): one [`TypeCounters`] per [`MessageType`], plus a
+/// type-less `filtered` count for junk (which has no direction to attribute to a message type).
+#[derive(Clone, Default)]
+pub(crate) struct CaptureCounters {
+    types: [TypeCounters; MESSAGE_TYPE_COUNT],
+    filtered: u64,
+}
+
+impl CaptureCounters {
+    /// Tally one packet's folded [`Outcome`].
+    pub(crate) fn record(&mut self, outcome: Outcome) {
+        match outcome {
+            Outcome::Reflected(t) => self.types[t as usize].reflected += 1,
+            Outcome::Skipped(t) => self.types[t as usize].skipped += 1,
+            Outcome::Dropped(t) => self.types[t as usize].dropped += 1,
+            Outcome::Stalled(t) => self.types[t as usize].stalled += 1,
+            Outcome::Filtered => self.filtered += 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl CaptureCounters {
+        /// The four typed tallies for `ty` (test oracle for [`record`](Self::record)).
+        fn typed(&self, ty: MessageType) -> (u64, u64, u64, u64) {
+            let c = self.types[ty as usize];
+            (c.reflected, c.skipped, c.dropped, c.stalled)
+        }
+        fn filtered(&self) -> u64 {
+            self.filtered
+        }
+    }
+
+    #[test]
+    fn message_type_display_omits_the_empty_direction() {
+        assert_eq!(MessageType::MdnsQuery.to_string(), "mDNS query");
+        assert_eq!(
+            MessageType::SsdpAdvertisement.to_string(),
+            "SSDP advertisement"
+        );
+        assert_eq!(MessageType::WakeOnLan.to_string(), "WoL");
+    }
+
+    #[test]
+    fn message_types_are_labelled_and_contiguously_indexed() {
+        // `record` indexes the counter array by `ty as usize`, so each variant's discriminant must
+        // equal its position in `ALL`, and every label must be non-empty.
+        for (index, &ty) in MessageType::ALL.iter().enumerate() {
+            assert!(!ty.to_string().is_empty(), "{ty:?} has an empty label");
+            assert_eq!(
+                ty as usize, index,
+                "discriminants must be contiguous from 0"
+            );
+        }
+    }
+
+    #[test]
+    fn disposition_orders_worst_to_best() {
+        use Disposition::*;
+        assert!(
+            Reflected > Dropped && Dropped > Stalled && Stalled > Skipped && Skipped > Filtered
+        );
+    }
+
+    #[test]
+    fn record_bumps_the_matching_bucket() {
+        let mut c = CaptureCounters::default();
+        c.record(Outcome::Reflected(MessageType::MdnsQuery));
+        c.record(Outcome::Reflected(MessageType::MdnsQuery));
+        c.record(Outcome::Skipped(MessageType::MdnsQuery));
+        c.record(Outcome::Dropped(MessageType::SsdpSearch));
+        c.record(Outcome::Stalled(MessageType::SsdpSearch));
+        c.record(Outcome::Filtered);
+        assert_eq!(c.typed(MessageType::MdnsQuery), (2, 1, 0, 0));
+        assert_eq!(c.typed(MessageType::SsdpSearch), (0, 0, 1, 1));
+        assert_eq!(c.typed(MessageType::WakeOnLan), (0, 0, 0, 0));
+        assert_eq!(c.filtered(), 1);
+    }
+
+    #[test]
+    fn combine_takes_the_higher_precedence_disposition() {
+        use MessageType::MdnsQuery as Q;
+        // Reflected dominates a skip; a failed reflect (dropped/stalled) still outranks a skip; junk
+        // is last.
+        assert_eq!(
+            Outcome::Reflected(Q).combine(Outcome::Skipped(Q)).0,
+            Outcome::Reflected(Q)
+        );
+        assert_eq!(
+            Outcome::Dropped(Q).combine(Outcome::Skipped(Q)).0,
+            Outcome::Dropped(Q)
+        );
+        assert_eq!(
+            Outcome::Stalled(Q).combine(Outcome::Skipped(Q)).0,
+            Outcome::Stalled(Q)
+        );
+        assert_eq!(
+            Outcome::Skipped(Q).combine(Outcome::Filtered).0,
+            Outcome::Skipped(Q)
+        );
+    }
+
+    #[test]
+    fn combine_is_order_independent() {
+        use MessageType::MdnsResponse as R;
+        let a = Outcome::Skipped(R);
+        let b = Outcome::Reflected(R);
+        assert_eq!(a.combine(b).0, b.combine(a).0);
+    }
+
+    #[test]
+    fn combine_flags_a_second_reflect_attempt() {
+        use MessageType::MdnsQuery as Q;
+        // The valid mirrored case (one reflect, one skip) is clean.
+        assert!(
+            !Outcome::Reflected(Q)
+                .combine(Outcome::Skipped(Q))
+                .1
+                .double_reflect
+        );
+        // Two reflect-attempts of any kind on one packet is the duplicate-reflector bug.
+        assert!(
+            Outcome::Reflected(Q)
+                .combine(Outcome::Reflected(Q))
+                .1
+                .double_reflect
+        );
+        assert!(
+            Outcome::Reflected(Q)
+                .combine(Outcome::Dropped(Q))
+                .1
+                .double_reflect
+        );
+    }
+
+    #[test]
+    fn combine_flags_a_type_mismatch() {
+        use MessageType::{MdnsQuery as Q, MdnsResponse as R};
+        // Handlers seeing one packet must agree on its type; a mismatch is a classifier/config bug.
+        assert!(
+            Outcome::Reflected(Q)
+                .combine(Outcome::Skipped(R))
+                .1
+                .type_mismatch
+        );
+        assert!(
+            !Outcome::Reflected(Q)
+                .combine(Outcome::Skipped(Q))
+                .1
+                .type_mismatch
+        );
+        // Junk carries no type, so it never triggers a mismatch.
+        assert!(
+            !Outcome::Filtered
+                .combine(Outcome::Skipped(Q))
+                .1
+                .type_mismatch
+        );
+    }
+}

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -167,6 +167,24 @@ struct TypeCounters {
     stalled: u64,
 }
 
+impl TypeCounters {
+    /// The non-zero tallies as `reflected=.. skipped=..`, or `None` when every tally is zero (so the
+    /// report omits a message type nothing has happened to).
+    fn format_nonzero(&self) -> Option<String> {
+        let parts: Vec<String> = [
+            ("reflected", self.reflected),
+            ("skipped", self.skipped),
+            ("dropped", self.dropped),
+            ("stalled", self.stalled),
+        ]
+        .into_iter()
+        .filter(|&(_, count)| count > 0)
+        .map(|(label, count)| format!("{label}={count}"))
+        .collect();
+        (!parts.is_empty()).then(|| parts.join(" "))
+    }
+}
+
 /// Every tally for one interface (capture): one [`TypeCounters`] per [`MessageType`], plus a
 /// type-less `filtered` count for junk (which has no direction to attribute to a message type).
 #[derive(Clone, Default)]
@@ -184,6 +202,36 @@ impl CaptureCounters {
             Outcome::Dropped(t) => self.types[t as usize].dropped += 1,
             Outcome::Stalled(t) => self.types[t as usize].stalled += 1,
             Outcome::Filtered => self.filtered += 1,
+        }
+    }
+
+    /// This row's non-zero tallies as one line — e.g. `mDNS query reflected=42 skipped=10; SSDP
+    /// search reflected=5 dropped=1; filtered=2` — or `None` when nothing has been counted, so an
+    /// idle interface produces no report line.
+    fn format_nonzero(&self) -> Option<String> {
+        let mut parts: Vec<String> = MessageType::ALL
+            .iter()
+            .zip(&self.types)
+            .filter_map(|(ty, counts)| {
+                counts
+                    .format_nonzero()
+                    .map(|fields| format!("{ty} {fields}"))
+            })
+            .collect();
+        if self.filtered > 0 {
+            parts.push(format!("filtered={}", self.filtered));
+        }
+        (!parts.is_empty()).then(|| parts.join("; "))
+    }
+}
+
+/// Log one `info` line per interface with any non-zero tallies (idle interfaces stay silent). The
+/// dispatcher calls this from its periodic report; the `(interface, row)` pairs come from the
+/// interface table, which owns the capture→interface-name mapping.
+pub(crate) fn log_counters<'a>(rows: impl Iterator<Item = (&'a str, &'a CaptureCounters)>) {
+    for (interface, counters) in rows {
+        if let Some(summary) = counters.format_nonzero() {
+            log::info!("counters {interface}: {summary}");
         }
     }
 }
@@ -248,6 +296,22 @@ mod tests {
         assert_eq!(c.typed(MessageType::SsdpSearch), (0, 0, 1, 1));
         assert_eq!(c.typed(MessageType::WakeOnLan), (0, 0, 0, 0));
         assert_eq!(c.filtered(), 1);
+    }
+
+    #[test]
+    fn format_nonzero_summarizes_only_touched_tallies() {
+        let mut c = CaptureCounters::default();
+        assert_eq!(c.format_nonzero(), None, "an untouched row logs no line");
+        c.record(Outcome::Reflected(MessageType::MdnsQuery));
+        c.record(Outcome::Reflected(MessageType::MdnsQuery));
+        c.record(Outcome::Skipped(MessageType::MdnsQuery));
+        c.record(Outcome::Dropped(MessageType::SsdpSearch));
+        c.record(Outcome::Filtered);
+        // Only touched types and sub-tallies appear, in declaration order, then the filtered total.
+        assert_eq!(
+            c.format_nonzero().as_deref(),
+            Some("mDNS query reflected=2 skipped=1; SSDP search dropped=1; filtered=1"),
+        );
     }
 
     #[test]

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -11,11 +11,6 @@
 //! The interface dimension is the ingress [`CaptureKey`](super::CaptureKey), which the dispatcher
 //! supplies; a [`CaptureCounters`] row per interface holds the tallies.
 
-// Nothing here is used until the module is wired into the dispatcher's `route()` (the next build step),
-// so the whole module reads as dead in a non-test build. Allow it module-wide meanwhile rather than
-// scattering per-item attributes; remove this once `combine`/`record` are called from `route()`.
-#![allow(dead_code)]
-
 use std::fmt;
 
 /// Declare [`MessageType`] from a single `Variant => (protocol, direction)` list, deriving its report
@@ -198,8 +193,9 @@ mod tests {
     use super::*;
 
     impl CaptureCounters {
-        /// The four typed tallies for `ty` (test oracle for [`record`](Self::record)).
-        fn typed(&self, ty: MessageType) -> (u64, u64, u64, u64) {
+        /// The four typed tallies (`reflected, skipped, dropped, stalled`) for `ty` — the test reader
+        /// for recorded outcomes, here and in the dispatcher's route-fold test.
+        pub(crate) fn typed(&self, ty: MessageType) -> (u64, u64, u64, u64) {
             let c = self.types[ty as usize];
             (c.reflected, c.skipped, c.dropped, c.stalled)
         }

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -9,6 +9,7 @@ use crate::capture::Capture;
 use crate::interface::{AddressChange, Interface, InterfaceAddresses};
 
 use super::CaptureKey;
+use super::counters::{CaptureCounters, Outcome};
 use super::multicast::MulticastJoiner;
 
 /// A `Copy` handle into the interface table's interface entries — an insert-only index, like
@@ -16,12 +17,15 @@ use super::multicast::MulticastJoiner;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(super) struct InterfaceKey(u32);
 
-/// One capture plus the interface it runs on. The `capture` is `Option` so the drain can
-/// take it OUT (leaving the `interface` link resident, so a capture's addresses resolve
-/// even mid-drain) and restore it; `None` marks "currently draining". Never removed.
+/// One capture, the interface it runs on, and its observability tallies. The `capture` is
+/// `Option` so the drain can take it OUT (leaving the `interface` link and `counters` resident, so a
+/// capture's addresses resolve and its routed outcomes still record mid-drain) and restore it; `None`
+/// marks "currently draining". Never removed — so the tallies accrue for the whole run. Bundling the
+/// counters here (rather than a parallel `Vec`) makes them impossible to desync: one push adds both.
 struct CaptureEntry {
     capture: Option<Capture>,
     interface: InterfaceKey,
+    counters: CaptureCounters,
 }
 
 /// One interface paired with its multicast joiner. Bundling them makes the two impossible to
@@ -90,6 +94,7 @@ impl InterfaceTable {
         self.captures.push(CaptureEntry {
             capture: Some(capture),
             interface,
+            counters: CaptureCounters::default(),
         });
         key
     }
@@ -159,6 +164,13 @@ impl InterfaceTable {
         }
     }
 
+    /// Tally a routed packet's folded [`Outcome`] on `capture`'s counter row. Indexed directly:
+    /// recording is reached only from `route`, with the ingress key of a real, in-range capture (the
+    /// drain's take-out guard rejects any other), so the row always exists.
+    pub(super) fn record(&mut self, capture: CaptureKey, outcome: Outcome) {
+        self.captures[capture.0 as usize].counters.record(outcome);
+    }
+
     /// Re-resolve the interface with kernel index `ifindex`, in place. A real index matches at
     /// most one interface — they dedup by name, and the kernel gives each a distinct index —
     /// so this finds rather than scans. Returns the fields that changed if one matched, or `None`
@@ -224,8 +236,34 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use super::*;
+    use crate::dispatch::MessageType;
     use crate::dispatch::multicast::join_unsupported;
     use crate::interface::{LOOPBACK_IFACE, if_index};
+
+    impl InterfaceTable {
+        /// Push a capture-less entry (no fd) so a routing test can mint a valid [`CaptureKey`] and
+        /// exercise the record path without opening a capture; the dangling [`InterfaceKey`] is
+        /// never resolved. Reachable from the dispatcher's own tests, hence `pub(in crate::dispatch)`.
+        pub(in crate::dispatch) fn add_test_capture(&mut self) -> CaptureKey {
+            let key =
+                CaptureKey(u32::try_from(self.captures.len()).expect("capture count fits a u32"));
+            self.captures.push(CaptureEntry {
+                capture: None,
+                interface: InterfaceKey(0),
+                counters: CaptureCounters::default(),
+            });
+            key
+        }
+
+        /// The `(reflected, skipped, dropped, stalled)` tally recorded for `ty` on `capture`'s row.
+        pub(in crate::dispatch) fn typed_counts(
+            &self,
+            capture: CaptureKey,
+            ty: MessageType,
+        ) -> (u64, u64, u64, u64) {
+            self.captures[capture.0 as usize].counters.typed(ty)
+        }
+    }
 
     // refresh_by_ifindex re-resolves only the interface(s) with the matching kernel index, reporting
     // the changed fields (`None` for an unwatched index). Resolution is unprivileged (no capture

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -171,6 +171,14 @@ impl InterfaceTable {
         self.captures[capture.0 as usize].counters.record(outcome);
     }
 
+    /// Each capture's `(interface name, counter row)` for the periodic report — the table owns the
+    /// capture→interface-name mapping, and stays log-free (the dispatcher does the logging).
+    pub(super) fn counter_rows(&self) -> impl Iterator<Item = (&str, &CaptureCounters)> {
+        self.captures
+            .iter()
+            .filter_map(move |entry| Some((self.interface_name(entry.interface)?, &entry.counters)))
+    }
+
     /// Re-resolve the interface with kernel index `ifindex`, in place. A real index matches at
     /// most one interface — they dedup by name, and the kernel gives each a distinct index —
     /// so this finds rather than scans. Returns the fields that changed if one matched, or `None`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,14 @@ pub fn run(args: &[String]) -> Result<()> {
             .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
     }
 
+    if let Some(interval) = config.counter_interval {
+        log::info!(
+            "packet counters enabled; reporting every {}s",
+            interval.as_secs()
+        );
+        dispatcher.enable_counter_report(interval, std::time::Instant::now());
+    }
+
     let mut reactor = Reactor::new()?;
     let watches = dispatcher.capture_watches();
     reactor.register_with_fds(Box::new(dispatcher), &watches)?;

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -77,6 +77,11 @@ pub(crate) trait Handler {
     /// a real clock.
     fn on_deadline(&mut self, _now: Instant, _reactor: &mut Reactor) {}
 
+    /// The run loop is broadcasting a [`ControlEvent`] to every handler — an out-of-band request
+    /// (currently a SIGUSR1 diagnostics dump), distinct from fd readiness and timers. Defaulted to a
+    /// no-op; a handler with state worth dumping overrides it.
+    fn on_control(&mut self, _event: ControlEvent, _reactor: &mut Reactor) {}
+
     /// Called once, right after [`register`](Reactor::register) inserts this handler, handing it its
     /// own [`HandlerKey`]. A handler that later watches fds it opens — or unregisters itself — records
     /// the key here. Defaulted to a no-op: most handlers act only through the `event` they are handed.
@@ -99,6 +104,14 @@ pub(crate) struct ReadyEvent {
     pub(crate) fd: RawFd,
     /// The opaque value the handler passed to [`watch`](Reactor::watch).
     pub(crate) user_data: u64,
+}
+
+/// An out-of-band control request the run loop broadcasts to every handler, separate from fd
+/// readiness and timer deadlines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ControlEvent {
+    /// Dump diagnostics: each handler logs whatever operational state it holds. Raised by SIGUSR1.
+    Dump,
 }
 
 /// A registered handler plus the keys of the fd-registrations that dispatch to it (so
@@ -125,12 +138,15 @@ struct Registration {
 pub(crate) struct Reactor {
     handlers: Arena<HandlerEntry>,
     registrations: Arena<Registration>,
-    /// Reused across deadline sweeps: the due handlers' keys, snapshotted so a handler firing
-    /// mid-sweep can touch the reactor without the buffer aliasing `&mut self`. Kept allocated so a
-    /// sweep doesn't allocate.
-    deadline_keys: Vec<Key>,
+    /// Reused across dispatch sweeps — deadline firing and control broadcasts — for the swept handlers'
+    /// keys, snapshotted so a handler firing mid-sweep can touch the reactor without the buffer aliasing
+    /// `&mut self`. Kept allocated so a sweep doesn't allocate.
+    dispatch_keys: Vec<Key>,
     poll: Poller,
     shutdown: bool,
+    /// Set by [`request_dump`](Self::request_dump) (the signal pipe, on SIGUSR1); the run loop
+    /// broadcasts a [`ControlEvent::Dump`] and clears it.
+    dump_pending: bool,
 }
 
 impl Reactor {
@@ -142,9 +158,10 @@ impl Reactor {
         Ok(Self {
             handlers: Arena::new(),
             registrations: Arena::new(),
-            deadline_keys: Vec::new(),
+            dispatch_keys: Vec::new(),
             poll: Poller::new(EVENT_CAPACITY)?,
             shutdown: false,
+            dump_pending: false,
         })
     }
 
@@ -362,15 +379,16 @@ impl Reactor {
     /// # Errors
     /// Returns an error if the shutdown handler cannot be installed or a wait fails.
     pub(crate) fn run(&mut self) -> io::Result<()> {
-        let (shutdown, pipe) = signal::ShutdownPipe::install()?;
+        let (guard, pipe) = signal::SignalGuard::install()?;
         let fd = pipe.read_fd();
         // The signal pipe is read-only with no per-fd token, so `user_data` is unused (0).
         let handler_key = self.register_with_fds(Box::new(pipe), &[(fd, 0)])?;
         self.shutdown = false;
+        self.dump_pending = false;
         let result = self.run_loop();
         // Restore the signal handlers and unpublish the write fd *before* closing
         // the read end, so a late signal can't write to a reader-less pipe.
-        drop(shutdown);
+        drop(guard);
         self.unregister(handler_key).ok();
         result
     }
@@ -383,6 +401,11 @@ impl Reactor {
             let deadline = self.next_deadline();
             let timeout = deadline.map(|d| d.saturating_duration_since(Instant::now()));
             self.poll_once(timeout)?;
+            // A signal handler may have set this via the signal pipe just dispatched; broadcast it now.
+            if self.dump_pending {
+                self.dump_pending = false;
+                self.dispatch_control(ControlEvent::Dump);
+            }
             // Sweep only if a deadline has actually come due — an fd wakeup before it leaves
             // `now < deadline`, so no scan.
             let now = Instant::now();
@@ -410,8 +433,8 @@ impl Reactor {
         // buffer borrow before the `&mut self` call; a handler that removes itself (or another due
         // handler) mid-sweep leaves a stale key, and the `get_mut` miss makes take and restore no-ops.
         // Deadline sweeps never nest, so one shared buffer suffices.
-        self.deadline_keys.clear();
-        self.deadline_keys.extend(
+        self.dispatch_keys.clear();
+        self.dispatch_keys.extend(
             self.handlers
                 .iter()
                 .filter(|(_, entry)| {
@@ -423,8 +446,8 @@ impl Reactor {
                 })
                 .map(|(key, _)| key),
         );
-        for i in 0..self.deadline_keys.len() {
-            let key = self.deadline_keys[i];
+        for i in 0..self.dispatch_keys.len() {
+            let key = self.dispatch_keys[i];
             // Gone if an earlier sweep in this pass removed it (its key went stale) — benign.
             let Some(mut handler) = self
                 .handlers
@@ -441,11 +464,45 @@ impl Reactor {
         }
     }
 
+    /// Broadcast `event` to every handler, taking each out for its call (as [`dispatch_deadlines`] and
+    /// [`dispatch`] do) so it can touch the reactor. Unconditional — a control request isn't tied to
+    /// any one handler. Shares the [`dispatch_keys`](Self::dispatch_keys) snapshot buffer with the
+    /// deadline sweep; the two never nest (the run loop runs them in sequence), so one buffer suffices.
+    ///
+    /// [`dispatch_deadlines`]: Self::dispatch_deadlines
+    /// [`dispatch`]: Self::dispatch
+    fn dispatch_control(&mut self, event: ControlEvent) {
+        self.dispatch_keys.clear();
+        self.dispatch_keys
+            .extend(self.handlers.iter().map(|(key, _)| key));
+        for i in 0..self.dispatch_keys.len() {
+            let key = self.dispatch_keys[i];
+            // Gone if an earlier handler in this pass removed it (its key went stale) — benign.
+            let Some(mut handler) = self
+                .handlers
+                .get_mut(key)
+                .and_then(|entry| entry.handler.take())
+            else {
+                continue;
+            };
+            handler.on_control(event, self);
+            if let Some(entry) = self.handlers.get_mut(key) {
+                entry.handler = Some(handler);
+            }
+        }
+    }
+
     /// Ask the run loop to stop once the current dispatch returns. Handlers call
     /// this (the self-pipe handler does, on a shutdown signal); calling it outside
     /// a run loop just arms the next one to exit immediately.
     pub(crate) fn request_shutdown(&mut self) {
         self.shutdown = true;
+    }
+
+    /// Ask the run loop to broadcast a [`ControlEvent::Dump`] to every handler once the current
+    /// dispatch returns. The signal pipe calls this on SIGUSR1.
+    pub(crate) fn request_dump(&mut self) {
+        self.dump_pending = true;
     }
 
     /// Deliver `readiness` to the fd that `reg_key` addresses — the seam
@@ -835,6 +892,52 @@ mod tests {
         (&peer).write_all(b"x").unwrap();
         reactor.run_loop().unwrap();
         assert!(reactor.shutdown);
+    }
+
+    /// Counts [`Handler::on_control`] broadcasts, for the SIGUSR1 dump fan-out tests.
+    struct ControlCounter(Rc<Cell<u32>>);
+
+    impl Handler for ControlCounter {
+        fn on_readable(&mut self, _event: ReadyEvent, _reactor: &mut Reactor) {}
+        fn on_control(&mut self, _event: ControlEvent, _reactor: &mut Reactor) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    #[test]
+    fn dispatch_control_reaches_every_handler() {
+        let mut reactor = Reactor::new().unwrap();
+        let count = Rc::new(Cell::new(0u32));
+        reactor.register(Box::new(ControlCounter(count.clone())));
+        reactor.register(Box::new(ControlCounter(count.clone())));
+        reactor.dispatch_control(ControlEvent::Dump);
+        assert_eq!(
+            count.get(),
+            2,
+            "every registered handler gets the control event"
+        );
+    }
+
+    #[test]
+    fn run_loop_broadcasts_a_pending_dump() {
+        let mut reactor = Reactor::new().unwrap();
+        let (a, peer) = pair();
+        let raw = a.as_raw_fd();
+        // On its read the trigger requests a dump and a shutdown, so the loop broadcasts once and exits.
+        let trigger = TestHandler::read(a, |_event, reactor| {
+            reactor.request_dump();
+            reactor.request_shutdown();
+        });
+        watch1(&mut reactor, trigger, raw);
+        let dumps = Rc::new(Cell::new(0u32));
+        reactor.register(Box::new(ControlCounter(dumps.clone())));
+        (&peer).write_all(b"x").unwrap();
+        reactor.run_loop().unwrap();
+        assert_eq!(
+            dumps.get(),
+            1,
+            "the pending dump broadcasts once before the loop stops"
+        );
     }
 
     #[test]

--- a/src/reactor/signal.rs
+++ b/src/reactor/signal.rs
@@ -1,34 +1,49 @@
-//! Self-pipe signal shutdown.
+//! Self-pipe signal handling: graceful shutdown (SIGINT/SIGTERM) and an on-demand
+//! diagnostics dump (SIGUSR1).
 //!
 //! A signal arrives at an arbitrary point and its handler may call only
 //! async-signal-safe functions, so it cannot touch the reactor (the arena, the
-//! logger, allocation — all off-limits). Instead the handler does the one safe
-//! thing it needs: `write` a byte to a pipe. The pipe's read end is registered
-//! with the reactor like any other fd, so the shutdown itself happens later, in
-//! normal code, when the loop wakes on it. This needs no per-backend signal
-//! support (no `signalfd` / `EVFILT_SIGNAL`) — the pipe is just a readable fd.
+//! logger, allocation — all off-limits). Instead the handler records which kind of
+//! signal arrived in an atomic flag and `write`s one byte to a pipe to wake the loop.
+//! The pipe's read end is registered with the reactor like any other fd, so the real
+//! work (a shutdown, or a counter dump) happens later, in normal code, when the loop
+//! wakes on it. This needs no per-backend signal support (no `signalfd` /
+//! `EVFILT_SIGNAL`) — the pipe is just a readable fd.
 
 use std::io;
 use std::mem;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::ptr;
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
 use libc::c_int;
 
 use super::{Handler, Reactor, ReadyEvent};
 
-/// Signals that request a graceful shutdown.
-const SHUTDOWN_SIGNALS: [c_int; 2] = [libc::SIGINT, libc::SIGTERM];
+/// The signal that requests an on-demand diagnostics dump (the counter summary).
+const DUMP_SIGNAL: c_int = libc::SIGUSR1;
+/// Every signal a [`SignalGuard`] installs a handler for: the two shutdown signals plus the dump one.
+const HANDLED_SIGNALS: [c_int; 3] = [libc::SIGINT, libc::SIGTERM, DUMP_SIGNAL];
 
 /// The write end of the installed self-pipe, or `-1` when none is installed. The
-/// handler reads this and writes a byte; [`ShutdownPipe`] owns the fd and is the
+/// handler reads this and writes a byte; [`SignalGuard`] owns the fd and is the
 /// only thing that sets this cell, and only one can exist at a time (single
 /// reactor, single thread).
 static WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+/// Set by the handler for a shutdown signal (SIGINT/SIGTERM); the pipe reader consumes it.
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+/// Set by the handler for [`DUMP_SIGNAL`]; the pipe reader consumes it.
+static DUMP_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// The signal handler: the one async-signal-safe action we need.
-extern "C" fn on_signal(_signum: c_int) {
+extern "C" fn on_signal(signum: c_int) {
+    // Record which kind arrived in an async-signal-safe atomic, then wake the loop. The pipe byte is
+    // a pure wakeup (its value carries nothing); these flags carry the intent.
+    if signum == DUMP_SIGNAL {
+        DUMP_REQUESTED.store(true, Ordering::Relaxed);
+    } else {
+        SHUTDOWN_REQUESTED.store(true, Ordering::Relaxed);
+    }
     let fd = WRITE_FD.load(Ordering::Relaxed);
     if fd >= 0 {
         let byte: u8 = 0;
@@ -44,20 +59,20 @@ extern "C" fn on_signal(_signum: c_int) {
 /// An installed self-pipe with the previous signal dispositions saved. Dropping it
 /// restores those dispositions, unpublishes the fd, and closes the write end — in
 /// that order, so no signal can reach a handler that points at a closed fd.
-pub(crate) struct ShutdownPipe {
+pub(crate) struct SignalGuard {
     /// Held only so its `OwnedFd` `Drop` closes the write end when the guard drops.
     _write_fd: OwnedFd,
-    saved_actions: [libc::sigaction; SHUTDOWN_SIGNALS.len()],
+    saved_actions: [libc::sigaction; HANDLED_SIGNALS.len()],
 }
 
-impl ShutdownPipe {
-    /// Create the self-pipe, publish its write end, and install the shutdown
-    /// handlers. Returns the guard plus the [`SignalPipe`] handler (owning the read
-    /// end) to register with the reactor.
+impl SignalGuard {
+    /// Create the self-pipe, publish its write end, and install the shutdown and dump handlers.
+    /// Returns the guard plus the [`SignalPipe`] handler (owning the read end) to register with the
+    /// reactor.
     ///
     /// # Errors
     /// Returns an error if the pipe cannot be created, a handler cannot be
-    /// installed, or a shutdown pipe is already installed.
+    /// installed, or a guard is already installed.
     pub(crate) fn install() -> io::Result<(Self, SignalPipe)> {
         let (read, write) = self_pipe()?;
         // Publish the write fd for the handler, refusing a second concurrent install.
@@ -65,9 +80,7 @@ impl ShutdownPipe {
             .compare_exchange(-1, write.as_raw_fd(), Ordering::SeqCst, Ordering::SeqCst)
             .is_err()
         {
-            return Err(io::Error::other(
-                "shutdown signal handler already installed",
-            ));
+            return Err(io::Error::other("signal handlers already installed"));
         }
         let saved = match install_handlers() {
             Ok(saved) => saved,
@@ -86,7 +99,7 @@ impl ShutdownPipe {
     }
 }
 
-impl Drop for ShutdownPipe {
+impl Drop for SignalGuard {
     fn drop(&mut self) {
         // Order matters: stop signals reaching our handler, then unpublish the fd;
         // `self._write_fd` closes last (after this body), when nothing can touch it.
@@ -111,16 +124,23 @@ impl SignalPipe {
 
 impl Handler for SignalPipe {
     fn on_readable(&mut self, _event: ReadyEvent, reactor: &mut Reactor) {
-        // Drain so a level-triggered wait does not keep re-reporting it.
+        // Drain so a level-triggered wait does not keep re-reporting it; the byte values carry
+        // nothing — the atomic flags carry which signal(s) arrived.
         let mut buf = [0u8; 16];
         let fd = self.read.as_raw_fd();
         // SAFETY: `self.read` is the registered, non-blocking read end; draining
         // stops at EOF (0) or EAGAIN (-1).
         while unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) } > 0 {}
-        // Once-per-process control event: tells the operator the daemon stopped on
-        // a signal, not a crash or self-termination.
-        log::info!("received shutdown signal; stopping");
-        reactor.request_shutdown();
+        // Shutdown wins if both arrived; a dump on the way out is harmless but pointless.
+        if SHUTDOWN_REQUESTED.swap(false, Ordering::Relaxed) {
+            // Tells the operator the daemon stopped on a signal, not a crash or self-termination.
+            log::info!("received shutdown signal; stopping");
+            reactor.request_shutdown();
+        }
+        if DUMP_REQUESTED.swap(false, Ordering::Relaxed) {
+            log::info!("received SIGUSR1; dumping diagnostics");
+            reactor.request_dump();
+        }
     }
 }
 
@@ -157,9 +177,9 @@ fn self_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     Ok((read, write))
 }
 
-/// Install [`on_signal`] for every shutdown signal, returning the previous
+/// Install [`on_signal`] for every handled signal, returning the previous
 /// dispositions to restore later. Rolls back on partial failure.
-fn install_handlers() -> io::Result<[libc::sigaction; SHUTDOWN_SIGNALS.len()]> {
+fn install_handlers() -> io::Result<[libc::sigaction; HANDLED_SIGNALS.len()]> {
     // SAFETY: an all-zero `sigaction` is a valid SIG_DFL disposition we overwrite.
     let mut action: libc::sigaction = unsafe { mem::zeroed() };
     // A function item can't cast straight to an integer; route through a pointer.
@@ -169,8 +189,8 @@ fn install_handlers() -> io::Result<[libc::sigaction; SHUTDOWN_SIGNALS.len()]> {
     unsafe { libc::sigemptyset(&raw mut action.sa_mask) };
 
     // SAFETY: zeroed `sigaction`s, each filled by its call's oldact out-param.
-    let mut saved: [libc::sigaction; SHUTDOWN_SIGNALS.len()] = unsafe { mem::zeroed() };
-    for (i, &signum) in SHUTDOWN_SIGNALS.iter().enumerate() {
+    let mut saved: [libc::sigaction; HANDLED_SIGNALS.len()] = unsafe { mem::zeroed() };
+    for (i, &signum) in HANDLED_SIGNALS.iter().enumerate() {
         // SAFETY: valid signal number with valid act / oldact pointers.
         let rc = unsafe { libc::sigaction(signum, &raw const action, &raw mut saved[i]) };
         if rc != 0 {
@@ -184,7 +204,7 @@ fn install_handlers() -> io::Result<[libc::sigaction; SHUTDOWN_SIGNALS.len()]> {
 
 /// Restore previously-saved signal dispositions (best effort — errors ignored).
 fn restore_handlers(saved: &[libc::sigaction]) {
-    for (&signum, action) in SHUTDOWN_SIGNALS.iter().zip(saved) {
+    for (&signum, action) in HANDLED_SIGNALS.iter().zip(saved) {
         // SAFETY: `action` is a disposition a prior `sigaction` produced.
         unsafe { libc::sigaction(signum, action, ptr::null_mut()) };
     }
@@ -219,22 +239,33 @@ mod tests {
     // The one test that touches process-global signal state, so it cannot race a
     // sibling: nothing else here installs handlers.
     #[test]
-    fn installed_handler_writes_on_signal() {
-        let (guard, pipe) = ShutdownPipe::install().unwrap();
+    fn installed_handler_flags_shutdown_and_dump() {
+        let (guard, pipe) = SignalGuard::install().unwrap();
 
-        // Our handler must catch SIGINT (write a byte), not terminate the process.
+        // Our handlers must catch these (set a flag, wake the pipe), not terminate the process:
+        // SIGINT flags a shutdown, SIGUSR1 flags a dump.
         // SAFETY: `raise` just delivers a signal to the current process.
-        let raised = unsafe { libc::raise(libc::SIGINT) };
-        assert_eq!(raised, 0);
+        assert_eq!(unsafe { libc::raise(libc::SIGINT) }, 0);
+        // SAFETY: as above — deliver SIGUSR1 to ourselves.
+        assert_eq!(unsafe { libc::raise(DUMP_SIGNAL) }, 0);
 
-        let mut buf = [0u8; 4];
+        let mut buf = [0u8; 8];
         // SAFETY: read up to `buf.len()` bytes into `buf` from the valid read-end fd.
         let n = unsafe { libc::read(pipe.read_fd(), buf.as_mut_ptr().cast(), buf.len()) };
-        assert!(n >= 1);
+        assert!(n >= 1, "each signal wakes the pipe");
+        // Consume the flags (as the pipe reader would), asserting each was set.
+        assert!(
+            SHUTDOWN_REQUESTED.swap(false, Ordering::Relaxed),
+            "SIGINT set the shutdown flag"
+        );
+        assert!(
+            DUMP_REQUESTED.swap(false, Ordering::Relaxed),
+            "SIGUSR1 set the dump flag"
+        );
 
         // A second install while the first guard holds the write fd is refused.
-        assert!(ShutdownPipe::install().is_err());
+        assert!(SignalGuard::install().is_err());
 
-        drop(guard); // restores the previous SIGINT/SIGTERM dispositions
+        drop(guard); // restores the previous dispositions
     }
 }

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -20,19 +20,21 @@ use std::net::SocketAddr;
 use thiserror::Error;
 
 use crate::config::AddressFamily;
-use crate::dispatch::{CaptureKey, PacketDispatcher};
+use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher};
 use crate::interface::InterfaceAddresses;
 use crate::reactor::Reactor;
 
-/// A reflector's verdict on a captured payload, from its protocol's classifier.
+/// A reflector's verdict on a captured payload, from its protocol's classifier. `Reflect`/`Skip` carry
+/// the message's own [`MessageType`] (the packet's *intrinsic* type, from the classifier) so the handler
+/// can tally it — see [`From`] impls like `From<MdnsKind>` in each protocol reflector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Verdict {
     /// A message for this direction — re-emit it.
-    Reflect,
+    Reflect(MessageType),
     /// A message for the *other* direction — drop it silently. Dropping the opposite direction is
     /// the loop-breaker (atop the capture's own-egress drop): a reflected query re-emitted on the
     /// egress is still a query, which the egress side's response-only reflector skips.
-    Skip,
+    Skip(MessageType),
     /// Not a recognizable protocol message on this dedicated group — drop it with a debug log.
     Junk,
 }

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -8,17 +8,28 @@
 use std::net::SocketAddr;
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{Filter, IpSet, PacketDispatcher};
+use crate::dispatch::{Filter, IpSet, MessageType, PacketDispatcher};
 use crate::net::mdns::{MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT, MDNS_TTL, MdnsKind, classify};
 
 use super::{BuildError, InterfaceMap, SimpleReflector, Verdict, require_bidirectional_families};
 
+/// mDNS's classifier kind *is* its message type — `Query`/`Response` map straight across.
+impl From<MdnsKind> for MessageType {
+    fn from(kind: MdnsKind) -> Self {
+        match kind {
+            MdnsKind::Query => Self::MdnsQuery,
+            MdnsKind::Response => Self::MdnsResponse,
+        }
+    }
+}
+
 /// The directional gate for the source → target reflector: reflect queries, skip responses (they
-/// flow the other way), and treat a too-short / non-DNS payload on the group as junk.
+/// flow the other way), and treat a too-short / non-DNS payload on the group as junk. The verdict
+/// carries the packet's own message type (via [`From<MdnsKind>`]) for the counters.
 fn query_verdict(payload: &[u8]) -> Verdict {
     match classify(payload) {
-        Some(MdnsKind::Query) => Verdict::Reflect,
-        Some(MdnsKind::Response) => Verdict::Skip,
+        Some(kind @ MdnsKind::Query) => Verdict::Reflect(kind.into()),
+        Some(kind @ MdnsKind::Response) => Verdict::Skip(kind.into()),
         None => Verdict::Junk,
     }
 }
@@ -26,8 +37,8 @@ fn query_verdict(payload: &[u8]) -> Verdict {
 /// The directional gate for the target → source reflector: the mirror of [`query_verdict`].
 fn response_verdict(payload: &[u8]) -> Verdict {
     match classify(payload) {
-        Some(MdnsKind::Query) => Verdict::Skip,
-        Some(MdnsKind::Response) => Verdict::Reflect,
+        Some(kind @ MdnsKind::Query) => Verdict::Skip(kind.into()),
+        Some(kind @ MdnsKind::Response) => Verdict::Reflect(kind.into()),
         None => Verdict::Junk,
     }
 }
@@ -152,11 +163,23 @@ mod tests {
         let query = [0u8; 12];
         let mut response = [0u8; 12];
         response[2] = 0x80;
-        assert_eq!(query_verdict(&query), Verdict::Reflect);
-        assert_eq!(query_verdict(&response), Verdict::Skip);
+        assert_eq!(
+            query_verdict(&query),
+            Verdict::Reflect(MessageType::MdnsQuery)
+        );
+        assert_eq!(
+            query_verdict(&response),
+            Verdict::Skip(MessageType::MdnsResponse)
+        );
         assert_eq!(query_verdict(&[0u8; 4]), Verdict::Junk);
-        assert_eq!(response_verdict(&query), Verdict::Skip);
-        assert_eq!(response_verdict(&response), Verdict::Reflect);
+        assert_eq!(
+            response_verdict(&query),
+            Verdict::Skip(MessageType::MdnsQuery)
+        );
+        assert_eq!(
+            response_verdict(&response),
+            Verdict::Reflect(MessageType::MdnsResponse)
+        );
         assert_eq!(response_verdict(&[0u8; 4]), Verdict::Junk);
     }
 }

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -13,7 +13,9 @@
 use std::net::{IpAddr, SocketAddr};
 use std::time::{Duration, Instant};
 
-use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler, RegistrationKey};
+use crate::dispatch::{
+    CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, RegistrationKey,
+};
 use crate::interface::{InterfaceAddresses, Ipv6Scope};
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
@@ -48,6 +50,8 @@ struct ResponseReflector {
     egress: CaptureKey,
     /// Protocol label for logs, e.g. `"SSDP"`.
     name: &'static str,
+    /// This reply leg's message type, for the counters (e.g. [`MessageType::SsdpResponse`]).
+    message_type: MessageType,
     ttl: u8,
     reply: Box<dyn ReplyRewrite>,
 }
@@ -58,10 +62,10 @@ impl PacketHandler for ResponseReflector {
         packet: &Packet,
         dispatcher: &mut PacketDispatcher,
         reactor: &mut Reactor,
-    ) {
+    ) -> Outcome {
         // The dispatcher's filter already pinned this capture to the reserved port, so every packet
         // here is a unicast reply for this searcher — nothing to classify. A family the source can't
-        // currently send is a quiet drop (transient address loss).
+        // currently send is a quiet, transient drop (address loss) — Stalled, not a failure.
         if !egress_sources(dispatcher, self.egress, self.searcher) {
             log::debug!(
                 "{}: egress has no source for searcher {} yet; dropping response from {}",
@@ -69,7 +73,7 @@ impl PacketHandler for ResponseReflector {
                 self.searcher,
                 packet.source
             );
-            return;
+            return Outcome::Stalled(self.message_type);
         }
         let payload = self
             .reply
@@ -82,17 +86,23 @@ impl PacketHandler for ResponseReflector {
             self.ttl,
             payload,
         ) {
-            Ok(()) => log::debug!(
-                "reflected {} response from {} to searcher {}",
-                self.name,
-                packet.source,
-                self.searcher
-            ),
-            Err(e) => log::warn!(
-                "{}: cannot reflect response to searcher {}: {e}",
-                self.name,
-                self.searcher
-            ),
+            Ok(()) => {
+                log::debug!(
+                    "reflected {} response from {} to searcher {}",
+                    self.name,
+                    packet.source,
+                    self.searcher
+                );
+                Outcome::Reflected(self.message_type)
+            }
+            Err(e) => {
+                log::warn!(
+                    "{}: cannot reflect response to searcher {}: {e}",
+                    self.name,
+                    self.searcher
+                );
+                Outcome::Dropped(self.message_type)
+            }
         }
     }
 }
@@ -118,6 +128,8 @@ pub(crate) struct SearchReflector {
     device_macs: Option<MacSet>,
     /// Protocol label for logs, e.g. `"SSDP"`.
     name: &'static str,
+    /// The reply leg's message type, handed to each session's [`ResponseReflector`] for the counters.
+    response_type: MessageType,
     /// The TTL each reflected search and reply is re-emitted at.
     ttl: u8,
     /// The ingress gate: is this payload a search for this direction?
@@ -137,6 +149,7 @@ impl SearchReflector {
         target_ifindex: u32,
         device_macs: Option<MacSet>,
         name: &'static str,
+        response_type: MessageType,
         ttl: u8,
         classify: fn(&[u8]) -> Verdict,
         window: fn(&[u8]) -> Duration,
@@ -148,6 +161,7 @@ impl SearchReflector {
             target_ifindex,
             device_macs,
             name,
+            response_type,
             ttl,
             classify,
             window,
@@ -158,21 +172,24 @@ impl SearchReflector {
 
     /// Open a session for a new searcher: reserve an ephemeral port on the target's own address of the
     /// search's family and register the reply capture there — before the caller reflects, so a fast
-    /// responder can't beat the capture. `None` (logged) if the cap is hit, the frame carries no
-    /// source MAC to reply to, the target has no address of that family, or the reservation fails.
+    /// responder can't beat the capture. `message_type` is the search's own type, carried on the
+    /// failure outcomes. `Err` (logged): the target has no source address of the search's family yet —
+    /// [`Outcome::Stalled`] (transient / best-effort v6) — or a real inability to open the session
+    /// (session cap, no source MAC to reply to, reservation failure) — [`Outcome::Dropped`].
     fn make_session(
         &self,
         packet: &Packet,
         dispatcher: &mut PacketDispatcher,
         expiry: Instant,
-    ) -> Option<Session> {
+        message_type: MessageType,
+    ) -> Result<Session, Outcome> {
         if self.sessions.len() >= MAX_SESSIONS {
             log::warn!(
                 "{}: dropping search from {}: {MAX_SESSIONS} sessions in flight (cap)",
                 self.name,
                 packet.source
             );
-            return None;
+            return Err(Outcome::Dropped(message_type));
         }
         let Some(searcher_mac) = packet.src_mac else {
             log::warn!(
@@ -180,7 +197,7 @@ impl SearchReflector {
                 self.name,
                 packet.source
             );
-            return None;
+            return Err(Outcome::Dropped(message_type));
         };
         // The replies come to the address the reflected search is sourced from, at the reserved port —
         // so this must be the same scope-matched pick `build_udp` makes for `packet.dest`, or the
@@ -197,12 +214,12 @@ impl SearchReflector {
         };
         let Some(our_addr) = our_addr else {
             log::warn!(
-                "{}: cannot reflect search from {}: target has no source address for {}",
+                "{}: cannot reflect search from {}: target has no source address for {} yet",
                 self.name,
                 packet.source,
                 packet.dest.ip()
             );
-            return None;
+            return Err(Outcome::Stalled(message_type));
         };
         let reservation = match PortReservation::create(our_addr, self.target_ifindex) {
             Ok(reservation) => reservation,
@@ -212,7 +229,7 @@ impl SearchReflector {
                     self.name,
                     packet.source
                 );
-                return None;
+                return Err(Outcome::Dropped(message_type));
             }
         };
         // Register before the reflect so a fast responder's reply is captured, not ICMP-rejected.
@@ -229,11 +246,12 @@ impl SearchReflector {
                 searcher_mac,
                 egress: self.source,
                 name: self.name,
+                message_type: self.response_type,
                 ttl: self.ttl,
                 reply: (self.make_reply)(),
             }),
         );
-        Some(Session {
+        Ok(Session {
             searcher: packet.source,
             expiry,
             reservation,
@@ -248,11 +266,11 @@ impl PacketHandler for SearchReflector {
         packet: &Packet,
         dispatcher: &mut PacketDispatcher,
         _reactor: &mut Reactor,
-    ) {
-        match (self.classify)(packet.payload) {
-            Verdict::Reflect => {}
+    ) -> Outcome {
+        let message_type = match (self.classify)(packet.payload) {
+            Verdict::Reflect(message_type) => message_type,
             // A message for the other direction (an announcement) flows through that reflector.
-            Verdict::Skip => return,
+            Verdict::Skip(message_type) => return Outcome::Skipped(message_type),
             Verdict::Junk => {
                 log::debug!(
                     "{}: dropping unrecognized payload ({} B) on the search path from {}",
@@ -260,9 +278,9 @@ impl PacketHandler for SearchReflector {
                     packet.payload.len(),
                     packet.source
                 );
-                return;
+                return Outcome::Filtered;
             }
-        }
+        };
         let expiry = Instant::now() + (self.window)(packet.payload);
 
         // A retransmit from a known searcher reuses its session: refresh the window and re-reflect from
@@ -273,7 +291,7 @@ impl PacketHandler for SearchReflector {
             .find(|s| s.searcher == packet.source)
         {
             let port = session.reservation.port();
-            match dispatcher.send_udp_group(
+            return match dispatcher.send_udp_group(
                 self.target,
                 packet.dest,
                 port,
@@ -288,19 +306,23 @@ impl PacketHandler for SearchReflector {
                         packet.source,
                         packet.dest
                     );
+                    Outcome::Reflected(message_type)
                 }
-                Err(e) => log::warn!(
-                    "{}: cannot reflect search from {} to {}: {e}",
-                    self.name,
-                    packet.source,
-                    packet.dest
-                ),
-            }
-            return;
+                Err(e) => {
+                    log::warn!(
+                        "{}: cannot reflect search from {} to {}: {e}",
+                        self.name,
+                        packet.source,
+                        packet.dest
+                    );
+                    Outcome::Dropped(message_type)
+                }
+            };
         }
 
-        let Some(session) = self.make_session(packet, dispatcher, expiry) else {
-            return; // make_session logged the cause
+        let session = match self.make_session(packet, dispatcher, expiry, message_type) {
+            Ok(session) => session,
+            Err(outcome) => return outcome, // make_session logged the cause
         };
         let port = session.reservation.port();
         match dispatcher.send_udp_group(self.target, packet.dest, port, self.ttl, packet.payload) {
@@ -313,6 +335,7 @@ impl PacketHandler for SearchReflector {
                     packet.dest,
                     self.sessions.len()
                 );
+                Outcome::Reflected(message_type)
             }
             Err(e) => {
                 // Roll back the response capture just registered; the reservation drops with `session`.
@@ -323,6 +346,7 @@ impl PacketHandler for SearchReflector {
                     packet.dest
                 );
                 dispatcher.unregister(session.response_key);
+                Outcome::Dropped(message_type)
             }
         }
     }
@@ -366,7 +390,7 @@ mod tests {
     /// A trivial ingress gate: every payload is a search. The session bookkeeping under test is
     /// independent of how a protocol classifies.
     fn always_reflect(_: &[u8]) -> Verdict {
-        Verdict::Reflect
+        Verdict::Reflect(MessageType::SsdpSearch)
     }
 
     /// A fixed session window, standing in for a protocol's window policy.
@@ -381,6 +405,7 @@ mod tests {
             0,
             None,
             "TEST",
+            MessageType::SsdpResponse,
             TEST_TTL,
             always_reflect,
             fixed_window,
@@ -409,6 +434,7 @@ mod tests {
                 searcher_mac: MacAddr::from([0; 6]),
                 egress: source,
                 name: "TEST",
+                message_type: MessageType::SsdpResponse,
                 ttl: TEST_TTL,
                 reply: Box::new(NoRewrite),
             }),

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -6,7 +6,7 @@
 //! advertisement direction rewrites the DIAL `LOCATION`). The search directions are stateful
 //! (per-searcher sessions), so they use the shared `SearchReflector` instead.
 
-use crate::dispatch::{CaptureKey, PacketDispatcher, PacketHandler};
+use crate::dispatch::{CaptureKey, Outcome, PacketDispatcher, PacketHandler};
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
 
@@ -64,55 +64,61 @@ impl PacketHandler for SimpleReflector {
         packet: &Packet,
         dispatcher: &mut PacketDispatcher,
         reactor: &mut Reactor,
-    ) {
-        match (self.classify)(packet.payload) {
-            Verdict::Reflect => {
-                // A family the egress can't currently source is a quiet drop (transient address
-                // loss), so send_udp_group's error stays a genuine failure.
-                if !egress_sources(dispatcher, self.egress, packet.dest) {
-                    log::debug!(
-                        "{}: egress has no source for {} yet; dropping {} from {}",
-                        self.name,
-                        packet.dest,
-                        self.kind,
-                        packet.source
-                    );
-                    return;
-                }
-                let payload =
-                    self.rewrite
-                        .rewrite(packet.payload, self.egress, dispatcher, reactor);
-                match dispatcher.send_udp_group(
-                    self.egress,
+    ) -> Outcome {
+        let message_type = match (self.classify)(packet.payload) {
+            Verdict::Reflect(message_type) => message_type,
+            Verdict::Skip(message_type) => return Outcome::Skipped(message_type),
+            Verdict::Junk => {
+                log::debug!(
+                    "{}: dropping unrecognized payload ({} B) to {} from {}",
+                    self.name,
+                    packet.payload.len(),
                     packet.dest,
-                    self.src_port,
-                    self.ttl,
-                    payload,
-                ) {
-                    Ok(()) => log::debug!(
-                        "reflected {} {} from {} to {}",
-                        self.name,
-                        self.kind,
-                        packet.source,
-                        packet.dest
-                    ),
-                    Err(e) => log::warn!(
-                        "{}: cannot reflect {} from {} to {}: {e}",
-                        self.name,
-                        self.kind,
-                        packet.source,
-                        packet.dest
-                    ),
-                }
+                    packet.source
+                );
+                return Outcome::Filtered;
             }
-            Verdict::Skip => {}
-            Verdict::Junk => log::debug!(
-                "{}: dropping unrecognized payload ({} B) to {} from {}",
+        };
+
+        // A family the egress can't currently source is a quiet, transient drop (address
+        // loss) — a Stalled, not a genuine send failure.
+        if !egress_sources(dispatcher, self.egress, packet.dest) {
+            log::debug!(
+                "{}: egress has no source for {} yet; dropping {} from {}",
                 self.name,
-                packet.payload.len(),
                 packet.dest,
+                self.kind,
                 packet.source
-            ),
+            );
+            return Outcome::Stalled(message_type);
+        }
+
+        let payload = self
+            .rewrite
+            .rewrite(packet.payload, self.egress, dispatcher, reactor);
+
+        match dispatcher.send_udp_group(self.egress, packet.dest, self.src_port, self.ttl, payload)
+        {
+            Ok(()) => {
+                log::debug!(
+                    "reflected {} {} from {} to {}",
+                    self.name,
+                    self.kind,
+                    packet.source,
+                    packet.dest
+                );
+                Outcome::Reflected(message_type)
+            }
+            Err(e) => {
+                log::warn!(
+                    "{}: cannot reflect {} from {} to {}: {e}",
+                    self.name,
+                    self.kind,
+                    packet.source,
+                    packet.dest
+                );
+                Outcome::Dropped(message_type)
+            }
         }
     }
 }

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{CaptureKey, Filter, IpSet, PacketDispatcher};
+use crate::dispatch::{CaptureKey, Filter, IpSet, MessageType, PacketDispatcher};
 use crate::interface::InterfaceAddresses;
 use crate::net::ssdp::{
     MSEARCH_MX_DEFAULT, SSDP_GROUP_V4, SSDP_GROUP_V6_LINK_LOCAL, SSDP_GROUP_V6_SITE_LOCAL,
@@ -93,12 +93,23 @@ impl ReplyRewrite for DialRewrite {
     }
 }
 
+/// SSDP's classifier kind maps to its two group message types. The unicast `200 OK` reply is a
+/// separate leg ([`MessageType::SsdpResponse`]), carried by the response reflector, not the classifier.
+impl From<SsdpKind> for MessageType {
+    fn from(kind: SsdpKind) -> Self {
+        match kind {
+            SsdpKind::Advertisement => Self::SsdpAdvertisement,
+            SsdpKind::Search => Self::SsdpSearch,
+        }
+    }
+}
+
 /// The directional gate for the advertisement leg: a `NOTIFY` is an advertisement to reflect, an
 /// `M-SEARCH` belongs to the search direction, and anything else on the group is junk.
 fn advertisement_verdict(payload: &[u8]) -> Verdict {
     match classify(payload) {
-        Some(SsdpKind::Advertisement) => Verdict::Reflect,
-        Some(SsdpKind::Search) => Verdict::Skip,
+        Some(kind @ SsdpKind::Advertisement) => Verdict::Reflect(kind.into()),
+        Some(kind @ SsdpKind::Search) => Verdict::Skip(kind.into()),
         None => Verdict::Junk,
     }
 }
@@ -107,8 +118,8 @@ fn advertisement_verdict(payload: &[u8]) -> Verdict {
 /// the advertisement direction, and anything else on the group is junk.
 fn search_verdict(payload: &[u8]) -> Verdict {
     match classify(payload) {
-        Some(SsdpKind::Search) => Verdict::Reflect,
-        Some(SsdpKind::Advertisement) => Verdict::Skip,
+        Some(kind @ SsdpKind::Search) => Verdict::Reflect(kind.into()),
+        Some(kind @ SsdpKind::Advertisement) => Verdict::Skip(kind.into()),
         None => Verdict::Junk,
     }
 }
@@ -225,6 +236,7 @@ pub(crate) fn build(
             target_ifindex,
             reflector.macs.clone(),
             "SSDP",
+            MessageType::SsdpResponse,
             SSDP_TTL,
             search_verdict,
             search_window,
@@ -278,5 +290,29 @@ mod tests {
             used_groups(AddressFamily::Ipv6),
             vec![link_local, site_local]
         );
+    }
+
+    #[test]
+    fn verdicts_gate_by_direction() {
+        let notify = b"NOTIFY * HTTP/1.1\r\n";
+        let msearch = b"M-SEARCH * HTTP/1.1\r\n";
+        assert_eq!(
+            advertisement_verdict(notify),
+            Verdict::Reflect(MessageType::SsdpAdvertisement)
+        );
+        assert_eq!(
+            advertisement_verdict(msearch),
+            Verdict::Skip(MessageType::SsdpSearch)
+        );
+        assert_eq!(advertisement_verdict(b"junk"), Verdict::Junk);
+        assert_eq!(
+            search_verdict(msearch),
+            Verdict::Reflect(MessageType::SsdpSearch)
+        );
+        assert_eq!(
+            search_verdict(notify),
+            Verdict::Skip(MessageType::SsdpAdvertisement)
+        );
+        assert_eq!(search_verdict(b"junk"), Verdict::Junk);
     }
 }

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -9,7 +9,9 @@
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{CaptureKey, Filter, PacketDispatcher, PacketHandler, PortSet};
+use crate::dispatch::{
+    CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, PortSet,
+};
 use crate::net::mac::MacSet;
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
@@ -44,26 +46,26 @@ impl PacketHandler for WolReflector {
         packet: &Packet,
         dispatcher: &mut PacketDispatcher,
         _reactor: &mut Reactor,
-    ) {
+    ) -> Outcome {
         if !is_magic_packet(packet.payload, self.target_macs.as_ref()) {
             log::debug!("WoL: ignoring non-magic packet from {}", packet.source);
-            return;
+            return Outcome::Filtered;
         }
         let Some(dst) = wol_destination(self.family, packet) else {
             log::debug!(
                 "WoL: {} is not a handled address family; ignoring",
                 packet.source
             );
-            return;
+            return Outcome::Filtered;
         };
-        // A family the egress can't currently source is a quiet drop (a transient address loss);
-        // that keeps send_udp_group's error meaning a genuine build/send failure.
+        // A family the egress can't currently source is a quiet, transient drop (address loss) —
+        // Stalled, not a genuine send failure.
         if !egress_sources(dispatcher, self.egress, dst) {
             log::debug!(
                 "WoL: egress has no source for {dst} yet; dropping wake from {}",
                 packet.source
             );
-            return;
+            return Outcome::Stalled(MessageType::WakeOnLan);
         }
         match dispatcher.send_udp_group(
             self.egress,
@@ -72,11 +74,17 @@ impl PacketHandler for WolReflector {
             packet.ttl,
             packet.payload,
         ) {
-            Ok(()) => log::debug!("reflected WoL packet from {} to {dst}", packet.source),
-            Err(e) => log::warn!(
-                "WoL: cannot reflect packet from {} to {dst}: {e}",
-                packet.source
-            ),
+            Ok(()) => {
+                log::debug!("reflected WoL packet from {} to {dst}", packet.source);
+                Outcome::Reflected(MessageType::WakeOnLan)
+            }
+            Err(e) => {
+                log::warn!(
+                    "WoL: cannot reflect packet from {} to {dst}: {e}",
+                    packet.source
+                );
+                Outcome::Dropped(MessageType::WakeOnLan)
+            }
         }
     }
 }

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{Filter, IpSet, PacketDispatcher};
+use crate::dispatch::{Filter, IpSet, MessageType, PacketDispatcher};
 use crate::net::wsd::{WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT, WSD_TTL, WsdKind, classify};
 
 use super::{
@@ -17,12 +17,23 @@ use super::{
     require_bidirectional_families,
 };
 
+/// WSD's classifier kind maps to its group message types. The `ProbeMatches`/`ResolveMatches` unicast
+/// replies are a separate leg ([`MessageType::WsdResponse`]), carried by the response reflector.
+impl From<WsdKind> for MessageType {
+    fn from(kind: WsdKind) -> Self {
+        match kind {
+            WsdKind::Announcement => Self::WsdAnnouncement,
+            WsdKind::Search => Self::WsdSearch,
+        }
+    }
+}
+
 /// The directional gate for the announcement direction: reflect `Hello` / `Bye`, skip a search (it
 /// flows the other way), and treat anything else on the group as junk.
 fn announcement_verdict(payload: &[u8]) -> Verdict {
     match classify(payload) {
-        Some(WsdKind::Announcement) => Verdict::Reflect,
-        Some(WsdKind::Search) => Verdict::Skip,
+        Some(kind @ WsdKind::Announcement) => Verdict::Reflect(kind.into()),
+        Some(kind @ WsdKind::Search) => Verdict::Skip(kind.into()),
         None => Verdict::Junk,
     }
 }
@@ -30,8 +41,8 @@ fn announcement_verdict(payload: &[u8]) -> Verdict {
 /// The directional gate for the search direction: the mirror of [`announcement_verdict`].
 fn search_verdict(payload: &[u8]) -> Verdict {
     match classify(payload) {
-        Some(WsdKind::Search) => Verdict::Reflect,
-        Some(WsdKind::Announcement) => Verdict::Skip,
+        Some(kind @ WsdKind::Search) => Verdict::Reflect(kind.into()),
+        Some(kind @ WsdKind::Announcement) => Verdict::Skip(kind.into()),
         None => Verdict::Junk,
     }
 }
@@ -125,6 +136,7 @@ pub(crate) fn build(
             target_ifindex,
             reflector.macs.clone(),
             "WSD",
+            MessageType::WsdResponse,
             WSD_TTL,
             search_verdict,
             window,
@@ -172,11 +184,23 @@ mod tests {
     fn verdicts_gate_by_direction() {
         let hello = b"<a:Action>http://x/Hello</a:Action>";
         let probe = b"<a:Action>http://x/Probe</a:Action>";
-        assert_eq!(announcement_verdict(hello), Verdict::Reflect);
-        assert_eq!(announcement_verdict(probe), Verdict::Skip);
+        assert_eq!(
+            announcement_verdict(hello),
+            Verdict::Reflect(MessageType::WsdAnnouncement)
+        );
+        assert_eq!(
+            announcement_verdict(probe),
+            Verdict::Skip(MessageType::WsdSearch)
+        );
         assert_eq!(announcement_verdict(b"junk"), Verdict::Junk);
-        assert_eq!(search_verdict(probe), Verdict::Reflect);
-        assert_eq!(search_verdict(hello), Verdict::Skip);
+        assert_eq!(
+            search_verdict(probe),
+            Verdict::Reflect(MessageType::WsdSearch)
+        );
+        assert_eq!(
+            search_verdict(hello),
+            Verdict::Skip(MessageType::WsdAnnouncement)
+        );
         assert_eq!(search_verdict(b"junk"), Verdict::Junk);
     }
 }


### PR DESCRIPTION
Adds per-interface observability counters — what the reflector did with each packet, tallied per message type and interface — answering the "is it working / what's crossing?" support question.

## What
- Handlers return an `Outcome` (Reflected/Skipped/Dropped/Stalled/Filtered); `route()` folds all matched handlers' outcomes and records one tally per packet on the ingress interface's row. Counters live in each `CaptureEntry`, so they can't desync from the capture set (one push adds both).
- **Periodic summary:** one `info` line per interface, nonzero fields only, enabled by `counters_interval_secs` (TOML + `REFLECTOR_COUNTERS_INTERVAL_SECS`; `0`/absent disables). Counters always record; this only controls reporting.
- **On-demand SIGUSR1 dump**, independent of the periodic interval, delivered via a generic reactor `ControlEvent` broadcast so the reactor stays domain-agnostic.

## Testing
- 382 unit tests.
- Linux e2e (Docker): the periodic summary accruing across intervals, and the SIGUSR1 dump.
- Native macOS signal-integration check.
