### PR TITLE
ci: build armv5 artifacts for ARMv5TE, not ARMv6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
           - armv7-unknown-linux-musleabihf
-          - arm-unknown-linux-musleabi
+          - armv5te-unknown-linux-musleabi
           - x86_64-unknown-freebsd
           - aarch64-apple-darwin
     steps:
@@ -176,7 +176,7 @@ jobs:
           - { name: release, flags: '--release' }
         target:
           - { name: linux-armv7, triple: armv7-unknown-linux-musleabihf }
-          - { name: linux-armv5, triple: arm-unknown-linux-musleabi }
+          - { name: linux-armv5, triple: armv5te-unknown-linux-musleabi }
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -210,7 +210,7 @@ jobs:
           [target.armv7-unknown-linux-musleabihf]
           runner = "qemu-arm-static"
 
-          [target.arm-unknown-linux-musleabi]
+          [target.armv5te-unknown-linux-musleabi]
           runner = "qemu-arm-static"
           EOF
       - name: Show toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
             target: armv7-unknown-linux-musleabihf
           - variant: linux-armv5
             runner: ubuntu-24.04
-            target: arm-unknown-linux-musleabi
+            target: armv5te-unknown-linux-musleabi
           - variant: macos-arm64
             runner: macos-15
             target: aarch64-apple-darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux; \
         arm) \
             case "${TARGETVARIANT}" in \
                 v7) triple=armv7-unknown-linux-musleabihf ;; \
-                v5) triple=arm-unknown-linux-musleabi ;; \
+                v5) triple=armv5te-unknown-linux-musleabi ;; \
                 *)  echo "unsupported arm variant: ${TARGETVARIANT}" >&2; exit 1 ;; \
             esac ;; \
         *) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \


### PR DESCRIPTION
The `linux/arm/v5` release binary and image were built with `arm-unknown-linux-musleabi`, which is Rust's **ARMv6** target (spec `+strict-align,+v6`). Its precompiled std emits v6-only instructions (`ldrex`/`strex` for atomics, `rev` for byte-swaps) that are undefined on ARMv5TE, so the artifact labeled armv5 `SIGILL`s at startup on real ARMv5TE hardware (the EN7562/armel boxes) — std runs atomics before `main`. The QEMU cross-test lane never caught it because `qemu-arm-static` implements v7.

Swaps to `armv5te-unknown-linux-musleabi` (tier-2, rustup-distributed std) in all five sites: Dockerfile image build, release binary, lint matrix, and the two cross-test config spots. The `cfg(target_env = "musl")` linker block and `qemu-arm-static` runner both still apply unchanged.

## Testing
Target resolves and installs precompiled std (`rustup target add armv5te-unknown-linux-musleabi`). The source has no `target_arch` cfgs, so it compiles identically; the corrected QEMU cross-test lane now builds and runs the suite against a genuine ARMv5 target.