### PR TITLE
libcex: centralize the hand-rolled libc FFI

### DIFF
--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -14,7 +14,8 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 
 use libc::{c_int, c_void};
 
-use super::filter::{BpfInsn, DROP_OUTGOING_PROLOGUE, ETHERNET_UDP_FILTER};
+use super::filter::{DROP_OUTGOING_PROLOGUE, ETHERNET_UDP_FILTER};
+use crate::libcex::BpfInsn;
 use crate::net::LinkType;
 use crate::sys::{IoStatus, socklen_of};
 

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -16,44 +16,10 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 use libc::{c_uint, c_ulong, c_void};
 
-use super::filter::{BpfInsn, DLT_NULL_UDP_FILTER, ETHERNET_UDP_FILTER};
+use super::filter::{DLT_NULL_UDP_FILTER, ETHERNET_UDP_FILTER};
+use crate::libcex::{BpfInsn, BpfProgram, DLT_EN10MB, DLT_NULL, bpf_wordalign};
 use crate::net::LinkType;
 use crate::sys::IoStatus;
-
-// DLT_EN10MB (Ethernet, 1) and DLT_NULL (0) are stable BPF link types,
-// but libc exposes them only on apple — define them locally, anchored to libc's
-// values where available.
-const DLT_EN10MB: c_uint = 1;
-const DLT_NULL: c_uint = 0;
-#[cfg(target_os = "macos")]
-const _: () = assert!(DLT_EN10MB == libc::DLT_EN10MB);
-#[cfg(target_os = "macos")]
-const _: () = assert!(DLT_NULL == libc::DLT_NULL);
-
-/// `struct bpf_program` — the filter handed to `BIOCSETF`. libc provides this
-/// (and `bpf_insn`) on FreeBSD but not apple, so define it for both; the asserts
-/// anchor the layout to libc where it exists. The per-frame header is read as
-/// `libc::bpf_hdr` (apple + FreeBSD both have it, with the right per-OS timestamp).
-#[repr(C)]
-struct BpfProgram {
-    bf_len: c_uint,
-    bf_insns: *mut BpfInsn,
-}
-#[cfg(target_os = "freebsd")]
-const _: () = assert!(size_of::<BpfProgram>() == size_of::<libc::bpf_program>());
-#[cfg(target_os = "freebsd")]
-const _: () = assert!(size_of::<BpfInsn>() == size_of::<libc::bpf_insn>());
-
-// `BPF_ALIGNMENT` as a usize. libc types it differently per platform (`c_int` on
-// apple, `usize` on FreeBSD), so normalize it once here.
-#[cfg(target_os = "macos")]
-const BPF_ALIGN: usize = libc::BPF_ALIGNMENT as usize;
-#[cfg(target_os = "freebsd")]
-const BPF_ALIGN: usize = libc::BPF_ALIGNMENT;
-
-const fn bpf_wordalign(x: usize) -> usize {
-    (x + (BPF_ALIGN - 1)) & !(BPF_ALIGN - 1)
-}
 
 /// A raw-capture handle on one interface.
 pub(crate) struct Capture {
@@ -335,6 +301,7 @@ mod tests {
 
     use super::*;
     use crate::capture::open_or_skip;
+    use crate::libcex::BPF_ALIGN;
 
     /// Append one synthetic BPF record (header + frame + word-align padding) to
     /// `batch`. Serializes the header field-by-field at its repr(C) offsets rather
@@ -351,16 +318,6 @@ mod tests {
         while !batch.len().is_multiple_of(BPF_ALIGN) {
             batch.push(0);
         }
-    }
-
-    #[test]
-    fn wordalign_rounds_up_to_alignment() {
-        // BPF_ALIGN is per-OS (4 on macOS, sizeof(long)=8 on FreeBSD/64-bit), so assert the round-up
-        // invariant against the real boundary rather than a hardcoded width.
-        assert_eq!(bpf_wordalign(0), 0);
-        assert_eq!(bpf_wordalign(1), BPF_ALIGN);
-        assert_eq!(bpf_wordalign(BPF_ALIGN), BPF_ALIGN);
-        assert_eq!(bpf_wordalign(BPF_ALIGN + 1), 2 * BPF_ALIGN);
     }
 
     #[test]

--- a/src/capture/filter.rs
+++ b/src/capture/filter.rs
@@ -4,20 +4,7 @@
 //! BSD BPF device (`BIOCSETF`): [`BpfInsn`] is layout-identical to libc's
 //! `sock_filter` and `bpf_insn`, so the same array installs on either backend.
 
-/// One classic-BPF instruction (`{ u16 code; u8 jt; u8 jf; u32 k }`).
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct BpfInsn {
-    pub(crate) code: u16,
-    pub(crate) jt: u8,
-    pub(crate) jf: u8,
-    pub(crate) k: u32,
-}
-
-// On Linux the same array installs via `SO_ATTACH_FILTER` as a `sock_filter`
-// program; anchor the layout to libc where it provides the type.
-#[cfg(target_os = "linux")]
-const _: () = assert!(size_of::<BpfInsn>() == size_of::<libc::sock_filter>());
+use crate::libcex::BpfInsn;
 
 const fn insn(code: u16, jt: u8, jf: u8, k: u32) -> BpfInsn {
     BpfInsn { code, jt, jf, k }

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -9,25 +9,10 @@ use std::io;
 use std::net::IpAddr;
 use std::os::fd::{AsRawFd, OwnedFd};
 
-use libc::{c_int, c_void};
+use libc::c_void;
 
+use crate::libcex::{GroupReq, MCAST_JOIN_GROUP};
 use crate::sys::{open_socket, sockaddr_for, socklen_of};
-
-/// `MCAST_JOIN_GROUP` (RFC 3678): by-index interface selection, no IPv4 by-address fallback to the
-/// wrong NIC. libc defines it only on Linux; the BSDs share the value 80 (checked against the Darwin
-/// SDK and FreeBSD headers).
-#[cfg(target_os = "linux")]
-const MCAST_JOIN_GROUP: c_int = libc::MCAST_JOIN_GROUP;
-#[cfg(any(target_os = "macos", target_os = "freebsd"))]
-const MCAST_JOIN_GROUP: c_int = 80;
-
-/// `struct group_req` (RFC 3678) — absent from libc everywhere, so hand-rolled. `#[repr(C)]` plus
-/// `sockaddr_storage`'s alignment reproduce the C layout (4 bytes of padding after `gr_interface`).
-#[repr(C)]
-struct GroupReq {
-    gr_interface: u32,
-    gr_group: libc::sockaddr_storage,
-}
 
 /// One capture interface's multicast memberships: one unbound `SOCK_DGRAM` fd per family, opened on
 /// that family's first join, under a fixed `ifindex`. `desired` records requested groups so they can

--- a/src/interface/address_monitor/rtnetlink.rs
+++ b/src/interface/address_monitor/rtnetlink.rs
@@ -7,7 +7,7 @@ use std::os::fd::{AsRawFd, OwnedFd};
 
 use libc::socklen_t;
 
-use super::super::rtnetlink::{IfInfoMsg, read_at};
+use super::super::rtnetlink::read_at;
 use crate::libcex::{IfAddrMsg, NETLINK_ROUTE, NlMsgHdr, SockAddrNl, nl_align};
 
 /// Holds one notification — multicast delivers one message per datagram, never a coalesced
@@ -77,8 +77,8 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
             }
             libc::RTM_NEWLINK | libc::RTM_DELLINK => {
                 // `ifi_index` is i32 but always a positive kernel index.
-                if let Some(body) = read_at::<IfInfoMsg>(&buf[..end], body_at)
-                    && let Ok(index) = u32::try_from(body.index)
+                if let Some(body) = read_at::<libc::ifinfomsg>(&buf[..end], body_at)
+                    && let Ok(index) = u32::try_from(body.ifi_index)
                 {
                     report(index, on_change);
                 }
@@ -126,7 +126,7 @@ mod tests {
 
     /// An `ifinfomsg` body carrying `ifi_index` (an `i32` at body offset 4).
     fn ifinfomsg(index: i32) -> Vec<u8> {
-        let mut b = vec![0u8; size_of::<IfInfoMsg>()];
+        let mut b = vec![0u8; size_of::<libc::ifinfomsg>()];
         b[4..8].copy_from_slice(&index.to_ne_bytes());
         b
     }

--- a/src/interface/address_monitor/rtnetlink.rs
+++ b/src/interface/address_monitor/rtnetlink.rs
@@ -5,11 +5,10 @@
 use std::io;
 use std::os::fd::{AsRawFd, OwnedFd};
 
-use libc::{c_int, socklen_t};
+use libc::socklen_t;
 
-use super::super::rtnetlink::{IfAddrMsg, IfInfoMsg, NlMsgHdr, nl_align, read_at};
-
-const NETLINK_ROUTE: c_int = 0;
+use super::super::rtnetlink::{IfInfoMsg, read_at};
+use crate::libcex::{IfAddrMsg, NETLINK_ROUTE, NlMsgHdr, SockAddrNl, nl_align};
 
 /// Holds one notification — multicast delivers one message per datagram, never a coalesced
 /// dump. Sized for the largest: an `RTM_NEWLINK` carries the interface's whole attribute set
@@ -20,16 +19,6 @@ pub(super) const READ_BUF: usize = 8192;
 /// as `RTM_NEWLINK`, not an address event, so `RTMGRP_LINK` is needed to catch it.
 const SUBSCRIBED_GROUPS: u32 =
     (libc::RTMGRP_IPV4_IFADDR | libc::RTMGRP_IPV6_IFADDR | libc::RTMGRP_LINK) as u32;
-
-/// `struct sockaddr_nl` — hand-rolled (`libc` exposes it for Android only).
-#[repr(C)]
-#[derive(Default)]
-struct SockAddrNl {
-    family: u16,
-    pad: u16,
-    pid: u32,
-    groups: u32,
-}
 
 /// Open a `NETLINK_ROUTE` socket bound to the change groups, non-blocking + close-on-exec.
 pub(super) fn open() -> io::Result<OwnedFd> {

--- a/src/interface/getifaddrs.rs
+++ b/src/interface/getifaddrs.rs
@@ -12,11 +12,8 @@ use std::ptr;
 use libc::c_int;
 
 use super::{InterfaceAddresses, V6Pick, v6_rank};
+use crate::libcex::{IN6_IFF_UNUSABLE, In6Ifreq, siocgifaflag_in6};
 use crate::net::mac::MacAddr;
-
-/// `IN6_IFF_*` bits that disqualify a v6 address as a source: DAD in progress, DAD failed
-/// (duplicate), or preferred-lifetime expired. Same values on macOS and FreeBSD.
-const IN6_IFF_UNUSABLE: c_int = 0x02 | 0x04 | 0x10; // TENTATIVE | DUPLICATED | DEPRECATED
 
 /// Resolve `if_name`'s current source addresses in one `getifaddrs` pass.
 ///
@@ -168,45 +165,6 @@ fn inet6_socket() -> Option<OwnedFd> {
     })
 }
 
-/// `in6_ifreq` for `SIOCGIFAFLAG_IN6`: an interface name plus a union holding the queried
-/// address (going in) and its flags (coming out). Hand-rolled — `libc` exposes it on
-/// macOS only, not FreeBSD.
-#[repr(C)]
-struct In6Ifreq {
-    name: [libc::c_char; libc::IFNAMSIZ],
-    ifru: In6Ifru,
-}
-
-#[repr(C)]
-union In6Ifru {
-    addr: libc::sockaddr_in6,
-    flags6: c_int,
-    // The kernel's `in6_ifreq` union is sized by its largest member, `icmp6_ifstat` — 34
-    // `u_quad_t` on both macOS and FreeBSD. This pad makes the whole struct match — load-
-    // bearing: `_IOWR` bakes `sizeof(in6_ifreq)` into the request code and the kernel
-    // dispatches on the whole code, so a too-small struct yields a request the kernel
-    // rejects, and every v6 address would be silently dropped. See the size assertions.
-    _icmp6_ifstat: [u64; 34],
-}
-
-// `libc` exposes `in6_ifreq` on macOS, so cross-check the hand-rolled size against it
-// there; FreeBSD's (16 + 34×8) is 288.
-#[cfg(target_os = "macos")]
-const _: () = assert!(size_of::<In6Ifreq>() == size_of::<libc::in6_ifreq>());
-#[cfg(target_os = "freebsd")]
-const _: () = assert!(size_of::<In6Ifreq>() == 288);
-
-/// `_IOWR('i', 73, in6_ifreq)` — the BSD `ioctl` request code, derived from the (now
-/// kernel-accurate) struct size rather than hardcoded.
-fn siocgifaflag_in6() -> libc::c_ulong {
-    const IOC_INOUT: libc::c_ulong = 0xc000_0000;
-    const IOCPARM_MASK: libc::c_ulong = 0x1fff;
-    const GROUP: libc::c_ulong = 0x69; // 'i'
-    const NUM: libc::c_ulong = 73;
-    let size = size_of::<In6Ifreq>() as libc::c_ulong;
-    IOC_INOUT | ((size & IOCPARM_MASK) << 16) | (GROUP << 8) | NUM
-}
-
 /// The `IN6_IFF_*` flags of `addr` on `if_name`, queried via `SIOCGIFAFLAG_IN6`, or `None`
 /// if the ioctl fails (the address is then treated as unusable).
 fn v6_flags(sock: &OwnedFd, if_name: &str, addr: libc::sockaddr_in6) -> Option<c_int> {
@@ -224,18 +182,4 @@ fn v6_flags(sock: &OwnedFd, if_name: &str, addr: libc::sockaddr_in6) -> Option<c
     }
     // SAFETY: a successful ioctl wrote `ifru_flags6` into the union.
     Some(unsafe { req.ifru.flags6 })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // The encoded request must equal the kernel's registered `SIOCGIFAFLAG_IN6`, or the
-    // ioctl is rejected and every v6 address is silently dropped. A too-small `In6Ifreq`
-    // (omitting the large union members) is exactly how that regresses.
-    #[test]
-    fn siocgifaflag_in6_is_the_kernel_request_code() {
-        // Identical on macOS and FreeBSD: both size `in6_ifreq` at 288 bytes.
-        assert_eq!(siocgifaflag_in6(), 0xc120_6949);
-    }
 }

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -11,37 +11,14 @@ use std::ptr;
 use libc::c_int;
 
 use super::{InterfaceAddresses, V6Pick, v6_rank};
+use crate::libcex::{
+    IfAddrMsg, NETLINK_ROUTE, NLM_F_DUMP, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, NlMsgHdr, RtAttr,
+    nl_align,
+};
 use crate::net::mac::MacAddr;
 
-const NETLINK_ROUTE: c_int = 0;
-const NLM_F_REQUEST: u16 = 0x01;
-const NLM_F_DUMP: u16 = 0x0300; // NLM_F_ROOT | NLM_F_MATCH
-const NLMSG_DONE: u16 = 0x03;
-const NLMSG_ERROR: u16 = 0x02;
 /// `IFA_F_*` bits that disqualify a v6 address as a source.
 const IFA_F_UNUSABLE: u32 = 0x40 | 0x20 | 0x08; // TENTATIVE | DEPRECATED | DADFAILED
-
-/// `struct nlmsghdr`. Shared with the address monitor (`len`/`msg_type` drive its walk).
-#[repr(C)]
-pub(super) struct NlMsgHdr {
-    pub(super) len: u32,
-    pub(super) msg_type: u16,
-    flags: u16,
-    seq: u32,
-    pid: u32,
-}
-
-/// `struct ifaddrmsg` — the body of an `RTM_*ADDR` message. A zeroed value (family
-/// `AF_UNSPEC`) is the dump request body. The address monitor reads `index` from it.
-#[repr(C)]
-#[derive(Default)]
-pub(super) struct IfAddrMsg {
-    family: u8,
-    prefixlen: u8,
-    flags: u8,
-    scope: u8,
-    pub(super) index: u32,
-}
 
 /// `struct ifinfomsg` — the body of an `RTM_*LINK` message. A zeroed value is the dump
 /// request body. The address monitor reads `index` from it.
@@ -54,13 +31,6 @@ pub(super) struct IfInfoMsg {
     pub(super) index: i32,
     flags: u32,
     change: u32,
-}
-
-/// `struct rtattr` — a type-length-value attribute header within a message.
-#[repr(C)]
-struct RtAttr {
-    len: u16,
-    attr_type: u16,
 }
 
 /// Iterator over the `rtattr` TLVs of a message: yields `(attr_type, value)` per attribute,
@@ -88,11 +58,6 @@ impl<'a> Iterator for RtAttrs<'a> {
         self.at += nl_align(rta_len);
         Some((rta.attr_type, data))
     }
-}
-
-/// `(n + 3) & !3` — netlink's 4-byte alignment for message and attribute lengths.
-pub(super) const fn nl_align(n: usize) -> usize {
-    (n + 3) & !3
 }
 
 /// Read a `repr(C)` POD `T` at `off` in `buf`, or `None` if `buf` is too short (or `off`

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -18,20 +18,7 @@ use crate::libcex::{
 use crate::net::mac::MacAddr;
 
 /// `IFA_F_*` bits that disqualify a v6 address as a source.
-const IFA_F_UNUSABLE: u32 = 0x40 | 0x20 | 0x08; // TENTATIVE | DEPRECATED | DADFAILED
-
-/// `struct ifinfomsg` — the body of an `RTM_*LINK` message. A zeroed value is the dump
-/// request body. The address monitor reads `index` from it.
-#[repr(C)]
-#[derive(Default)]
-pub(super) struct IfInfoMsg {
-    family: u8,
-    pad: u8,
-    dev_type: u16,
-    pub(super) index: i32,
-    flags: u32,
-    change: u32,
-}
+const IFA_F_UNUSABLE: u32 = libc::IFA_F_TENTATIVE | libc::IFA_F_DEPRECATED | libc::IFA_F_DADFAILED;
 
 /// Iterator over the `rtattr` TLVs of a message: yields `(attr_type, value)` per attribute,
 /// stopping at the first malformed length (as the kernel's own walk does).
@@ -97,11 +84,13 @@ pub(super) fn resolve(if_name: &str, ifindex: u32) -> io::Result<InterfaceAddres
             scan_addr(msg, if_name, ifindex, &mut addrs, &mut v6_pick);
         },
     )?;
