### PR TITLE
config/cli: input validation and robustness fixes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -201,8 +201,8 @@ impl TryFrom<RawConfig> for Config {
 
     fn try_from(raw: RawConfig) -> Result<Self, ConfigError> {
         let mut reflectors = Vec::with_capacity(raw.reflectors.len());
-        for (name, raw_reflector) in raw.reflectors {
-            let reflector = Reflector::try_from((name, raw_reflector))?;
+        for (key, raw_reflector) in raw.reflectors {
+            let reflector = Reflector::try_from((key, raw_reflector))?;
             log::debug!(
                 "reflector {}: {} -> {} [{}] family={:?}",
                 reflector.name,
@@ -334,10 +334,17 @@ fn families_overlap(a: AddressFamily, b: AddressFamily) -> bool {
     (a.uses_ipv4() && b.uses_ipv4()) || (a.uses_ipv6() && b.uses_ipv6())
 }
 
-/// Reject any pair of reflectors that would reflect the same packet twice.
+/// Reject any pair of reflectors that share a name or would reflect the same packet twice. Names are the
+/// canonical (lowercased) identity, so `==` catches keys that only differ in case or whitespace — which
+/// `merge_env` folds env-vs-file but the file table cannot.
 fn check_conflicts(reflectors: &[Reflector]) -> Result<(), ConfigError> {
     for (i, a) in reflectors.iter().enumerate() {
         for b in &reflectors[i + 1..] {
+            if a.name == b.name {
+                return Err(ConfigError::DuplicateReflectorName {
+                    name: a.name.clone(),
+                });
+            }
             if let Some(protocol) = a.conflicts_with(b) {
                 return Err(ConfigError::ConflictingReflectors {
                     protocol,
@@ -550,6 +557,34 @@ mod tests {
             at_cap.counter_interval,
             Some(Duration::from_secs(MAX_INTERVAL_SECS))
         );
+    }
+
+    #[test]
+    fn two_file_reflectors_cannot_share_a_folded_name() {
+        // Table keys differing only in case or surrounding whitespace resolve to one display name;
+        // reject rather than silently produce two reflectors sharing it (env-vs-file already folds).
+        let cfg = |k1: &str, k2: &str| {
+            format!(
+                r#"
+                [reflectors.{k1}]
+                source_if = "a"
+                target_if = "b"
+                mdns = true
+                [reflectors.{k2}]
+                source_if = "c"
+                target_if = "d"
+                mdns = true
+                "#
+            )
+        };
+        assert!(matches!(
+            from_toml(&cfg("TV", "tv")),
+            Err(ConfigError::DuplicateReflectorName { name }) if name.as_str() == "tv"
+        ));
+        assert!(matches!(
+            from_toml(&cfg("\"  tv  \"", "tv")),
+            Err(ConfigError::DuplicateReflectorName { name }) if name.as_str() == "tv"
+        ));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ mod value;
 pub(crate) use self::error::{ConfigError, Protocol};
 pub(crate) use self::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
 
+use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -260,10 +261,11 @@ struct LogLevelProbe {
     log_level: Option<LogLevel>,
 }
 
-/// Read a configuration file, mapping I/O failure to [`ConfigError::ReadFile`].
-pub(crate) fn read_config_file(path: &str) -> Result<String, ConfigError> {
+/// Read a configuration file, mapping I/O failure to [`ConfigError::ReadFile`]. Takes a `Path` so a
+/// non-UTF-8 path (valid on Unix) reads without loss; only the error message renders it lossily.
+pub(crate) fn read_config_file(path: &Path) -> Result<String, ConfigError> {
     std::fs::read_to_string(path).map_err(|source| ConfigError::ReadFile {
-        path: path.to_owned(),
+        path: path.display().to_string(),
         source,
     })
 }
@@ -584,6 +586,17 @@ mod tests {
         assert!(matches!(
             from_toml(&cfg("\"  tv  \"", "tv")),
             Err(ConfigError::DuplicateReflectorName { name }) if name.as_str() == "tv"
+        ));
+    }
+
+    #[test]
+    fn read_config_file_tolerates_a_non_utf8_path() {
+        use std::os::unix::ffi::OsStrExt;
+        // An invalid-UTF-8 path byte must not panic; a missing file yields ReadFile (rendered lossily).
+        let path = std::path::Path::new(std::ffi::OsStr::from_bytes(b"/no/\xff/such.toml"));
+        assert!(matches!(
+            read_config_file(path),
+            Err(ConfigError::ReadFile { .. })
         ));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,17 +220,34 @@ impl TryFrom<RawConfig> for Config {
 
         Ok(Config {
             log_level: raw.log_level.unwrap_or_default(),
-            // 0 or absent disables each report; any positive count is its period.
-            debug_memory_interval: raw
-                .debug_memory_interval_secs
-                .filter(|&s| s > 0)
-                .map(Duration::from_secs),
-            counter_interval: raw
-                .counters_interval_secs
-                .filter(|&s| s > 0)
-                .map(Duration::from_secs),
+            debug_memory_interval: interval_from(
+                raw.debug_memory_interval_secs,
+                "debug_memory_interval_secs",
+            )?,
+            counter_interval: interval_from(raw.counters_interval_secs, "counters_interval_secs")?,
             reflectors,
         })
+    }
+}
+
+/// One year. A diagnostic cadence beyond this is a config typo, and a value large enough to overflow the
+/// reporter's `Instant + Duration` deadline would panic it at startup; reject it with a clear error.
+const MAX_INTERVAL_SECS: u64 = 60 * 60 * 24 * 365;
+
+/// A positive-seconds report interval as a `Duration`; `0` or absent disables the report. `field` is the
+/// config key, named in the error for an over-large value.
+///
+/// # Errors
+/// [`ConfigError::IntervalTooLarge`] when `secs` exceeds [`MAX_INTERVAL_SECS`].
+fn interval_from(secs: Option<u64>, field: &'static str) -> Result<Option<Duration>, ConfigError> {
+    match secs {
+        Some(s) if s > MAX_INTERVAL_SECS => Err(ConfigError::IntervalTooLarge {
+            field,
+            secs: s,
+            max: MAX_INTERVAL_SECS,
+        }),
+        Some(s) if s > 0 => Ok(Some(Duration::from_secs(s))),
+        _ => Ok(None),
     }
 }
 
@@ -489,6 +506,50 @@ mod tests {
             None
         );
         assert_eq!(from_toml(&toml("")).unwrap().debug_memory_interval, None);
+    }
+
+    #[test]
+    fn an_over_large_interval_is_rejected_by_field() {
+        // Past the cap is a typo that would overflow the reporter's Instant+Duration deadline and panic
+        // at startup; reject it, naming the key, rather than accept it. The cap itself is valid.
+        let toml = |line: &str| {
+            format!(
+                r#"
+                {line}
+                [reflectors.d]
+                source_if = "a"
+                target_if = "b"
+                mdns = true
+                "#
+            )
+        };
+        let too_big = MAX_INTERVAL_SECS + 1;
+        assert!(matches!(
+            from_toml(&toml(&format!("debug_memory_interval_secs = {too_big}"))),
+            Err(ConfigError::IntervalTooLarge { field: "debug_memory_interval_secs", secs, .. })
+                if secs == too_big
+        ));
+        assert!(matches!(
+            from_toml(&toml(&format!("counters_interval_secs = {too_big}"))),
+            Err(ConfigError::IntervalTooLarge {
+                field: "counters_interval_secs",
+                ..
+            })
+        ));
+        // The cap itself is accepted, for both keys.
+        let at_cap = from_toml(&toml(&format!(
+            "debug_memory_interval_secs = {MAX_INTERVAL_SECS}\n\
+             counters_interval_secs = {MAX_INTERVAL_SECS}"
+        )))
+        .unwrap();
+        assert_eq!(
+            at_cap.debug_memory_interval,
+            Some(Duration::from_secs(MAX_INTERVAL_SECS))
+        );
+        assert_eq!(
+            at_cap.counter_interval,
+            Some(Duration::from_secs(MAX_INTERVAL_SECS))
+        );
     }
 
     #[test]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -266,7 +266,8 @@ mod tests {
             ("REFLECTOR_TV_NAME", "Living Room"),
         ])
         .unwrap();
-        assert_eq!(cfg.reflectors[0].name.as_str(), "Living Room");
+        // NAME sets the display name (canonicalized lowercase), overriding the `TV` tag.
+        assert_eq!(cfg.reflectors[0].name.as_str(), "living room");
     }
 
     #[test]
@@ -520,7 +521,7 @@ mod tests {
     }
 
     #[test]
-    fn env_name_is_trimmed() {
+    fn env_name_is_trimmed_and_lowercased() {
         let cfg = from_env(&[
             ("REFLECTOR_TV_SOURCE_IF", "a"),
             ("REFLECTOR_TV_TARGET_IF", "b"),
@@ -528,7 +529,7 @@ mod tests {
             ("REFLECTOR_TV_NAME", "  Living Room  "),
         ])
         .unwrap();
-        assert_eq!(cfg.reflectors[0].name.as_str(), "Living Room");
+        assert_eq!(cfg.reflectors[0].name.as_str(), "living room");
     }
 
     #[test]

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -61,6 +61,11 @@ pub(crate) enum ConfigError {
     #[error("reflector \"{name}\" is defined in both the configuration file and the environment")]
     DuplicateReflector { name: String },
 
+    #[error(
+        "reflector name \"{name}\" is used by more than one reflector (names are compared case-insensitively and trimmed)"
+    )]
+    DuplicateReflectorName { name: ReflectorName },
+
     /// Two reflectors would reflect the same protocol's packets twice.
     #[error(
         "reflectors \"{first}\" and \"{second}\" both reflect {protocol} on {source_if} -> {target_if} with overlapping MAC selection and address family"

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -86,7 +86,9 @@ pub(crate) enum ConfigError {
     )]
     EnvInvalidTag { var: String, tag: String },
 
-    #[error("environment variable \"{var}\" uses a reserved tag (log and debug are globals)")]
+    #[error(
+        "environment variable \"{var}\" uses a reserved tag (log, debug, and counters are globals)"
+    )]
     EnvReservedTag { var: String },
 
     #[error("environment variable \"{var}\" sets unknown parameter \"{param}\"")]

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -96,6 +96,13 @@ pub(crate) enum ConfigError {
 
     #[error("reflector \"{name}\" (from the environment) has no {field}")]
     EnvMissingField { name: String, field: RequiredField },
+
+    #[error("{field} = {secs} is too large; the maximum is {max} seconds")]
+    IntervalTooLarge {
+        field: &'static str,
+        secs: u64,
+        max: u64,
+    },
 }
 
 /// A required reflector field, named in [`ConfigError::EnvMissingField`].

--- a/src/config/value.rs
+++ b/src/config/value.rs
@@ -157,7 +157,9 @@ impl<'de> Deserialize<'de> for InterfaceName {
     }
 }
 
-/// A reflector's display name: surrounding whitespace trimmed, never empty.
+/// A reflector's name: surrounding whitespace trimmed and ASCII-lowercased (names are the reflector's
+/// case-insensitive identity), never empty. The canonical form makes `Eq` the identity check, so no
+/// caller has to fold case itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ReflectorName(String);
 
@@ -186,7 +188,7 @@ impl FromStr for ReflectorName {
         if trimmed.is_empty() {
             return Err(ParseReflectorNameError);
         }
-        Ok(Self(trimmed.to_owned()))
+        Ok(Self(trimmed.to_ascii_lowercase()))
     }
 }
 
@@ -315,6 +317,8 @@ mod tests {
     #[test]
     fn reflector_name_parses_via_fromstr() {
         assert_eq!("  tv  ".parse::<ReflectorName>().unwrap().as_str(), "tv");
+        // Canonicalized to lowercase, so casing is not part of the identity.
+        assert_eq!("TV".parse::<ReflectorName>().unwrap().as_str(), "tv");
         assert_eq!("".parse::<ReflectorName>(), Err(ParseReflectorNameError));
         assert_eq!("   ".parse::<ReflectorName>(), Err(ParseReflectorNameError));
     }

--- a/src/config/value.rs
+++ b/src/config/value.rs
@@ -117,7 +117,9 @@ impl<'de> Deserialize<'de> for AddressFamily {
     }
 }
 
-/// A non-empty network interface name.
+/// A network interface name: non-empty and whitespace-free. OS interface names never contain
+/// whitespace; a padded one would miss the interface (a confusing capture error) and slip past the
+/// `source_if`/`target_if` equality check, so reject it here rather than downstream.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InterfaceName(String);
 
@@ -135,14 +137,14 @@ impl fmt::Display for InterfaceName {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
-#[error("interface name must not be empty")]
+#[error("interface name must not be empty or contain whitespace")]
 pub(crate) struct ParseInterfaceNameError;
 
 impl FromStr for InterfaceName {
     type Err = ParseInterfaceNameError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.is_empty() {
+        if s.is_empty() || s.chars().any(char::is_whitespace) {
             return Err(ParseInterfaceNameError);
         }
         Ok(Self(s.to_owned()))
@@ -312,6 +314,15 @@ mod tests {
     fn interface_name_parses_via_fromstr() {
         assert_eq!("en0".parse::<InterfaceName>().unwrap().as_str(), "en0");
         assert_eq!("".parse::<InterfaceName>(), Err(ParseInterfaceNameError));
+        // Whitespace is rejected: a padded name misses the interface and dodges SameInterface.
+        assert_eq!(
+            " en0 ".parse::<InterfaceName>(),
+            Err(ParseInterfaceNameError)
+        );
+        assert_eq!(
+            "e n0".parse::<InterfaceName>(),
+            Err(ParseInterfaceNameError)
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ pub struct Error(ErrorKind);
 /// The private cause behind an [`struct@Error`]: one variant per subsystem.
 #[derive(Debug, Error)]
 enum ErrorKind {
+    /// The command line was misused (see [`TooManyArgs`]).
+    #[error(transparent)]
+    Usage(#[from] TooManyArgs),
     /// Configuration could not be loaded or failed validation.
     #[error("config: {0}")]
     Config(#[from] ConfigError),
@@ -84,3 +87,15 @@ impl From<io::Error> for Error {
         Self(ErrorKind::Reactor(source))
     }
 }
+
+impl From<TooManyArgs> for Error {
+    fn from(source: TooManyArgs) -> Self {
+        Self(ErrorKind::Usage(source))
+    }
+}
+
+/// More than the single optional config-path argument was passed on the command line; the payload is the
+/// first unexpected argument. The CLI's own matchable error, lifted into [`struct@Error`] by `?`.
+#[derive(Debug, Error)]
+#[error("unexpected extra argument \"{0}\"; usage: reflector [CONFIG_PATH]")]
+pub(crate) struct TooManyArgs(pub(crate) String);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use std::path::Path;
 use self::capture::Capture;
 use self::config::Config;
 use self::dispatch::PacketDispatcher;
+use self::error::TooManyArgs;
 use self::reactor::Reactor;
 use self::reflector::InterfaceMap;
 
@@ -39,7 +40,7 @@ use self::reflector::InterfaceMap;
 /// Returns [`Error`] if configuration loading or validation fails, or if the
 /// reactor cannot be created or its event loop fails.
 pub fn run(args: &[OsString]) -> Result<()> {
-    let path = args.first().map(Path::new);
+    let path = config_path(args)?;
     let toml_text = path.map(config::read_config_file).transpose()?;
     let env: Vec<(String, String)> = std::env::vars().collect();
 
@@ -110,6 +111,19 @@ pub fn run(args: &[OsString]) -> Result<()> {
     Ok(())
 }
 
+/// The config-file path from the CLI args, or `None` for env-only configuration. The reflector takes at
+/// most one positional argument; reject extras rather than silently ignoring them (a likely typo).
+///
+/// # Errors
+/// [`TooManyArgs`] when more than one argument is given (lifted into [`Error`] by `?` in [`run`]).
+fn config_path(args: &[OsString]) -> std::result::Result<Option<&Path>, TooManyArgs> {
+    match args {
+        [] => Ok(None),
+        [path] => Ok(Some(Path::new(path))),
+        [_path, extra, ..] => Err(TooManyArgs(extra.to_string_lossy().into_owned())),
+    }
+}
+
 /// Open one capture per distinct interface: the `source ∪ target` of every reflector, in
 /// first-seen order. Records each in an [`InterfaceMap`] for the per-protocol builders.
 /// Fail-closed: a capture that can't open (missing `CAP_NET_RAW`, an absent interface) aborts
@@ -129,4 +143,22 @@ fn open_captures(config: &Config, dispatcher: &mut PacketDispatcher) -> Result<I
         }
     }
     Ok(interfaces)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_path_takes_at_most_one_arg() {
+        assert_eq!(config_path(&[]).unwrap(), None);
+        let one = [OsString::from("reflector.toml")];
+        assert_eq!(
+            config_path(&one).unwrap(),
+            Some(Path::new("reflector.toml"))
+        );
+        // A second positional argument is rejected, not ignored.
+        let two = [OsString::from("reflector.toml"), OsString::from("extra")];
+        assert!(matches!(config_path(&two), Err(TooManyArgs(_))));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ mod sys;
 pub use self::error::{Error, Result};
 pub use self::logging::init as init_logging;
 
+use std::ffi::OsString;
+use std::path::Path;
+
 use self::capture::Capture;
 use self::config::Config;
 use self::dispatch::PacketDispatcher;
@@ -35,8 +38,8 @@ use self::reflector::InterfaceMap;
 /// # Errors
 /// Returns [`Error`] if configuration loading or validation fails, or if the
 /// reactor cannot be created or its event loop fails.
-pub fn run(args: &[String]) -> Result<()> {
-    let path = args.first().map(String::as_str);
+pub fn run(args: &[OsString]) -> Result<()> {
+    let path = args.first().map(Path::new);
     let toml_text = path.map(config::read_config_file).transpose()?;
     let env: Vec<(String, String)> = std::env::vars().collect();
 
@@ -45,7 +48,10 @@ pub fn run(args: &[String]) -> Result<()> {
     logging::set_level(config::resolve_log_level(toml_text.as_deref(), &env)?);
     log::info!("reflector {} starting", env!("CARGO_PKG_VERSION"));
     if let Some(path) = path {
-        log::debug!("loading configuration from {path} with REFLECTOR_* overrides");
+        log::debug!(
+            "loading configuration from {} with REFLECTOR_* overrides",
+            path.display()
+        );
     } else {
         log::debug!("loading configuration from REFLECTOR_* environment only");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,13 @@
 //! and turns a [`reflector::Result`] into an exit code: on failure it logs the
 //! error and exits non-zero.
 
+use std::ffi::OsString;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
     reflector::init_logging();
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    // args_os, not args: a non-UTF-8 argument (a path can be non-UTF-8 on Unix) makes args() panic.
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
     match reflector::run(&args) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {


### PR DESCRIPTION
Config and CLI input-validation / robustness fixes (audit group).

- **Bound the report intervals** — reject `debug_memory_interval_secs` / `counters_interval_secs` past one year, which would overflow the reporter's `Instant + Duration` deadline and panic at startup.
- **Canonicalize reflector names** — trim + ASCII-lowercase so the name is the case-insensitive identity, and reject two reflectors resolving to the same name (previously caught only env-vs-file, so `[reflectors.TV]` + `[reflectors.tv]` silently produced two).
- **Reject whitespace in interface names** — a padded name was accepted, causing a confusing capture failure and bypassing the `source_if == target_if` check.
- **Name `counters` in the reserved-tag error** — it was reserved but omitted from the message alongside `log`/`debug`.
- **Read argv with `args_os`** — `env::args()` panics on a non-UTF-8 argument, and a config path can be non-UTF-8 on Unix; the path now flows through as a `Path`.
- **Reject extra command-line arguments** — `run()` used only the first arg and silently dropped the rest.

Testing: `cargo fmt` + `cargo clippy --all-targets -D warnings` + full `cargo test --lib` green on macOS, Linux, and FreeBSD (clippy).
