### PR TITLE
BREAKING: make debug_memory a configurable interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,12 @@ side — enabling container mode, creating the `veth`s, and attaching each to it
 `config.toml` contains optional top-level settings plus at least one reflector entry. Entries are tables
 under `reflectors`, keyed by name (`[reflectors.<name>]`) — the name is the label used in logs — each
 describing one `source_if` → `target_if` bridge that enables any combination of the protocols. The
-top-level settings are `log_level`, `debug_memory`, and `counters_interval_secs`:
+top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_interval_secs`:
 
 ```toml
-log_level = "info"               # optional; one of debug | info | warning | error (default: info)
-debug_memory = false             # optional; periodically log RSS + heap stats for footprint debugging (default false)
-counters_interval_secs = 0       # optional; seconds between per-interface packet-counter summaries; 0 disables (default 0)
+log_level = "info"                 # optional; one of debug | info | warning | error (default: info)
+debug_memory_interval_secs = 0     # optional; seconds between memory (RSS/peak) diagnostic reports; 0 disables (default 0)
+counters_interval_secs = 0         # optional; seconds between per-interface packet-counter summaries; 0 disables (default 0)
 
 [reflectors.tv]
 source_if = "en0"                # required; interface to listen on (must differ from target_if)
@@ -261,8 +261,9 @@ then optional; with none, the environment is the whole configuration. Variables 
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
   `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
 
-The globals are `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY`, and `REFLECTOR_COUNTERS_INTERVAL_SECS`,
-so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are `true`/`false` or `1`/`0`; `WOL_PORTS`
+The globals are `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
+`REFLECTOR_COUNTERS_INTERVAL_SECS`, so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are
+`true`/`false` or `1`/`0`; `WOL_PORTS`
 and `MACS` are comma-separated (`7,9` / `B0:...,C4:...`). The `[reflectors.tv]` entry above looks like
 this in the environment:
 
