### PR TITLE
reactor: hardening

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -314,6 +314,10 @@ impl Reactor {
             log::trace!("set_write_interest: {reg_key:?} already gone");
             return Ok(false);
         };
+        // Already in the wanted state: skip the redundant epoll_ctl/kevent.
+        if registration.write_interest == enabled {
+            return Ok(true);
+        }
         // Program the kernel first; flip the in-memory flag only on success, so the arena and
         // kernel never disagree about interest. (`self.poll` and `self.registrations` are disjoint
         // fields, so the `registration` borrow stays live across the syscall.)

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -505,9 +505,9 @@ impl Reactor {
         }
     }
 
-    /// Ask the run loop to stop once the current dispatch returns. Handlers call
-    /// this (the self-pipe handler does, on a shutdown signal); calling it outside
-    /// a run loop just arms the next one to exit immediately.
+    /// Ask the run loop to stop once the current dispatch returns. Handlers call this (the self-pipe
+    /// handler does, on a shutdown signal). Calling it outside a run loop has no lasting effect:
+    /// [`run`](Self::run) clears the flag before entering the loop.
     pub(crate) fn request_shutdown(&mut self) {
         self.shutdown = true;
     }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -226,6 +226,15 @@ impl Reactor {
                 "watch: no such handler",
             ));
         };
+        // Enforce add-once here, not in the Poller: kqueue's EV_ADD silently modifies an existing
+        // filter instead of reporting a re-add, so a double-watch would retag one fd's routing and
+        // let a later unwatch strip both regs' kernel interest. A caller bug, rejected uniformly.
+        if self.registrations.iter().any(|(_, reg)| reg.fd == fd) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "watch: fd already watched",
+            ));
+        }
         let reg_key = RegKey(self.registrations.insert(Registration {
             fd,
             handler_key,
@@ -1019,6 +1028,18 @@ mod tests {
         // A live fd, so the rejection is due to the stale handler key, not a bad fd.
         let (b, _pb) = pair();
         assert!(reactor.watch(hk, b.as_raw_fd(), 0).is_err());
+    }
+
+    #[test]
+    fn watch_rejects_a_duplicate_fd() {
+        let mut reactor = Reactor::new().unwrap();
+        let (a, _pa) = pair();
+        let raw = a.as_raw_fd();
+        let (hk, _rk) = watch1(&mut reactor, TestHandler::read(a, |_, _| {}), raw);
+        // A second watch of the same fd is a caller bug the reactor rejects uniformly: kqueue's
+        // EV_ADD can't report the re-add, so without this the BSD backend would retag the fd and a
+        // later unwatch would strip both regs' interest.
+        assert!(reactor.watch(hk, raw, 0).is_err());
     }
 
     #[test]

--- a/src/reactor/signal.rs
+++ b/src/reactor/signal.rs
@@ -81,6 +81,10 @@ impl SignalGuard {
         {
             return Err(io::Error::other("signal handlers already installed"));
         }
+        // Clear any flag a signal set during a previous guard's teardown window, so it can't leak into
+        // this run and turn the first wakeup into a spurious shutdown. No handler is installed yet.
+        SHUTDOWN_REQUESTED.store(false, Ordering::Relaxed);
+        DUMP_REQUESTED.store(false, Ordering::Relaxed);
         let saved = match install_handlers() {
             Ok(saved) => saved,
             Err(e) => {
@@ -209,7 +213,13 @@ fn restore_handlers(saved: &[libc::sigaction]) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    /// Serializes the tests that call [`SignalGuard::install`]: both touch the process-global
+    /// `WRITE_FD` and signal flags, and the harness runs tests on parallel threads.
+    static SIGNAL_STATE: Mutex<()> = Mutex::new(());
 
     #[test]
     fn self_pipe_is_cloexec_and_nonblocking() {
@@ -233,10 +243,13 @@ mod tests {
         }
     }
 
-    // The one test that touches process-global signal state, so it cannot race a
-    // sibling: nothing else here installs handlers.
+    // Installs process-global signal handlers, so it is serialized with the other install test via
+    // `SIGNAL_STATE`.
     #[test]
     fn installed_handler_flags_shutdown_and_dump() {
+        let _serialized = SIGNAL_STATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (guard, pipe) = SignalGuard::install().unwrap();
 
         // Our handlers must catch these (set a flag, wake the pipe), not terminate the process:
@@ -264,5 +277,26 @@ mod tests {
         assert!(SignalGuard::install().is_err());
 
         drop(guard); // restores the previous dispositions
+    }
+
+    #[test]
+    fn install_clears_a_stale_signal_flag() {
+        let _serialized = SIGNAL_STATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // A flag a signal set during a prior run's teardown window must not survive into the next
+        // install, or the first wakeup would act on it (e.g. a spurious shutdown).
+        SHUTDOWN_REQUESTED.store(true, Ordering::Relaxed);
+        DUMP_REQUESTED.store(true, Ordering::Relaxed);
+        let (guard, _pipe) = SignalGuard::install().unwrap();
+        assert!(
+            !SHUTDOWN_REQUESTED.load(Ordering::Relaxed),
+            "install clears a stale shutdown flag"
+        );
+        assert!(
+            !DUMP_REQUESTED.load(Ordering::Relaxed),
+            "install clears a stale dump flag"
+        );
+        drop(guard);
     }
 }


### PR DESCRIPTION
kqueue's `EV_ADD` silently modifies an existing filter instead of reporting a re-add, so watching one fd twice retagged its routing to the second registration, and a later `unwatch`/`unregister` of either `EV_DELETE`d the filter for both, stranding the survivor with read interest but no kernel interest (its fd never fires again). epoll masks this (`EPOLL_CTL_ADD` returns `EEXIST`). No current caller double-watches, so it is latent, but the add-once enforcement the epoll backend attributes to the reactor was never written.

`watch()` now rejects a second watch of an already-watched fd, uniform across both backends.

## Testing
fmt/clippy clean; reactor suite 50 pass, including the new `watch_rejects_a_duplicate_fd`.