+    // SAFETY: a zeroed `ifinfomsg` (an all-integer POD) is a valid `AF_UNSPEC` link-dump request body.
+    let link_req: libc::ifinfomsg = unsafe { std::mem::zeroed() };
     dump(
         &sock,
         libc::RTM_GETLINK,
         libc::RTM_NEWLINK,
-        IfInfoMsg::default(),
+        link_req,
         |msg| {
             scan_link(msg, if_name, ifindex, &mut addrs);
         },
@@ -278,14 +267,14 @@ fn scan_addr(
 /// record it as the MAC. `msg` spans one netlink message.
 fn scan_link(msg: &[u8], if_name: &str, ifindex: u32, addrs: &mut InterfaceAddresses) {
     let body_at = nl_align(size_of::<NlMsgHdr>());
-    let Some(body) = read_at::<IfInfoMsg>(msg, body_at) else {
+    let Some(body) = read_at::<libc::ifinfomsg>(msg, body_at) else {
         return;
     };
-    if u32::try_from(body.index).ok() != Some(ifindex) {
+    if u32::try_from(body.ifi_index).ok() != Some(ifindex) {
         return;
     }
 
-    for (attr_type, data) in rtattrs(msg, body_at + nl_align(size_of::<IfInfoMsg>())) {
+    for (attr_type, data) in rtattrs(msg, body_at + nl_align(size_of::<libc::ifinfomsg>())) {
         if attr_type == libc::IFLA_ADDRESS
             && let Ok(mac) = <[u8; 6]>::try_from(data)
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod config;
 mod dispatch;
 mod error;
 mod interface;
+mod libcex;
 mod logging;
 mod memory_report;
 mod net;

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -12,11 +12,15 @@
 mod bpf;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod bpf_device;
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+mod in6_ifreq;
 mod multicast;
 
 pub(crate) use self::bpf::BpfInsn;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 pub(crate) use self::bpf_device::{BpfProgram, DLT_EN10MB, DLT_NULL, bpf_wordalign};
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+pub(crate) use self::in6_ifreq::{IN6_IFF_UNUSABLE, In6Ifreq, siocgifaflag_in6};
 // `BPF_ALIGN` is used outside `bpf_device` only by the BPF capture's test helpers (production rounds
 // via `bpf_wordalign`), so re-export it only for tests.
 #[cfg(all(test, any(target_os = "macos", target_os = "freebsd")))]

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -15,6 +15,8 @@ mod bpf_device;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod in6_ifreq;
 mod multicast;
+#[cfg(target_os = "linux")]
+mod netlink;
 
 pub(crate) use self::bpf::BpfInsn;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
@@ -26,3 +28,8 @@ pub(crate) use self::in6_ifreq::{IN6_IFF_UNUSABLE, In6Ifreq, siocgifaflag_in6};
 #[cfg(all(test, any(target_os = "macos", target_os = "freebsd")))]
 pub(crate) use self::bpf_device::BPF_ALIGN;
 pub(crate) use self::multicast::{GroupReq, MCAST_JOIN_GROUP};
+#[cfg(target_os = "linux")]
+pub(crate) use self::netlink::{
+    IfAddrMsg, NETLINK_ROUTE, NLM_F_DUMP, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, NlMsgHdr, RtAttr,
+    SockAddrNl, nl_align,
+};

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -9,6 +9,16 @@
 //! *some* platform, the hand-rolled arm is anchored to it with a `const _: () = assert!(…)` so it can't
 //! silently drift.
 
+mod bpf;
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+mod bpf_device;
 mod multicast;
 
+pub(crate) use self::bpf::BpfInsn;
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+pub(crate) use self::bpf_device::{BpfProgram, DLT_EN10MB, DLT_NULL, bpf_wordalign};
+// `BPF_ALIGN` is used outside `bpf_device` only by the BPF capture's test helpers (production rounds
+// via `bpf_wordalign`), so re-export it only for tests.
+#[cfg(all(test, any(target_os = "macos", target_os = "freebsd")))]
+pub(crate) use self::bpf_device::BPF_ALIGN;
 pub(crate) use self::multicast::{GroupReq, MCAST_JOIN_GROUP};

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -1,0 +1,14 @@
+//! `libcex` — "libc extended": C library / kernel FFI definitions that are missing from the `libc`
+//! crate (for the platforms we build) but should be there, gathered in one place. Elsewhere the code
+//! references only `libc::` (standard, upstream-maintained) and `libcex::` (these hand-rolled fills).
+//!
+//! The split is deliberate — this module does NOT re-export `libc`. The prefix is a provenance signal
+//! for `unsafe` FFI: `libc::x` is a definition upstream maintains and vets across platforms, `libcex::x`
+//! is one we transcribed from a C header and must scrutinise (layout, value, `cfg`). Keeping them apart
+//! also keeps visible pressure to delete a fill once libc ships it. Where libc provides a definition on
+//! *some* platform, the hand-rolled arm is anchored to it with a `const _: () = assert!(…)` so it can't
+//! silently drift.
+
+mod multicast;
+
+pub(crate) use self::multicast::{GroupReq, MCAST_JOIN_GROUP};

--- a/src/libcex/bpf.rs
+++ b/src/libcex/bpf.rs
@@ -1,0 +1,18 @@
+//! The classic-BPF instruction encoding, shared by the Linux socket filter (`SO_ATTACH_FILTER`) and
+//! the BSD BPF device (`BIOCSETF`). libc has `sock_filter`/`bpf_insn` on Linux and FreeBSD, but not
+//! apple, so define it once here for all three.
+
+/// One classic-BPF instruction (`{ u16 code; u8 jt; u8 jf; u32 k }`).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct BpfInsn {
+    pub(crate) code: u16,
+    pub(crate) jt: u8,
+    pub(crate) jf: u8,
+    pub(crate) k: u32,
+}
+
+// On Linux the same array installs via `SO_ATTACH_FILTER` as a `sock_filter`
+// program; anchor the layout to libc where it provides the type.
+#[cfg(target_os = "linux")]
+const _: () = assert!(size_of::<BpfInsn>() == size_of::<libc::sock_filter>());

--- a/src/libcex/bpf_device.rs
+++ b/src/libcex/bpf_device.rs
@@ -1,0 +1,56 @@
+//! BSD BPF-device FFI (macOS + FreeBSD): the `DLT_*` link types, the `bpf_program` filter struct, and
+//! `BPF_WORDALIGN` batch-record alignment. libc provides some of these on only one of the two BSDs.
+
+use libc::c_uint;
+
+use super::bpf::BpfInsn;
+
+// DLT_EN10MB (Ethernet, 1) and DLT_NULL (0) are stable BPF link types,
+// but libc exposes them only on apple — define them locally, anchored to libc's
+// values where available.
+pub(crate) const DLT_EN10MB: c_uint = 1;
+pub(crate) const DLT_NULL: c_uint = 0;
+#[cfg(target_os = "macos")]
+const _: () = assert!(DLT_EN10MB == libc::DLT_EN10MB);
+#[cfg(target_os = "macos")]
+const _: () = assert!(DLT_NULL == libc::DLT_NULL);
+
+/// `struct bpf_program` — the filter handed to `BIOCSETF`. libc provides this
+/// (and `bpf_insn`) on FreeBSD but not apple, so define it for both; the asserts
+/// anchor the layout to libc where it exists. The per-frame header is read as
+/// `libc::bpf_hdr` (apple + FreeBSD both have it, with the right per-OS timestamp).
+#[repr(C)]
+pub(crate) struct BpfProgram {
+    pub(crate) bf_len: c_uint,
+    pub(crate) bf_insns: *mut BpfInsn,
+}
+#[cfg(target_os = "freebsd")]
+const _: () = assert!(size_of::<BpfProgram>() == size_of::<libc::bpf_program>());
+#[cfg(target_os = "freebsd")]
+const _: () = assert!(size_of::<BpfInsn>() == size_of::<libc::bpf_insn>());
+
+// `BPF_ALIGNMENT` as a usize. libc types it differently per platform (`c_int` on
+// apple, `usize` on FreeBSD), so normalize it once here.
+#[cfg(target_os = "macos")]
+pub(crate) const BPF_ALIGN: usize = libc::BPF_ALIGNMENT as usize;
+#[cfg(target_os = "freebsd")]
+pub(crate) const BPF_ALIGN: usize = libc::BPF_ALIGNMENT;
+
+pub(crate) const fn bpf_wordalign(x: usize) -> usize {
+    (x + (BPF_ALIGN - 1)) & !(BPF_ALIGN - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wordalign_rounds_up_to_alignment() {
+        // BPF_ALIGN is per-OS (4 on macOS, sizeof(long)=8 on FreeBSD/64-bit), so assert the round-up
+        // invariant against the real boundary rather than a hardcoded width.
+        assert_eq!(bpf_wordalign(0), 0);
+        assert_eq!(bpf_wordalign(1), BPF_ALIGN);
+        assert_eq!(bpf_wordalign(BPF_ALIGN), BPF_ALIGN);
+        assert_eq!(bpf_wordalign(BPF_ALIGN + 1), 2 * BPF_ALIGN);
+    }
+}

--- a/src/libcex/in6_ifreq.rs
+++ b/src/libcex/in6_ifreq.rs
@@ -1,0 +1,62 @@
+//! BSD `SIOCGIFAFLAG_IN6` FFI (macOS + FreeBSD): the `in6_ifreq` request struct and the `IN6_IFF_*`
+//! address-flag bits used to decide whether a v6 address is usable. libc exposes `in6_ifreq` on macOS
+//! only, and the `IN6_IFF_*` bits on neither BSD, so both are hand-rolled.
+
+use libc::c_int;
+
+/// `IN6_IFF_*` bits that disqualify a v6 address as a source: DAD in progress, DAD failed
+/// (duplicate), or preferred-lifetime expired. Same values on macOS and FreeBSD.
+pub(crate) const IN6_IFF_UNUSABLE: c_int = 0x02 | 0x04 | 0x10; // TENTATIVE | DUPLICATED | DEPRECATED
+
+/// `in6_ifreq` for `SIOCGIFAFLAG_IN6`: an interface name plus a union holding the queried
+/// address (going in) and its flags (coming out). Hand-rolled — `libc` exposes it on
+/// macOS only, not FreeBSD.
+#[repr(C)]
+pub(crate) struct In6Ifreq {
+    pub(crate) name: [libc::c_char; libc::IFNAMSIZ],
+    pub(crate) ifru: In6Ifru,
+}
+
+#[repr(C)]
+pub(crate) union In6Ifru {
+    pub(crate) addr: libc::sockaddr_in6,
+    pub(crate) flags6: c_int,
+    // The kernel's `in6_ifreq` union is sized by its largest member, `icmp6_ifstat` — 34
+    // `u_quad_t` on both macOS and FreeBSD. This pad makes the whole struct match — load-
+    // bearing: `_IOWR` bakes `sizeof(in6_ifreq)` into the request code and the kernel
+    // dispatches on the whole code, so a too-small struct yields a request the kernel
+    // rejects, and every v6 address would be silently dropped. See the size assertions.
+    _icmp6_ifstat: [u64; 34],
+}
+
+// `libc` exposes `in6_ifreq` on macOS, so cross-check the hand-rolled size against it
+// there; FreeBSD's (16 + 34×8) is 288.
+#[cfg(target_os = "macos")]
+const _: () = assert!(size_of::<In6Ifreq>() == size_of::<libc::in6_ifreq>());
+#[cfg(target_os = "freebsd")]
+const _: () = assert!(size_of::<In6Ifreq>() == 288);
+
+/// `_IOWR('i', 73, in6_ifreq)` — the BSD `ioctl` request code, derived from the (now
+/// kernel-accurate) struct size rather than hardcoded.
+pub(crate) fn siocgifaflag_in6() -> libc::c_ulong {
+    const IOC_INOUT: libc::c_ulong = 0xc000_0000;
+    const IOCPARM_MASK: libc::c_ulong = 0x1fff;
+    const GROUP: libc::c_ulong = 0x69; // 'i'
+    const NUM: libc::c_ulong = 73;
+    let size = size_of::<In6Ifreq>() as libc::c_ulong;
+    IOC_INOUT | ((size & IOCPARM_MASK) << 16) | (GROUP << 8) | NUM
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The encoded request must equal the kernel's registered `SIOCGIFAFLAG_IN6`, or the
+    // ioctl is rejected and every v6 address is silently dropped. A too-small `In6Ifreq`
+    // (omitting the large union members) is exactly how that regresses.
+    #[test]
+    fn siocgifaflag_in6_is_the_kernel_request_code() {
+        // Identical on macOS and FreeBSD: both size `in6_ifreq` at 288 bytes.
+        assert_eq!(siocgifaflag_in6(), 0xc120_6949);
+    }
+}

--- a/src/libcex/multicast.rs
+++ b/src/libcex/multicast.rs
@@ -1,0 +1,19 @@
+//! Multicast-group FFI absent from `libc`: the RFC 3678 by-index group join.
+
+use libc::c_int;
+
+/// `MCAST_JOIN_GROUP` (RFC 3678): by-index interface selection, no IPv4 by-address fallback to the
+/// wrong NIC. libc defines it only on Linux; the BSDs share the value 80 (checked against the Darwin
+/// SDK and FreeBSD headers).
+#[cfg(target_os = "linux")]
+pub(crate) const MCAST_JOIN_GROUP: c_int = libc::MCAST_JOIN_GROUP;
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+pub(crate) const MCAST_JOIN_GROUP: c_int = 80;
+
+/// `struct group_req` (RFC 3678) — absent from libc everywhere, so hand-rolled. `#[repr(C)]` plus
+/// `sockaddr_storage`'s alignment reproduce the C layout (4 bytes of padding after `gr_interface`).
+#[repr(C)]
+pub(crate) struct GroupReq {
+    pub(crate) gr_interface: u32,
+    pub(crate) gr_group: libc::sockaddr_storage,
+}

--- a/src/libcex/netlink.rs
+++ b/src/libcex/netlink.rs
@@ -1,0 +1,55 @@
+//! rtnetlink (`NETLINK_ROUTE`) message-framing FFI, hand-rolled because `libc` exposes it for Android
+//! only, not glibc/musl: the netlink/message/attribute header structs, the `sockaddr_nl`, the request
+//! and message-type flags, and the 4-byte `NLMSG_ALIGN`.
+
+use libc::c_int;
+
+pub(crate) const NETLINK_ROUTE: c_int = 0;
+pub(crate) const NLM_F_REQUEST: u16 = 0x01;
+pub(crate) const NLM_F_DUMP: u16 = 0x0300; // NLM_F_ROOT | NLM_F_MATCH
+pub(crate) const NLMSG_DONE: u16 = 0x03;
+pub(crate) const NLMSG_ERROR: u16 = 0x02;
+
+/// `struct nlmsghdr`. Shared with the address monitor (`len`/`msg_type` drive its walk).
+#[repr(C)]
+pub(crate) struct NlMsgHdr {
+    pub(crate) len: u32,
+    pub(crate) msg_type: u16,
+    pub(crate) flags: u16,
+    pub(crate) seq: u32,
+    pub(crate) pid: u32,
+}
+
+/// `struct ifaddrmsg` — the body of an `RTM_*ADDR` message. A zeroed value (family
+/// `AF_UNSPEC`) is the dump request body. The address monitor reads `index` from it.
+#[repr(C)]
+#[derive(Default)]
+pub(crate) struct IfAddrMsg {
+    pub(crate) family: u8,
+    pub(crate) prefixlen: u8,
+    pub(crate) flags: u8,
+    pub(crate) scope: u8,
+    pub(crate) index: u32,
+}
+
+/// `struct rtattr` — a type-length-value attribute header within a message.
+#[repr(C)]
+pub(crate) struct RtAttr {
+    pub(crate) len: u16,
+    pub(crate) attr_type: u16,
+}
+
+/// `struct sockaddr_nl` — hand-rolled (`libc` exposes it for Android only).
+#[repr(C)]
+#[derive(Default)]
+pub(crate) struct SockAddrNl {
+    pub(crate) family: u16,
+    pub(crate) pad: u16,
+    pub(crate) pid: u32,
+    pub(crate) groups: u32,
+}
+
+/// `(n + 3) & !3` — netlink's 4-byte alignment for message and attribute lengths.
+pub(crate) const fn nl_align(n: usize) -> usize {
+    (n + 3) & !3
+}


### PR DESCRIPTION
New `libcex` module for the C definitions we hand-roll because the `libc` crate doesn't have them on the platforms we build. Code now uses `libc::` for standard items and `libcex::` for our own.

I didn't re-export libc from libcex, on purpose. Keeping the prefixes separate makes it obvious which definitions are ours (and worth extra scrutiny in unsafe code), and it means we'll notice when libc adds one so we can drop ours.

Moved, one commit per area:

- multicast: `GroupReq`, `MCAST_JOIN_GROUP`
- BPF: `BpfInsn` in `libcex::bpf`; `DLT_*`, `bpf_program`, `BPF_WORDALIGN` in `libcex::bpf_device` (BSD)
- getifaddrs (BSD): `in6_ifreq`, `SIOCGIFAFLAG_IN6`, `IN6_IFF_UNUSABLE`
- netlink (Linux): the `nlmsghdr`/`ifaddrmsg`/`rtattr`/`sockaddr_nl` structs, the `NLM_F_*`/`NLMSG_*`/`NETLINK_ROUTE` flags, and `nl_align`; also drops the duplicate `NETLINK_ROUTE`

These are verbatim moves. I only widened field visibility to `pub(crate)`, and checked each one with an original-vs-moved diff. The size-check asserts and unit tests moved with their definitions, and each submodule is gated the same way its source file was, so nothing picked up a new `cfg`. epoll, kqueue, and AF_PACKET were already all `libc::`, so nothing moved there. The parsing helpers (`read_at`, `RtAttrs`) stayed put, since they're our code rather than libc types.

The last commit swaps two definitions back to libc, since the audit found libc 0.2.186 now has them on every target we build: `IfInfoMsg` becomes `libc::ifinfomsg` (same layout), and `IFA_F_UNUSABLE` is built from `libc::IFA_F_*`.

Testing: clippy/test/doc/fmt on the host and on Linux (`docker_test`) for each commit. I also ran the `mdns_address_change` and `dial_address_change` e2e cases to check that rtnetlink address resolution and the change monitor still work against a real kernel after the `ifinfomsg` swap.