@@ -279,8 +280,9 @@ REFLECTOR_TV_WSD=true
 ```
 
 When a file and environment variables are both given they are merged: each contributes entries to one
-combined configuration, and each global variable (`REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY`,
-`REFLECTOR_COUNTERS_INTERVAL_SECS`) overrides its file counterpart. The
+combined configuration, and each global variable (`REFLECTOR_LOG_LEVEL`,
+`REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, `REFLECTOR_COUNTERS_INTERVAL_SECS`) overrides its file
+counterpart. The
 [duplicate detection](#duplicate-detection) below applies across both
 sources. An unknown `<PARAM>`, a non-alphanumeric or reserved tag, and a tag with no parameter are all
 rejected at startup.

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,8 +165,8 @@ impl TryFrom<(String, RawReflector)> for Reflector {
 pub(crate) struct Config {
     /// Minimum severity to log.
     pub(crate) log_level: LogLevel,
-    /// Whether to periodically log memory-footprint diagnostics.
-    pub(crate) debug_memory: bool,
+    /// How often to log memory-footprint diagnostics, or `None` to disable them.
+    pub(crate) debug_memory_interval: Option<Duration>,
     /// How often to log per-interface packet counters, or `None` to disable them.
     pub(crate) counter_interval: Option<Duration>,
     pub(crate) reflectors: Vec<Reflector>,
@@ -220,8 +220,11 @@ impl TryFrom<RawConfig> for Config {
 
         Ok(Config {
             log_level: raw.log_level.unwrap_or_default(),
-            debug_memory: raw.debug_memory.unwrap_or_default(),
-            // 0 or absent disables the summary; any positive count is its period.
+            // 0 or absent disables each report; any positive count is its period.
+            debug_memory_interval: raw
+                .debug_memory_interval_secs
+                .filter(|&s| s > 0)
+                .map(Duration::from_secs),
             counter_interval: raw
                 .counters_interval_secs
                 .filter(|&s| s > 0)
@@ -357,7 +360,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cfg.log_level, LogLevel::Info);
-        assert!(!cfg.debug_memory);
+        assert!(cfg.debug_memory_interval.is_none());
         assert_eq!(cfg.reflectors.len(), 1);
         let r = &cfg.reflectors[0];
         assert_eq!(r.name.as_str(), "discovery");
@@ -394,7 +397,7 @@ mod tests {
         let cfg = from_toml(
             r#"
             log_level = "DEBUG"
-            debug_memory = true
+            debug_memory_interval_secs = 30
 
             [reflectors.tv]
             source_if = "en0"
@@ -410,7 +413,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cfg.log_level, LogLevel::Debug);
-        assert!(cfg.debug_memory);
+        assert_eq!(cfg.debug_memory_interval, Some(Duration::from_secs(30)));
         assert_eq!(cfg.reflectors.len(), 1);
         let r = &cfg.reflectors[0];
         assert_eq!(r.name.as_str(), "tv");
@@ -457,6 +460,50 @@ mod tests {
             None
         );
         assert_eq!(from_toml(&toml("")).unwrap().counter_interval, None);
+    }
+
+    #[test]
+    fn debug_memory_interval_parses_and_zero_disables() {
+        // A positive interval becomes a Duration; 0 disables it, as does omitting the key.
+        let toml = |secs: &str| {
+            format!(
+                r#"
+                {secs}
+                [reflectors.d]
+                source_if = "a"
+                target_if = "b"
+                mdns = true
+                "#
+            )
+        };
+        assert_eq!(
+            from_toml(&toml("debug_memory_interval_secs = 30"))
+                .unwrap()
+                .debug_memory_interval,
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(
+            from_toml(&toml("debug_memory_interval_secs = 0"))
+                .unwrap()
+                .debug_memory_interval,
+            None
+        );
+        assert_eq!(from_toml(&toml("")).unwrap().debug_memory_interval, None);
+    }
+
+    #[test]
+    fn old_debug_memory_bool_is_rejected() {
+        // The 0.10.x `debug_memory = true` no longer parses (renamed to an interval, and the config
+        // denies unknown fields) — the deliberate breaking change fails loud at startup rather than
+        // silently ignoring a stale setting.
+        let text = r#"
+            debug_memory = true
+            [reflectors.d]
+            source_if = "a"
+            target_if = "b"
+            mdns = true
+            "#;
+        assert!(matches!(err(text), ConfigError::Parse(_)));
     }
 
     #[test]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -80,14 +80,14 @@ impl PartialReflector {
 
 /// Parse `REFLECTOR_*` variables into the raw configuration they describe.
 ///
-/// `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY`, and `REFLECTOR_COUNTERS_INTERVAL_SECS` set
-/// the globals; every other `REFLECTOR_<tag>_<param>` contributes to the reflector keyed by the
-/// lowercased `tag`. Unprefixed variables are ignored.
+/// `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
+/// `REFLECTOR_COUNTERS_INTERVAL_SECS` set the globals; every other `REFLECTOR_<tag>_<param>`
+/// contributes to the reflector keyed by the lowercased `tag`. Unprefixed variables are ignored.
 pub(super) fn parse_env(
     vars: impl IntoIterator<Item = (String, String)>,
 ) -> Result<RawConfig, ConfigError> {
     let mut log_level = None;
-    let mut debug_memory = None;
+    let mut debug_memory_interval_secs = None;
     let mut counters_interval_secs = None;
     let mut partials: BTreeMap<String, PartialReflector> = BTreeMap::new();
 
@@ -101,9 +101,9 @@ pub(super) fn parse_env(
                 log_level = Some(env_value(&value, &key)?);
                 continue;
             }
-            "DEBUG_MEMORY" => {
+            "DEBUG_MEMORY_INTERVAL_SECS" => {
                 log::trace!("env {key} = {value}");
-                debug_memory = Some(env_bool(&value, &key)?);
+                debug_memory_interval_secs = Some(env_value(&value, &key)?);
                 continue;
             }
             "COUNTERS_INTERVAL_SECS" => {
@@ -139,7 +139,7 @@ pub(super) fn parse_env(
     }
     Ok(RawConfig {
         log_level,
-        debug_memory,
+        debug_memory_interval_secs,
         counters_interval_secs,
         reflectors,
     })
@@ -224,7 +224,7 @@ mod tests {
     fn env_globals_and_bool_forms() {
         let cfg = from_env(&[
             ("REFLECTOR_LOG_LEVEL", "debug"),
-            ("REFLECTOR_DEBUG_MEMORY", "1"),
+            ("REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS", "30"),
             ("REFLECTOR_COUNTERS_INTERVAL_SECS", "45"),
             ("REFLECTOR_TV_SOURCE_IF", "a"),
             ("REFLECTOR_TV_TARGET_IF", "b"),
@@ -233,7 +233,10 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(cfg.log_level, LogLevel::Debug);
-        assert!(cfg.debug_memory);
+        assert_eq!(
+            cfg.debug_memory_interval,
+            Some(std::time::Duration::from_secs(30))
+        );
         assert_eq!(
             cfg.counter_interval,
             Some(std::time::Duration::from_secs(45))

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -17,7 +17,8 @@ use crate::net::mac::MacSet;
 #[serde(deny_unknown_fields)]
 pub(super) struct RawConfig {
     pub(super) log_level: Option<LogLevel>,
-    pub(super) debug_memory: Option<bool>,
+    /// Seconds between memory-footprint diagnostic reports; `0` or absent disables them.
+    pub(super) debug_memory_interval_secs: Option<u64>,
     /// Seconds between periodic counter summaries; `0` or absent disables them.
     pub(super) counters_interval_secs: Option<u64>,
     #[serde(default)]
@@ -58,7 +59,9 @@ impl RawConfig {
     /// added, and a reflector named by both sources is rejected.
     pub(super) fn merge_env(&mut self, env: RawConfig) -> Result<(), ConfigError> {
         self.log_level = env.log_level.or(self.log_level);
-        self.debug_memory = env.debug_memory.or(self.debug_memory);
+        self.debug_memory_interval_secs = env
+            .debug_memory_interval_secs
+            .or(self.debug_memory_interval_secs);
         self.counters_interval_secs = env.counters_interval_secs.or(self.counters_interval_secs);
         for (name, reflector) in env.reflectors {
             // Compare folded: an env tag is already lowercase and unpadded, but a TOML table key is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,19 +82,20 @@ pub fn run(args: &[String]) -> Result<()> {
     let mut reactor = Reactor::new()?;
     let watches = dispatcher.capture_watches();
     reactor.register_with_fds(Box::new(dispatcher), &watches)?;
-    if config.debug_memory {
+    if let Some(interval) = config.debug_memory_interval {
         log::info!(
             "memory diagnostics enabled; reporting every {}s",
-            memory_report::INTERVAL.as_secs()
+            interval.as_secs()
         );
         memory_report::log_report(); // a baseline before the loop starts
         reactor.register(Box::new(memory_report::MemoryReporter::new(
+            interval,
             std::time::Instant::now(),
         )));
     }
     log::info!("running; press Ctrl-C or send SIGTERM to stop");
     reactor.run()?;
-    if config.debug_memory {
+    if config.debug_memory_interval.is_some() {
         memory_report::log_report(); // a final report at shutdown
     }
     log::info!("stopped");

--- a/src/memory_report.rs
+++ b/src/memory_report.rs
@@ -1,21 +1,14 @@
-//! Optional memory-footprint diagnostics, enabled by the `debug_memory` config flag.
+//! Optional memory-footprint diagnostics, enabled by the `debug_memory_interval_secs` config setting.
 //!
 //! [`MemoryReporter`] is a timer-only reactor handler that logs the process's resident set size every
-//! [`INTERVAL`]; [`run`](crate::run) also emits a baseline at startup and one report at shutdown. The
-//! peak RSS comes from `getrusage` (cross-platform); on Linux the current RSS is read from
+//! configured interval; [`run`](crate::run) also emits a baseline at startup and one report at
+//! shutdown. The peak RSS comes from `getrusage` (cross-platform); on Linux the current RSS is read from
 //! `/proc/self/status`. Heap-arena stats (glibc `mallinfo2`) are intentionally omitted — the static
 //! musl build has no equivalent.
 
 use std::time::{Duration, Instant};
 
 use crate::reactor::{Handler, Reactor, ReadyEvent};
-
-/// How often the periodic report fires.
-#[expect(
-    clippy::duration_suboptimal_units,
-    reason = "the report cadence is 60 seconds; Duration::from_mins is still unstable"
-)]
-pub(crate) const INTERVAL: Duration = Duration::from_secs(60);
 
 /// Peak resident set size in KiB via `getrusage` — no `/proc` needed, so it works on every target.
 /// `ru_maxrss` is reported in KiB on Linux and FreeBSD, in bytes on macOS.
@@ -59,16 +52,18 @@ pub(crate) fn log_report() {
     log::info!("memory: peak={peak} KiB");
 }
 
-/// A timer-only reactor handler (it watches no fds) that logs [`log_report`] every [`INTERVAL`].
+/// A timer-only reactor handler (it watches no fds) that logs [`log_report`] every `interval`.
 pub(crate) struct MemoryReporter {
+    interval: Duration,
     next: Instant,
 }
 
 impl MemoryReporter {
-    /// A reporter whose first periodic report fires [`INTERVAL`] after `now`.
-    pub(crate) fn new(now: Instant) -> Self {
+    /// A reporter whose first report fires `interval` after `now`, then every `interval`.
+    pub(crate) fn new(interval: Duration, now: Instant) -> Self {
         Self {
-            next: now + INTERVAL,
+            interval,
+            next: now + interval,
         }
     }
 }
@@ -83,7 +78,7 @@ impl Handler for MemoryReporter {
 
     fn on_deadline(&mut self, now: Instant, _reactor: &mut Reactor) {
         log_report();
-        self.next = now + INTERVAL;
+        self.next = now + self.interval;
     }
 }
 
@@ -105,11 +100,12 @@ mod tests {
 
     #[test]
     fn reporter_schedules_the_next_report_an_interval_out() {
+        let interval = Duration::from_secs(30);
         let now = Instant::now();
-        let mut reporter = MemoryReporter::new(now);
-        assert_eq!(reporter.next_deadline(), Some(now + INTERVAL));
-        let later = now + INTERVAL;
+        let mut reporter = MemoryReporter::new(interval, now);
+        assert_eq!(reporter.next_deadline(), Some(now + interval));
+        let later = now + interval;
         reporter.on_deadline(later, &mut Reactor::new().unwrap());
-        assert_eq!(reporter.next_deadline(), Some(later + INTERVAL));
+        assert_eq!(reporter.next_deadline(), Some(later + interval));
     }
 }


### PR DESCRIPTION
Unifies `debug_memory` with the `counters_interval_secs` shape: it becomes `debug_memory_interval_secs` (seconds; `0`/absent disables), so the memory-diagnostics cadence is configurable instead of a fixed 60s.

## What
- `debug_memory` (bool) → `debug_memory_interval_secs` (u64 seconds) → `Config.debug_memory_interval: Option<Duration>`; env `REFLECTOR_DEBUG_MEMORY` → `REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`.
- `MemoryReporter` takes the interval (dropped the fixed `INTERVAL` const).
- README updated.

## Breaking
A 0.10.x `debug_memory = true` config no longer parses (unknown field, `deny_unknown_fields`) and fails loud at startup. Shipped as 0.11.0.

## Testing
- Unit tests: config parse, `0`/absent disables, old-bool rejected (`ConfigError::Parse`), reporter reschedule.
- Live Docker run: memory reports fire at the configured interval — startup baseline, every N seconds, and a shutdown-time final report.
