### PR TITLE
interface: address-monitor robustness + a macOS multicast fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@
   denies broken/private intra-doc links, but only `cargo doc` runs that check
   (clippy/build don't). It's a separate gate step; run it on Linux too
   (`./docker_test.sh doc --no-deps --document-private-items`) for `cfg` items.
+- Gate shared-logic changes (errno classifier, parser, struct layout) with the full
+  `cargo test --lib`, not a name-filtered subset that can skip the integration test
+  exercising the real syscall path.
 - Platform `cfg` code (the epoll backend now, AF_PACKET capture later) isn't built
   on the macOS dev host — verify it on Linux with `./docker_test.sh` (forwards to
   cargo, e.g. `./docker_test.sh clippy --all-targets -- -D warnings`). Check both

--- a/README.md
+++ b/README.md
@@ -329,6 +329,12 @@ appears. Gaining a family logs at `info`; losing a *required* family logs at `er
 `info`. The monitor is best-effort: if it cannot start, the reflector logs a warning and runs without
 address refresh.
 
+It does not, however, adapt to an interface being destroyed and recreated (a fresh kernel ifindex,
+e.g. a PPPoE reconnect or a bridge/VLAN rebuild): the ifindex and capture are pinned when the interface
+is opened, so reflection on a recreated interface stays dead until you restart the daemon. The interfaces
+a reflector bridges are normally stable LAN segments, so this rarely bites, and it matches avahi, which
+likewise needs a restart when an interface disappears and returns.
+
 ### Per-protocol behavior
 
 | Protocol | Port(s) | Group / destination | Relay direction |

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -574,8 +574,13 @@ impl PacketDispatcher {
                 changed.push(ifindex);
             }
         }) {
-            log::warn!("address monitor read failed; skipping refresh: {e}");
-            return;
+            // The drain already consumed and collected these notifications before failing, so refresh
+            // what we have rather than discard it; the socket's unread remainder stays readable and the
+            // level-triggered wait re-drains it.
+            log::warn!("address monitor read failed mid-drain; refreshing what was collected: {e}");
+        }
+        if changed.is_empty() {
+            return; // nothing collected (a spurious wakeup, or a drain error before the first read)
         }
         // The DIAL proxies bind IPv4 only, so collect the interfaces whose v4 address actually moved. A
         // routine v6 or MAC change must not churn a proxy whose v4 (and cached LOCATION) is unchanged.

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -103,10 +103,10 @@ impl MulticastJoiner {
     }
 }
 
-/// Whether a join error means the membership is already held, a benign duplicate. The errno isn't
-/// uniform: Linux and the BSDs' IPv4 path return `EADDRINUSE`, FreeBSD's IPv6 path `EINVAL`.
+/// Whether a join error means the membership is already held, the benign duplicate the idempotent join
+/// relies on. Every target returns `EADDRINUSE` for an any-source re-join of an existing membership.
 fn already_member(err: &io::Error) -> bool {
-    matches!(err.raw_os_error(), Some(libc::EADDRINUSE | libc::EINVAL))
+    err.raw_os_error() == Some(libc::EADDRINUSE)
 }
 
 /// Whether a join error means the environment can't perform the join at all (vs a real rejection),
@@ -127,10 +127,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn already_member_only_for_the_duplicate_join_errnos() {
+    fn already_member_only_for_the_duplicate_join_errno() {
         let of = io::Error::from_raw_os_error;
-        assert!(already_member(&of(libc::EADDRINUSE))); // Linux / BSD IPv4 duplicate
-        assert!(already_member(&of(libc::EINVAL))); // FreeBSD IPv6 duplicate
+        assert!(already_member(&of(libc::EADDRINUSE))); // duplicate any-source join, every target
+        assert!(!already_member(&of(libc::EINVAL))); // a genuine rejection (bad / non-multicast group)
         assert!(!already_member(&of(libc::ENOBUFS))); // membership cap, a real failure
         assert!(!already_member(&of(libc::EADDRNOTAVAIL))); // interface transiently down
     }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -130,6 +130,11 @@ impl Ipv6Scope {
 /// One configured interface: its name (kept for re-resolution), kernel ifindex (the address
 /// monitor's lookup key), and current source addresses. Built by [`open`](Self::open); the
 /// monitor later refreshes `addrs` in place.
+///
+/// The `ifindex` is cached at open, not re-derived: if the OS destroys and recreates the interface
+/// (a fresh kernel ifindex, e.g. a `PPPoE` reconnect or a bridge/VLAN rebuild), the monitor no longer
+/// matches its notifications and the capture stays bound to the dead index, so reflection on it is
+/// dead until a restart.
 pub(crate) struct Interface {
     pub(crate) name: String,
     pub(crate) ifindex: u32,

--- a/src/interface/address_monitor.rs
+++ b/src/interface/address_monitor.rs
@@ -65,13 +65,20 @@ impl AddressMonitor {
     pub(crate) fn drain(&mut self, mut on_change: impl FnMut(u32)) -> io::Result<()> {
         let mut overflows = 0u32;
         loop {
-            // SAFETY: `recv` fills up to `buf.len()` bytes of the owned buffer.
+            // SAFETY: an all-zero sockaddr_storage is a valid, inert source-address out-param.
+            let mut src: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut addrlen = libc::socklen_t::try_from(size_of::<libc::sockaddr_storage>())
+                .expect("sockaddr_storage fits socklen_t");
+            // SAFETY: `recvfrom` fills up to `buf.len()` bytes of the owned buffer and writes the
+            // datagram's source address into the `src`/`addrlen` out-params.
             let n = unsafe {
-                libc::recv(
+                libc::recvfrom(
                     self.sock.as_raw_fd(),
                     self.buf.as_mut_ptr().cast(),
                     self.buf.len(),
                     0,
+                    (&raw mut src).cast::<libc::sockaddr>(),
+                    &raw mut addrlen,
                 )
             };
             // ENOBUFS is the drain's own signal (a dropped-notification overflow → re-resolve
@@ -101,7 +108,13 @@ impl AddressMonitor {
                 // don't EOF).
                 IoStatus::WouldBlock | IoStatus::Ready(0) => return Ok(()),
                 IoStatus::Ready(len) => {
-                    backend::for_each_change(&self.buf[..len], &mut on_change);
+                    if backend::sender_ok(&src, addrlen) {
+                        backend::for_each_change(&self.buf[..len], &mut on_change);
+                    } else {
+                        log::debug!(
+                            "address monitor: dropping a notification from a non-kernel sender"
+                        );
+                    }
                 }
             }
         }

--- a/src/interface/address_monitor/route.rs
+++ b/src/interface/address_monitor/route.rs
@@ -14,6 +14,12 @@ use libc::c_int;
 /// backend's 8 KiB suffices.
 pub(super) const READ_BUF: usize = 2048;
 
+/// Requested `SO_RCVBUF` for the route socket, whose default receive queue is only ~8 KiB. Enlarge it so
+/// a burst of routing messages is far less likely to overflow it and drop changes. Best-effort and
+/// kernel-clamped; FreeBSD's `SO_RERROR` still recovers from an overflow, and macOS (no `SO_RERROR`)
+/// relies on this alone. Linux's netlink monitor already defaults to the system max, so it isn't grown.
+const RECV_BUFFER: c_int = 256 * 1024;
+
 /// `ifam_index` (in `ifa_msghdr`) and `ifm_index` (in `if_msghdr`) are both a `u16` at this
 /// offset; the asserts pin it against the libc layout.
 const INDEX_OFFSET: usize = 12;
@@ -31,6 +37,7 @@ pub(super) fn open() -> io::Result<OwnedFd> {
     let sock = crate::sys::owned_fd_from(unsafe { libc::socket(libc::PF_ROUTE, socktype, 0) })?;
     #[cfg(target_os = "macos")]
     crate::sys::set_cloexec_nonblock(sock.as_raw_fd())?;
+    crate::sys::set_recv_buffer(sock.as_raw_fd(), RECV_BUFFER);
     // FreeBSD only: without SO_RERROR a receive-buffer overflow is dropped silently, so the drain's
     // ENOBUFS re-resolve-all recovery never fires and address changes are lost under pressure. Enabling
     // it surfaces the overflow as ENOBUFS on the next recv; Linux netlink already reports it. macOS has

--- a/src/interface/address_monitor/route.rs
+++ b/src/interface/address_monitor/route.rs
@@ -5,9 +5,7 @@
 //! the BSDs.
 
 use std::io;
-#[cfg(target_os = "macos")]
-use std::os::fd::AsRawFd;
-use std::os::fd::OwnedFd;
+use std::os::fd::{AsRawFd, OwnedFd};
 
 use libc::c_int;
 
@@ -33,6 +31,28 @@ pub(super) fn open() -> io::Result<OwnedFd> {
     let sock = crate::sys::owned_fd_from(unsafe { libc::socket(libc::PF_ROUTE, socktype, 0) })?;
     #[cfg(target_os = "macos")]
     crate::sys::set_cloexec_nonblock(sock.as_raw_fd())?;
+    // FreeBSD only: without SO_RERROR a receive-buffer overflow is dropped silently, so the drain's
+    // ENOBUFS re-resolve-all recovery never fires and address changes are lost under pressure. Enabling
+    // it surfaces the overflow as ENOBUFS on the next recv; Linux netlink already reports it. macOS has
+    // the same silent drop but no SO_RERROR (a FreeBSD 13.0+ option) or equivalent, so the
+    // overflow-recovery gap is unfixable there.
+    #[cfg(target_os = "freebsd")]
+    {
+        let on: c_int = 1;
+        // SAFETY: setsockopt reads `on` (a c_int of the given length) on a valid socket fd.
+        let rc = unsafe {
+            libc::setsockopt(
+                sock.as_raw_fd(),
+                libc::SOL_SOCKET,
+                crate::libcex::SO_RERROR,
+                (&raw const on).cast(),
+                libc::socklen_t::try_from(size_of::<c_int>()).expect("c_int fits socklen_t"),
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
     Ok(sock)
 }
 

--- a/src/interface/address_monitor/route.rs
+++ b/src/interface/address_monitor/route.rs
@@ -72,6 +72,12 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
     }
 }
 
+/// `PF_ROUTE` messages have no per-message sender identity; every one is the kernel's, so accept all.
+/// (Mirrors the netlink backend's `sender_ok`, which rejects locally-spoofed datagrams.)
+pub(super) fn sender_ok(_src: &libc::sockaddr_storage, _len: libc::socklen_t) -> bool {
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/interface/address_monitor/rtnetlink.rs
+++ b/src/interface/address_monitor/rtnetlink.rs
@@ -92,6 +92,18 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
     }
 }
 
+/// Whether a notification came from the kernel. The kernel's netlink source address has `nl_pid == 0`;
+/// a user process's carries its port id, so a non-zero pid is a locally-spoofed datagram (netlink
+/// user-to-user unicast needs no privilege) and is dropped.
+pub(super) fn sender_ok(src: &libc::sockaddr_storage, len: socklen_t) -> bool {
+    if usize::try_from(len).unwrap_or(0) < size_of::<SockAddrNl>() {
+        return false;
+    }
+    // SAFETY: the len check guarantees the storage holds a full sockaddr_nl; read its prefix unaligned.
+    let nl = unsafe { std::ptr::read_unaligned((&raw const *src).cast::<SockAddrNl>()) };
+    nl.pid == 0
+}
+
 /// Forward a change for `index`, unless `index` is 0. Zero names no interface (kernel
 /// indices are >= 1) and is the parent's "re-resolve everything" overflow signal, so a stray
 /// 0 must never be forwarded.
@@ -132,6 +144,29 @@ mod tests {
         let mut b = vec![0u8; size_of::<libc::ifinfomsg>()];
         b[4..8].copy_from_slice(&index.to_ne_bytes());
         b
+    }
+
+    /// A `sockaddr_storage` holding a `sockaddr_nl` with `pid` as its `nl_pid`.
+    fn storage_with_pid(pid: u32) -> libc::sockaddr_storage {
+        let nl = SockAddrNl {
+            pid,
+            ..SockAddrNl::default()
+        };
+        // SAFETY: an all-zero sockaddr_storage is valid, and it is large enough and aligned to hold a
+        // sockaddr_nl written into its prefix.
+        unsafe {
+            let mut ss: libc::sockaddr_storage = std::mem::zeroed();
+            std::ptr::write((&raw mut ss).cast::<SockAddrNl>(), nl);
+            ss
+        }
+    }
+
+    #[test]
+    fn sender_ok_accepts_only_the_kernel() {
+        let full = socklen_t::try_from(size_of::<SockAddrNl>()).unwrap();
+        assert!(sender_ok(&storage_with_pid(0), full)); // the kernel (nl_pid 0)
+        assert!(!sender_ok(&storage_with_pid(1234), full)); // a user process's port id
+        assert!(!sender_ok(&storage_with_pid(0), 4)); // a too-short source address
     }
 
     #[test]

--- a/src/interface/address_monitor/rtnetlink.rs
+++ b/src/interface/address_monitor/rtnetlink.rs
@@ -57,7 +57,10 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
     let mut offset = 0;
     while let Some(hdr) = read_at::<NlMsgHdr>(buf, offset) {
         let len = hdr.len as usize;
-        if len < size_of::<NlMsgHdr>() || offset + len > buf.len() {
+        // checked_add: a crafted len must not wrap `offset + len` past the bound on a 32-bit usize
+        // (which would also make `nl_align(len)` wrap to 0 and spin the walk forever).
+        if len < size_of::<NlMsgHdr>() || offset.checked_add(len).is_none_or(|end| end > buf.len())
+        {
             // Not a normal end (that's the `while` running out): a message claims an
             // impossible length (truncated datagram or corruption), so a change is dropped.
             log::warn!(
@@ -175,5 +178,19 @@ mod tests {
         let mut seen = Vec::new();
         for_each_change(&buf, &mut |i| seen.push(i));
         assert!(seen.is_empty());
+    }
+
+    #[test]
+    fn stops_at_a_length_that_would_overflow_the_offset() {
+        // A crafted second message with len ~usize::MAX (u32::MAX on the 32-bit targets) must not wrap
+        // `offset + len` past the bound check and spin the walk forever (the wrap needs a non-zero
+        // offset); the walk reports the valid first message, then breaks.
+        let mut buf = message(libc::RTM_NEWADDR, &ifaddrmsg(7));
+        let second = buf.len();
+        buf.extend(message(libc::RTM_NEWADDR, &ifaddrmsg(9)));
+        buf[second..second + 4].copy_from_slice(&u32::MAX.to_ne_bytes());
+        let mut seen = Vec::new();
+        for_each_change(&buf, &mut |i| seen.push(i));
+        assert_eq!(seen, [7]);
     }
 }

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -8,12 +8,12 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::ptr;
 
-use libc::c_int;
+use libc::{c_int, socklen_t};
 
 use super::{InterfaceAddresses, V6Pick, v6_rank};
 use crate::libcex::{
     IfAddrMsg, NETLINK_ROUTE, NLM_F_DUMP, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, NlMsgHdr, RtAttr,
-    nl_align,
+    SockAddrNl, nl_align,
 };
 use crate::net::mac::MacAddr;
 
@@ -171,12 +171,32 @@ fn dump<B>(
         let size = usize::try_from(size).expect("recv count is non-negative");
         buf.resize(size, 0);
 
-        // SAFETY: `recv` fills up to `buf.len()` bytes of the owned buffer, which now holds
-        // the whole datagram.
-        let received =
-            unsafe { libc::recv(sock.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len(), 0) };
+        let mut src = SockAddrNl::default();
+        let mut addrlen =
+            socklen_t::try_from(size_of::<SockAddrNl>()).expect("sockaddr_nl fits socklen_t");
+        // SAFETY: `recvfrom` fills up to `buf.len()` bytes of the owned buffer (now the whole
+        // datagram) and writes the source address into the `src`/`addrlen` out-params.
+        let received = unsafe {
+            libc::recvfrom(
+                sock.as_raw_fd(),
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                0,
+                (&raw mut src).cast::<libc::sockaddr>(),
+                &raw mut addrlen,
+            )
+        };
         if received < 0 {
             return Err(io::Error::last_os_error());
+        }
+        // Only the kernel (nl_pid == 0) may answer the dump; a local process could unicast a spoofed
+        // reply to inject a bogus address. Discard anything else and read the next datagram.
+        if src.pid != 0 {
+            log::debug!(
+                "netlink dump: ignoring a reply from a non-kernel sender (pid {})",
+                src.pid
+            );
+            continue;
         }
         let received = usize::try_from(received).expect("recv count is non-negative");
 

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -202,7 +202,7 @@ fn dump<B>(
 
         match walk_dump(&buf[..received], reply_type, &mut on_msg) {
             DumpStep::Done => return Ok(()),
-            DumpStep::Failed => return Err(io::Error::other("netlink dump failed")),
+            DumpStep::Failed(e) => return Err(e),
             DumpStep::More => {} // read the next datagram
         }
     }
@@ -212,8 +212,8 @@ fn dump<B>(
 enum DumpStep {
     /// `NLMSG_DONE`: the dump is complete.
     Done,
-    /// `NLMSG_ERROR`: the kernel reported a dump error.
-    Failed,
+    /// `NLMSG_ERROR`: the kernel reported a dump error (carrying its errno).
+    Failed(io::Error),
     /// The datagram was fully walked; read the next one.
     More,
 }
@@ -233,13 +233,22 @@ fn walk_dump(buf: &[u8], reply_type: u16, on_msg: &mut impl FnMut(&[u8])) -> Dum
         }
         match hdr.msg_type {
             NLMSG_DONE => return DumpStep::Done,
-            NLMSG_ERROR => return DumpStep::Failed,
+            NLMSG_ERROR => return DumpStep::Failed(nlmsg_error(buf, offset)),
             t if t == reply_type => on_msg(&buf[offset..offset + len]),
             _ => {}
         }
         offset += nl_align(len);
     }
     DumpStep::More
+}
+
+/// The error for an `NLMSG_ERROR` reply at `offset`. Its payload is `struct nlmsgerr { int error; ... }`
+/// where `error` is a negative errno, or 0 for an ACK (which our dumps never request).
+fn nlmsg_error(buf: &[u8], offset: usize) -> io::Error {
+    match read_at::<c_int>(buf, offset + nl_align(size_of::<NlMsgHdr>())) {
+        Some(errno) if errno != 0 => io::Error::from_raw_os_error(errno.saturating_neg()),
+        _ => io::Error::other("netlink dump failed (NLMSG_ERROR without an errno)"),
+    }
 }
 
 /// Parse one `RTM_NEWADDR` message; if it carries a usable address of `ifindex`, record it
@@ -415,6 +424,17 @@ mod tests {
         let step = walk_dump(&buf, libc::RTM_NEWADDR, &mut |_| count += 1);
         assert!(matches!(step, DumpStep::More));
         assert_eq!(count, 1); // only the valid first message was delivered
+    }
+
+    #[test]
+    fn walk_dump_surfaces_the_nlmsg_error_errno() {
+        // NLMSG_ERROR's first payload word is a negative errno; the walk must report it, not a blank
+        // failure. -EPERM here.
+        let buf = nl_message(NLMSG_ERROR, &(-libc::EPERM).to_ne_bytes());
+        match walk_dump(&buf, libc::RTM_NEWADDR, &mut |_| {}) {
+            DumpStep::Failed(e) => assert_eq!(e.raw_os_error(), Some(libc::EPERM)),
+            _ => panic!("expected DumpStep::Failed carrying the errno"),
+        }
     }
 
     #[test]

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -180,21 +180,46 @@ fn dump<B>(
         }
         let received = usize::try_from(received).expect("recv count is non-negative");
 
-        let mut offset = 0;
-        while let Some(hdr) = read_at::<NlMsgHdr>(&buf[..received], offset) {
-            let len = hdr.len as usize;
-            if len < size_of::<NlMsgHdr>() || offset + len > received {
-                break;
-            }
-            match hdr.msg_type {
-                NLMSG_DONE => return Ok(()),
-                NLMSG_ERROR => return Err(io::Error::other("netlink dump failed")),
-                t if t == reply_type => on_msg(&buf[offset..offset + len]),
-                _ => {}
-            }
-            offset += nl_align(len);
+        match walk_dump(&buf[..received], reply_type, &mut on_msg) {
+            DumpStep::Done => return Ok(()),
+            DumpStep::Failed => return Err(io::Error::other("netlink dump failed")),
+            DumpStep::More => {} // read the next datagram
         }
     }
+}
+
+/// One dump datagram's outcome from [`walk_dump`].
+enum DumpStep {
+    /// `NLMSG_DONE`: the dump is complete.
+    Done,
+    /// `NLMSG_ERROR`: the kernel reported a dump error.
+    Failed,
+    /// The datagram was fully walked; read the next one.
+    More,
+}
+
+/// Walk one dump datagram, feeding each `reply_type` message to `on_msg`, and report whether the dump is
+/// done, failed, or needs another datagram. Split from [`dump`]'s socket loop so the message walk (and
+/// its bounds handling) is unit-testable.
+fn walk_dump(buf: &[u8], reply_type: u16, on_msg: &mut impl FnMut(&[u8])) -> DumpStep {
+    let mut offset = 0;
+    while let Some(hdr) = read_at::<NlMsgHdr>(buf, offset) {
+        let len = hdr.len as usize;
+        // checked_add: a crafted len must not wrap `offset + len` past the bound on a 32-bit usize,
+        // which would then panic the `&buf[offset..offset + len]` slice (start > end) below.
+        if len < size_of::<NlMsgHdr>() || offset.checked_add(len).is_none_or(|end| end > buf.len())
+        {
+            break;
+        }
+        match hdr.msg_type {
+            NLMSG_DONE => return DumpStep::Done,
+            NLMSG_ERROR => return DumpStep::Failed,
+            t if t == reply_type => on_msg(&buf[offset..offset + len]),
+            _ => {}
+        }
+        offset += nl_align(len);
+    }
+    DumpStep::More
 }
 
 /// Parse one `RTM_NEWADDR` message; if it carries a usable address of `ifindex`, record it
@@ -325,6 +350,16 @@ mod tests {
         m
     }
 
+    /// A netlink message with its `nlmsghdr` len/type set from `body`, length-padded.
+    fn nl_message(msg_type: u16, body: &[u8]) -> Vec<u8> {
+        let len = size_of::<NlMsgHdr>() + body.len();
+        let mut m = vec![0u8; nl_align(len)];
+        m[0..4].copy_from_slice(&u32::try_from(len).unwrap().to_ne_bytes());
+        m[4..6].copy_from_slice(&msg_type.to_ne_bytes());
+        m[size_of::<NlMsgHdr>()..size_of::<NlMsgHdr>() + body.len()].copy_from_slice(body);
+        m
+    }
+
     #[test]
     fn nl_align_rounds_up_to_four() {
         assert_eq!(nl_align(0), 0);
@@ -342,6 +377,24 @@ mod tests {
         );
         assert_eq!(read_at::<u32>(&buf, 2), None); // 2 + 4 > 5
         assert_eq!(read_at::<u16>(&buf, usize::MAX), None); // offset overflow
+    }
+
+    #[test]
+    fn walk_dump_stops_at_a_length_that_would_overflow_the_offset() {
+        // A crafted second message with len ~usize::MAX (u32::MAX on the 32-bit targets) must not wrap
+        // `offset + len` past the bound and panic the `&buf[offset..offset + len]` slice (start > end);
+        // the walk delivers the valid first message, then breaks and asks for the next datagram.
+        let mut buf = nl_message(libc::RTM_NEWADDR, &[0u8; size_of::<IfAddrMsg>()]);
+        let second = buf.len();
+        buf.extend(nl_message(
+            libc::RTM_NEWADDR,
+            &[0u8; size_of::<IfAddrMsg>()],
+        ));
+        buf[second..second + 4].copy_from_slice(&u32::MAX.to_ne_bytes());
+        let mut count = 0;
+        let step = walk_dump(&buf, libc::RTM_NEWADDR, &mut |_| count += 1);
+        assert!(matches!(step, DumpStep::More));
+        assert_eq!(count, 1); // only the valid first message was delivered
     }
 
     #[test]

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -16,6 +16,8 @@ mod in6_ifreq;
 mod multicast;
 #[cfg(target_os = "linux")]
 mod netlink;
+#[cfg(target_os = "freebsd")]
+mod sockopt;
 
 pub(crate) use self::bpf::BpfInsn;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
@@ -32,3 +34,5 @@ pub(crate) use self::netlink::{
     IfAddrMsg, NETLINK_ROUTE, NLM_F_DUMP, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, NlMsgHdr, RtAttr,
     SockAddrNl, nl_align,
 };
+#[cfg(target_os = "freebsd")]
+pub(crate) use self::sockopt::SO_RERROR;

--- a/src/libcex/multicast.rs
+++ b/src/libcex/multicast.rs
@@ -10,10 +10,23 @@ pub(crate) const MCAST_JOIN_GROUP: c_int = libc::MCAST_JOIN_GROUP;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 pub(crate) const MCAST_JOIN_GROUP: c_int = 80;
 
-/// `struct group_req` (RFC 3678). Absent from libc everywhere, so hand-rolled. `#[repr(C)]` plus
-/// `sockaddr_storage`'s alignment reproduce the C layout: 4 bytes of padding after `gr_interface`.
-#[repr(C)]
+/// `struct group_req` (RFC 3678), absent from libc everywhere. The layout differs by platform: Linux and
+/// FreeBSD align `gr_group` naturally, so `#[repr(C)]` (which pads `gr_interface` out to the
+/// `sockaddr_storage` alignment) matches. macOS declares the multicast request structs `#pragma pack(4)`,
+/// putting `gr_group` at offset 4 with no padding (size 132, not 136); sending the padded layout there
+/// fails the join with `EINVAL`. So pack the struct on macOS and leave it natural elsewhere.
+#[cfg_attr(target_os = "macos", repr(C, packed(4)))]
+#[cfg_attr(not(target_os = "macos"), repr(C))]
 pub(crate) struct GroupReq {
     pub(crate) gr_interface: u32,
     pub(crate) gr_group: libc::sockaddr_storage,
 }
+
+/// Pin the macOS packed layout so a naive `#[repr(C)]` "cleanup" can't silently reintroduce the offset-8
+/// gap that fails the join with `EINVAL`. (Linux/FreeBSD track the kernel by natural alignment, incl. the
+/// 4-byte offset on 32-bit, so they need no pin.)
+#[cfg(target_os = "macos")]
+const _: () = {
+    assert!(size_of::<GroupReq>() == 132);
+    assert!(std::mem::offset_of!(GroupReq, gr_group) == 4);
+};

--- a/src/libcex/sockopt.rs
+++ b/src/libcex/sockopt.rs
@@ -1,0 +1,6 @@
+//! FreeBSD socket options missing from `libc`.
+
+/// `SO_RERROR`: make a receive-buffer overflow surface as an error (`ENOBUFS` on the next recv) instead
+/// of being silently dropped. FreeBSD 13.0+; absent from `libc` as of 0.2.186. Value from
+/// `sys/sys/socket.h`.
+pub(crate) const SO_RERROR: libc::c_int = 0x0002_0000;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -67,6 +67,30 @@ pub(crate) fn socklen_of<T>() -> socklen_t {
     socklen_t::try_from(size_of::<T>()).expect("option/address size fits socklen_t")
 }
 
+/// Best-effort: request a larger `SO_RCVBUF` so a burst can't overflow the kernel receive queue as
+/// easily. The kernel clamps it to its own maximum, and a failure is logged and ignored (the default
+/// buffer still works), so this never fails the caller. Only the BSD route socket needs it (Linux
+/// netlink already defaults to the system max).
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+pub(crate) fn set_recv_buffer(fd: RawFd, bytes: c_int) {
+    // SAFETY: setsockopt reads `bytes` (a c_int of the given length) on a valid socket fd.
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            (&raw const bytes).cast(),
+            socklen_of::<c_int>(),
+        )
+    };
+    if rc != 0 {
+        log::warn!(
+            "could not set the socket receive buffer to {bytes} bytes: {}",
+            io::Error::last_os_error()
+        );
+    }
+}
+
 /// Open a socket of `family` and `base_type` (e.g. `SOCK_DGRAM`/`SOCK_STREAM`), close-on-exec and
 /// non-blocking. Non-blocking keeps a stray read from freezing the single-threaded reactor. Linux and
 /// FreeBSD set both flags in the socket type; macOS lacks them and applies them by `fcntl`.


### PR DESCRIPTION
Address-monitor/interface audit findings, plus a macOS `group_req` layout bug surfaced while removing the `already_member` EINVAL mask — multicast reflection never worked on macOS (join failed EINVAL, silently swallowed).

- netlink walk length-overflow guard; drop non-kernel datagrams; keep changes collected on a mid-drain error
- FreeBSD `SO_RERROR` + larger BSD route socket receive buffer; document the recreated-interface restart limit
- accept only `EADDRINUSE` as a duplicate join; surface the netlink dump errno
- fix the macOS `group_req` `#pragma pack(4)` layout so multicast joins work at all

Testing: fmt + clippy + full `cargo test --lib` green on macOS, Linux, FreeBSD (clippy). New unit tests for the netlink overflow/errno and join errno; macOS join verified against the kernel and a standalone C probe.
