### PR TITLE
dial + HTTP framing hardening

### DIFF
--- a/src/dispatch/dial_context.rs
+++ b/src/dispatch/dial_context.rs
@@ -8,10 +8,10 @@ use crate::reactor::{HandlerKey, Reactor};
 
 use super::CaptureKey;
 
-/// Cap on concurrent minted DIAL proxies, so a burst of advertised devices can't exhaust source-side
-/// listeners or reactor slots. At the cap a new device's `LOCATION` is reflected unchanged (visible but
-/// unproxied) rather than evicting a live proxy.
-const MAX_DIAL_PROXIES: usize = 32;
+/// Cap on concurrent minted DIAL proxies (daemon-wide), so a burst of advertised devices can't exhaust
+/// source-side listeners or reactor slots. At the cap a new device's `LOCATION` is reflected unchanged
+/// (visible but unproxied) rather than evicting a live proxy.
+const MAX_DIAL_PROXIES: usize = 64;
 
 /// One minted DIAL description proxy, keyed by `(source, endpoint)`:
 /// - `target`: capture the device connections egress on; a change on either interface evicts the proxy.

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -28,7 +28,7 @@ pub(crate) fn parse_authority(value: &[u8], bare: bool) -> Option<Authority> {
     };
     let len = rest
         .iter()
-        .position(|&b| matches!(b, b'/' | b' ' | b'\t' | b'\r'))
+        .position(|&b| matches!(b, b'/' | b'?' | b'#' | b' ' | b'\t' | b'\r'))
         .unwrap_or(rest.len());
     let authority = &rest[..len];
     let (host, port) = match authority.iter().rposition(|&b| b == b':') {
@@ -88,6 +88,18 @@ mod tests {
                 .endpoint,
             "10.0.0.7:80".parse().unwrap()
         );
+    }
+
+    #[test]
+    fn authority_terminates_at_query_or_fragment() {
+        // A pathless URL with a query or fragment: the authority ends at '?'/'#' (RFC 3986), so the
+        // host:port is still parsed and rewritten instead of poisoning the port parse.
+        let a = parse_authority(b"http://10.0.0.7:8008?token=x", false).unwrap();
+        assert_eq!(a.endpoint, "10.0.0.7:8008".parse().unwrap());
+        assert_eq!(a.len, "10.0.0.7:8008".len());
+        let a = parse_authority(b"http://10.0.0.7#frag", false).unwrap();
+        assert_eq!(a.endpoint, "10.0.0.7:80".parse().unwrap());
+        assert_eq!(a.len, "10.0.0.7".len());
     }
 
     #[test]

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -10,9 +10,10 @@ const CRLF: &[u8] = b"\r\n";
 
 const HEADER_TERMINATOR: &[u8] = b"\r\n\r\n";
 
-/// Header-block byte cap. A header not terminated by this point is refused, so a peer can't grow the
-/// owner's buffer unbounded. The proxy's receive buffer must EXCEED this (a const-assert there), else
-/// the over-cap refusal can't fire before the buffer fills and the reader livelocks.
+/// Header-block byte cap: a header block larger than this is refused whether or not it has terminated,
+/// so the limit doesn't depend on TCP segmentation and a peer can't grow the owner's buffer unbounded.
+/// The proxy's receive buffer must EXCEED this (a const-assert there), else the over-cap refusal can't
+/// fire before the buffer fills and the reader livelocks.
 pub(crate) const MAX_HEADER: usize = 2 * 1024;
 
 /// The unterminated-line guard for a single chunk-size line (`1a3\r\n`, plus any chunk extensions).
@@ -137,6 +138,9 @@ impl HttpFraming {
                     authority: None,
                 }); // incomplete: read more
             };
+            if end > MAX_HEADER {
+                return Err(FramingError::HeaderTooLong);
+            }
             authority = self.scan_and_rewrite_header(&input[..end])?;
             pos = end;
             header_complete = true;
@@ -549,6 +553,17 @@ mod tests {
             Err(FramingError::MalformedChunkSize)
         );
         assert_eq!(parse_chunk_size(b"ff"), Ok(255)); // a bare hex size still parses
+    }
+
+    #[test]
+    fn rejects_an_over_cap_header_even_when_terminated() {
+        // The cap must not depend on TCP segmentation: a terminated header block over MAX_HEADER is
+        // refused just like an unterminated one, so a coalesced recv can't slip a huge header through.
+        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        let mut msg = b"HTTP/1.1 200 OK\r\nX-Pad: ".to_vec();
+        msg.resize(msg.len() + MAX_HEADER, b'a');
+        msg.extend_from_slice(b"\r\n\r\n");
+        assert!(matches!(f.feed(&msg), Err(FramingError::HeaderTooLong)));
     }
 
     #[test]

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -382,8 +382,12 @@ fn parse_chunk_size(line: &[u8]) -> Result<usize, FramingError> {
         Some(semi) => &line[..semi],
         None => line,
     };
-    let text =
-        std::str::from_utf8(hex.trim_ascii()).map_err(|_| FramingError::MalformedChunkSize)?;
+    let hex = hex.trim_ascii();
+    // Reject a sign or other non-hex lead (RFC 9112 §7.1 is 1*HEXDIG): from_str_radix tolerates a '+'.
+    if !hex.first().is_some_and(u8::is_ascii_hexdigit) {
+        return Err(FramingError::MalformedChunkSize);
+    }
+    let text = std::str::from_utf8(hex).map_err(|_| FramingError::MalformedChunkSize)?;
     usize::from_str_radix(text, 16).map_err(|_| FramingError::MalformedChunkSize)
 }
 
@@ -405,7 +409,12 @@ fn parse_status_code(line: &[u8]) -> u16 {
 /// Parse a `Content-Length` value: surrounding whitespace (RFC 7230 OWS) is tolerated, but the rest
 /// must be a bare integer. `12abc` is rejected, not truncated to 12.
 fn parse_content_length(value: &[u8]) -> Result<usize, FramingError> {
-    std::str::from_utf8(value.trim_ascii())
+    let digits = value.trim_ascii();
+    // Reject a sign or other non-digit lead (RFC 9110 §8.6 is 1*DIGIT): parse tolerates a '+'.
+    if !digits.first().is_some_and(u8::is_ascii_digit) {
+        return Err(FramingError::MalformedContentLength);
+    }
+    std::str::from_utf8(digits)
         .ok()
         .and_then(|s| s.parse().ok())
         .ok_or(FramingError::MalformedContentLength)
@@ -525,6 +534,21 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    #[test]
+    fn rejects_a_signed_length_or_chunk_size() {
+        // Rust's integer parsing accepts a leading '+', but the RFC grammars are 1*DIGIT / 1*HEXDIG.
+        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        assert_eq!(
+            f.scan_and_rewrite_header(b"HTTP/1.1 200 OK\r\nContent-Length: +5\r\n\r\n"),
+            Err(FramingError::MalformedContentLength)
+        );
+        assert_eq!(
+            parse_chunk_size(b"+ff"),
+            Err(FramingError::MalformedChunkSize)
+        );
+        assert_eq!(parse_chunk_size(b"ff"), Ok(255)); // a bare hex size still parses
     }
 
     #[test]

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -42,9 +42,14 @@ enum Phase {
     BodyCloseDelimited,
 }
 
-/// A malformed or over-cap message. The proxy maps any variant to drop-and-close.
+/// A message the proxy can't safely forward: malformed, over-cap, or a method whose response it can't
+/// delimit. The proxy maps any variant to drop-and-close.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum FramingError {
+    /// A `HEAD` request. A HEAD response carries no body yet may still send `Content-Length`,
+    /// indistinguishable from a real body without tracking the request method, so the proxy refuses HEAD
+    /// rather than risk desyncing the keep-alive stream. DIAL itself never uses HEAD.
+    UnsupportedMethod,
     /// A header block that never terminated within [`MAX_HEADER`] bytes.
     HeaderTooLong,
     /// A `Content-Length` value that isn't a bare non-negative integer.
@@ -230,8 +235,14 @@ impl HttpFraming {
             let line_end = find_crlf(&block[pos..]).map_or(block.len(), |i| pos + i);
             let line = &block[pos..line_end];
             if first {
-                if matches!(self.kind, Kind::Response) {
-                    status = parse_status_code(line);
+                match self.kind {
+                    Kind::Response => status = parse_status_code(line),
+                    // Refuse HEAD: its bodyless response can't be told from a Content-Length body
+                    // without tracking the request method (see FramingError::UnsupportedMethod).
+                    Kind::Request if line.starts_with(b"HEAD ") => {
+                        return Err(FramingError::UnsupportedMethod);
+                    }
+                    Kind::Request => {}
                 }
                 self.copy_line(line);
                 first = false;
@@ -467,6 +478,23 @@ mod tests {
         assert_eq!(
             f.header,
             b"GET /apps/YouTube HTTP/1.1\r\nHost: 10.1.3.80:36866\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn refuses_a_head_request() {
+        // A HEAD response is bodyless but may still carry Content-Length, which would desync the
+        // keep-alive stream, so the proxy refuses HEAD outright (DIAL never uses it).
+        let mut f = HttpFraming::new(Kind::Request, RewritePolicy::NONE);
+        assert_eq!(
+            f.scan_and_rewrite_header(b"HEAD /dd.xml HTTP/1.1\r\nHost: 10.0.0.1:80\r\n\r\n"),
+            Err(FramingError::UnsupportedMethod)
+        );
+        // A normal request method still frames.
+        let mut g = HttpFraming::new(Kind::Request, RewritePolicy::NONE);
+        assert!(
+            g.scan_and_rewrite_header(b"GET /dd.xml HTTP/1.1\r\nHost: 10.0.0.1:80\r\n\r\n")
+                .is_ok()
         );
     }
 

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -54,6 +54,9 @@ pub(crate) enum FramingError {
     HeaderTooLong,
     /// A `Content-Length` value that isn't a bare non-negative integer.
     MalformedContentLength,
+    /// Multiple `Content-Length` header fields with differing values: RFC 9112 §6.3 treats a message with
+    /// conflicting Content-Lengths as unrecoverable (a request-smuggling vector), so the proxy refuses it.
+    ConflictingContentLength,
     /// A chunk-size line that isn't a hex integer.
     MalformedChunkSize,
     /// A chunk size so large that adding its terminating CRLF would overflow `usize`. No legitimate
@@ -266,7 +269,13 @@ impl HttpFraming {
         chunked: &mut bool,
     ) -> Result<Option<AuthorityHeader>, FramingError> {
         if let Some(value) = strip_prefix_ignore_ascii_case(line, b"Content-Length:") {
-            *content_length = Some(parse_content_length(value)?);
+            let n = parse_content_length(value)?;
+            // A second, differing Content-Length is a request-smuggling vector (RFC 9112 §6.3): refuse
+            // the message rather than pick a last-wins length. Identical repeats agree, so they're kept.
+            if content_length.is_some_and(|prev| prev != n) {
+                return Err(FramingError::ConflictingContentLength);
+            }
+            *content_length = Some(n);
             self.copy_line(line);
             return Ok(None);
         }
@@ -495,6 +504,26 @@ mod tests {
         assert!(
             g.scan_and_rewrite_header(b"GET /dd.xml HTTP/1.1\r\nHost: 10.0.0.1:80\r\n\r\n")
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_conflicting_content_lengths() {
+        // Two differing Content-Length headers are a smuggling vector; refuse rather than last-wins.
+        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        assert_eq!(
+            f.scan_and_rewrite_header(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nContent-Length: 100\r\n\r\n"
+            ),
+            Err(FramingError::ConflictingContentLength)
+        );
+        // Identical repeats agree on the framing, so they are tolerated.
+        let mut g = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        assert!(
+            g.scan_and_rewrite_header(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\n"
+            )
+            .is_ok()
         );
     }
 

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -23,6 +23,11 @@ use super::proxy::{DialDeviceProxy, Listener};
 /// UDA-recommended minimum device validity (DIAL's own example advertises `max-age=1800`).
 const DEFAULT_DESC_GRACE: Duration = Duration::from_mins(30);
 
+/// Ceiling on an advertised `max-age`, which sets the proxy's grace-sweep deadline, so clamp it to bound
+/// how long one advertisement (a spoofed burst included) can pin a scarce proxy slot. Well above any real
+/// DIAL device's re-advertise interval, so a live device still refreshes its grace in time.
+const MAX_DESC_GRACE: Duration = Duration::from_hours(2);
+
 /// Stack scratch to rewrite one SSDP datagram into. Anchored to the dispatcher's send frame buffer
 /// ([`SCRATCH_LEN`](crate::dispatch::SCRATCH_LEN)): the reflector builds its outgoing frame there, so
 /// anything that doesn't fit can't be forwarded anyway. A `LOCATION` rewrite can grow the datagram;
@@ -69,9 +74,10 @@ pub(crate) fn rewrite_location(
         return false;
     };
     // The grace is refreshed on every advertisement / search response, so a re-advertised device's
-    // cached LOCATION keeps resolving for another max-age.
+    // cached LOCATION keeps resolving for another max-age. Clamp it (MAX_DESC_GRACE): the value is
+    // attacker-controlled and sets a proxy-slot eviction deadline.
     let max_age = parse_cache_control_max_age(payload).map_or(DEFAULT_DESC_GRACE, |seconds| {
-        Duration::from_secs(u64::from(seconds))
+        Duration::from_secs(u64::from(seconds)).min(MAX_DESC_GRACE)
     });
     let desc_grace = Instant::now() + max_age;
     let desc_addr = if let Some(addr) = ctx.lookup(
@@ -356,6 +362,24 @@ mod tests {
         assert!(
             !reactor.is_registered(key),
             "and torn down from the reactor"
+        );
+    }
+
+    #[test]
+    fn rewrite_location_clamps_an_oversized_max_age() {
+        let mut reactor = Reactor::new().expect("reactor");
+        let mut ctx = DialContext::new();
+        // A spoofed advertisement with an enormous max-age must not pin the proxy slot for ~136 years.
+        let advert = b"NOTIFY * HTTP/1.1\r\nNT: urn:dial-multiscreen-org:service:dial:1\r\n\
+            LOCATION: http://10.0.0.5:8008/dd.xml\r\nCACHE-CONTROL: max-age=4294967295\r\n\r\n";
+        assert!(rewrite_advert(&mut ctx, &mut reactor, advert).is_some());
+        let ceiling = Instant::now() + MAX_DESC_GRACE;
+        let grace = ctx
+            .grace_of(advert_source(), ADVERT_ENDPOINT.parse().unwrap())
+            .expect("a grace was recorded");
+        assert!(
+            grace <= ceiling,
+            "an oversized max-age is clamped to MAX_DESC_GRACE"
         );
     }
 }


### PR DESCRIPTION
DIAL proxy + HTTP/1.x framing hardening (six fixes).

- **dial: clamp max-age, bump proxy cap.** An unbounded `CACHE-CONTROL: max-age` set the proxy grace verbatim, so one spoofed advertisement could pin a slot for ~136 years. Clamp to 2h; raise `MAX_DIAL_PROXIES` 32→64. Refuse-at-cap kept (the cap bounds daemon resources; DIAL cap configurability deferred to the config PR).
- **http: refuse HEAD.** A HEAD response has no body but may send `Content-Length`; the response framer cannot see the request method, so it would await phantom bytes and desync keep-alive. Refuse HEAD at the request framer.
- **http: terminate the authority at `?`/`#`.** `parse_authority` stopped only at `/`/space/tab/CR, so a pathless URL with a query poisoned the port parse and skipped the rewrite (device-address leak). Added `?`/`#` per RFC 3986.
- **http: reject conflicting Content-Length.** A second, differing `Content-Length` overwrote the first (last-wins), a smuggling divergence. Refuse per RFC 9112 §6.3; identical repeats still pass.
- **http: reject a signed length / chunk-size.** Rust parsing accepts a leading `+` that `1*DIGIT` / `1*HEXDIG` forbid; require a digit/hex lead.
- **http: enforce MAX_HEADER on terminated headers too.** The cap fired only on unterminated headers, making the limit depend on TCP segmentation. Check the found block size too.

## Testing
fmt/clippy/doc clean; `cargo test` 394 pass, with a new test per fix.