### PR TITLE
reflector: dual-scope search sessions + visible join failures

### DIFF
--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -15,7 +15,8 @@ pub(crate) use search::SearchReflector;
 pub(crate) use simple::SimpleReflector;
 
 use std::fmt;
-use std::net::SocketAddr;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
 
 use thiserror::Error;
 
@@ -185,11 +186,52 @@ fn require_bidirectional_families(
     Ok(())
 }
 
+/// Whether a group-join failure is deferrable: `EADDRNOTAVAIL` means the interface has no address of the
+/// group's family yet, so the joiner records the group and retries on the next address change. Every
+/// other error is a hard failure that will not self-heal.
+fn join_deferrable(e: &io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EADDRNOTAVAIL)
+}
+
+/// Join `group` on `capture` for `protocol`'s `side` leg (`"source"`/`"target"`), logging the outcome.
+/// A [deferrable](join_deferrable) failure logs at debug (it retries on the next address change); any
+/// other failure is a warning, since that group's traffic won't be reflected and won't self-heal — a
+/// dead reflector must not hide behind a debug line.
+fn join_group_logged(
+    dispatcher: &mut PacketDispatcher,
+    capture: CaptureKey,
+    group: IpAddr,
+    protocol: &str,
+    side: &str,
+) {
+    match dispatcher.join_group(capture, group) {
+        Ok(()) => {}
+        Err(e) if join_deferrable(&e) => {
+            log::debug!(
+                "{protocol}: join {group} on {side} deferred (no address of its family yet): {e}"
+            );
+        }
+        Err(e) => {
+            log::warn!(
+                "{protocol}: join {group} on {side} failed; its traffic will not be reflected: {e}"
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
 
     use super::*;
+
+    #[test]
+    fn only_eaddrnotavail_is_a_deferrable_join() {
+        let of = io::Error::from_raw_os_error;
+        assert!(join_deferrable(&of(libc::EADDRNOTAVAIL))); // no address of this family yet; retried
+        assert!(!join_deferrable(&of(libc::ENODEV))); // a hard failure: warn, don't hide
+        assert!(!join_deferrable(&of(libc::EINVAL)));
+    }
 
     #[test]
     fn missing_required_family_enforces_the_requires_policy() {

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -11,7 +11,10 @@ use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{Filter, IpSet, MessageType, PacketDispatcher};
 use crate::net::mdns::{MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT, MDNS_TTL, MdnsKind, classify};
 
-use super::{BuildError, InterfaceMap, SimpleReflector, Verdict, require_bidirectional_families};
+use super::{
+    BuildError, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
+    require_bidirectional_families,
+};
 
 /// mDNS's classifier kind *is* its message type: `Query`/`Response` map straight across.
 impl From<MdnsKind> for MessageType {
@@ -78,10 +81,8 @@ pub(crate) fn build(
     // on the next address change, so a deferred join logs rather than fails the build.
     let groups = used_groups(reflector.address_family);
     for group in &groups {
-        for capture in [source, target] {
-            if let Err(e) = dispatcher.join_group(capture, group.ip()) {
-                log::debug!("mDNS: join {} deferred: {e}", group.ip());
-            }
+        for (capture, side) in [(source, "source"), (target, "target")] {
+            join_group_logged(dispatcher, capture, group.ip(), "mDNS", side);
         }
     }
     // One handler per direction spans every group; its filter matches the group set at the mDNS port.

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -28,12 +28,17 @@ use super::{ReplyRewrite, Verdict, egress_sources};
 /// the cap a new search is dropped (no live session is evicted early).
 const MAX_SESSIONS: usize = 64;
 
-/// One in-flight search. The searcher (`ip:port`) is the dedup key; `expiry` is when the session
-/// lapses; `reservation` holds the ephemeral target port the replies arrive on for the session's life
-/// (dropping it frees the port); `response_key` is the per-session response capture. A
+/// One in-flight search, keyed by `(searcher, dest)`. The searcher (`ip:port`) plus the group it
+/// searched: each group's replies arrive at a different scope-matched target address (link-local for
+/// `ff02::c`, routable for `ff05::c`), so one searcher's searches to two scopes need separate sessions.
+/// `expiry` is when the session lapses; `reservation` holds the ephemeral target reply port for the
+/// session's life (dropping it frees the port); `response_key` is the per-session response capture. A
 /// `RegistrationKey` is not a RAII guard, so eviction and rollback `unregister` it by hand.
 struct Session {
     searcher: SocketAddr,
+    /// The multicast group searched; part of the dedup key, since its scope picks the reserved reply
+    /// address — a different group is a new session, not a retransmit.
+    dest: SocketAddr,
     expiry: Instant,
     reservation: PortReservation,
     response_key: RegistrationKey,
@@ -253,11 +258,27 @@ impl SearchReflector {
         );
         Ok(Session {
             searcher: packet.source,
+            dest: packet.dest,
             expiry,
             reservation,
             response_key,
         })
     }
+}
+
+/// The live session a search belongs to: same searcher *and* same group. The group is part of the key
+/// because its scope picks the reserved reply address, so a search to a different group is a new session,
+/// not a retransmit. A free fn over `&mut [Session]`, not a `&mut self` method: a `&mut self` return
+/// would lock all of `self`, but the caller reads other fields (`target`, `ttl`) while holding the
+/// session.
+fn session_for(
+    sessions: &mut [Session],
+    source: SocketAddr,
+    dest: SocketAddr,
+) -> Option<&mut Session> {
+    sessions
+        .iter_mut()
+        .find(|s| s.searcher == source && s.dest == dest)
 }
 
 impl PacketHandler for SearchReflector {
@@ -283,13 +304,10 @@ impl PacketHandler for SearchReflector {
         };
         let expiry = Instant::now() + (self.window)(packet.payload);
 
-        // A retransmit from a known searcher reuses its session: refresh the window and re-reflect from
-        // the same reserved port. A new searcher opens a fresh session.
-        if let Some(session) = self
-            .sessions
-            .iter_mut()
-            .find(|s| s.searcher == packet.source)
-        {
+        // A retransmit from a known searcher to the same group reuses its session: refresh the window and
+        // re-reflect from the same reserved port. A new searcher, or the same searcher to a different
+        // group (a different reply scope), opens a fresh session.
+        if let Some(session) = session_for(&mut self.sessions, packet.source, packet.dest) {
             let port = session.reservation.port();
             return match dispatcher.send_udp_group(
                 self.target,
@@ -420,9 +438,11 @@ mod tests {
         reflector: &mut SearchReflector,
         dispatcher: &mut PacketDispatcher,
         searcher: &str,
+        dest: &str,
         expiry: Instant,
     ) {
         let searcher: SocketAddr = searcher.parse().unwrap();
+        let dest: SocketAddr = dest.parse().unwrap();
         let (target, source) = (reflector.target, reflector.source);
         let reservation = PortReservation::create(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)
             .expect("reserve a loopback port");
@@ -441,6 +461,7 @@ mod tests {
         );
         reflector.sessions.push(Session {
             searcher,
+            dest,
             expiry,
             reservation,
             response_key,
@@ -461,12 +482,14 @@ mod tests {
             &mut reflector,
             &mut dispatcher,
             "10.0.0.1:5",
+            "239.255.255.250:1900",
             base + Duration::from_secs(5),
         );
         push_session(
             &mut reflector,
             &mut dispatcher,
             "10.0.0.2:5",
+            "239.255.255.250:1900",
             base + Duration::from_secs(2),
         );
         assert_eq!(
@@ -481,11 +504,18 @@ mod tests {
         let mut reactor = Reactor::new().unwrap();
         let mut reflector = test_reflector();
         let base = Instant::now();
-        push_session(&mut reflector, &mut dispatcher, "10.0.0.1:5", base); // already due
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.1:5",
+            "239.255.255.250:1900",
+            base,
+        ); // already due
         push_session(
             &mut reflector,
             &mut dispatcher,
             "10.0.0.2:5",
+            "239.255.255.250:1900",
             base + Duration::from_secs(10),
         ); // live
         assert_eq!(dispatcher.registration_count(), 2);
@@ -520,7 +550,13 @@ mod tests {
         // so the re-reflect "succeeds" with no real capture; this exercises only the bookkeeping.
         let mut reflector = test_reflector();
         let base = Instant::now();
-        push_session(&mut reflector, &mut dispatcher, "10.0.0.7:50000", base);
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.7:50000",
+            "239.255.255.250:1900",
+            base,
+        );
         assert_eq!(dispatcher.registration_count(), 1);
 
         let packet = Packet {
@@ -547,5 +583,27 @@ mod tests {
             reflector.sessions[0].expiry > base,
             "the session's window is refreshed"
         );
+    }
+
+    #[test]
+    fn a_session_is_keyed_by_searcher_and_group() {
+        // The dedup key is (searcher, group). One live session for a searcher's link-local search: a
+        // retransmit (same searcher, same group) finds it, but the same searcher's site-local search does
+        // not — its replies come to a different scope-matched address, so it needs its own session. The
+        // bug keyed on the searcher alone, so the site-local search wrongly reused the link-local session.
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reflector = test_reflector();
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "[fe80::1]:50000",
+            "[ff02::c]:1900",
+            Instant::now(),
+        );
+        let searcher: SocketAddr = "[fe80::1]:50000".parse().unwrap();
+        let link_local: SocketAddr = "[ff02::c]:1900".parse().unwrap();
+        let site_local: SocketAddr = "[ff05::c]:1900".parse().unwrap();
+        assert!(session_for(&mut reflector.sessions, searcher, link_local).is_some());
+        assert!(session_for(&mut reflector.sessions, searcher, site_local).is_none());
     }
 }

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -23,7 +23,7 @@ use crate::reactor::Reactor;
 use super::dial::{ProxyPlacement, REWRITE_BUF_LEN, rewrite_location};
 use super::{
     BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
-    require_bidirectional_families,
+    join_group_logged, require_bidirectional_families,
 };
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
@@ -177,12 +177,8 @@ pub(crate) fn build(
     // with no address yet is recorded and re-attempted on the next address change.
     let groups = used_groups(reflector.address_family);
     for group in &groups {
-        if let Err(e) = dispatcher.join_group(target, group.ip()) {
-            log::debug!("SSDP: join {} on target deferred: {e}", group.ip());
-        }
-        if let Err(e) = dispatcher.join_group(source, group.ip()) {
-            log::debug!("SSDP: join {} on source deferred: {e}", group.ip());
-        }
+        join_group_logged(dispatcher, target, group.ip(), "SSDP", "target");
+        join_group_logged(dispatcher, source, group.ip(), "SSDP", "source");
     }
     // One handler per direction spans every group; its filter matches the group set at the SSDP port.
     let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -14,7 +14,7 @@ use crate::net::wsd::{WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT, WSD_TTL, WsdKind, cl
 
 use super::{
     BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
-    require_bidirectional_families,
+    join_group_logged, require_bidirectional_families,
 };
 
 /// WSD's classifier kind maps to its group message types. The `ProbeMatches`/`ResolveMatches` unicast
@@ -94,12 +94,8 @@ pub(crate) fn build(
     // no address yet is recorded and re-attempted on the next address change.
     let groups = used_groups(reflector.address_family);
     for group in &groups {
-        if let Err(e) = dispatcher.join_group(target, group.ip()) {
-            log::debug!("WSD: join {} on target deferred: {e}", group.ip());
-        }
-        if let Err(e) = dispatcher.join_group(source, group.ip()) {
-            log::debug!("WSD: join {} on source deferred: {e}", group.ip());
-        }
+        join_group_logged(dispatcher, target, group.ip(), "WSD", "target");
+        join_group_logged(dispatcher, source, group.ip(), "WSD", "source");
     }
     // One handler per direction spans every group; its filter matches the group set at the WSD port.
     let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();


### PR DESCRIPTION
Two reflector correctness/observability fixes from the audit.

- **Key SSDP search sessions by `(searcher, group)`, not the searcher alone.** One `SearchReflector` spans every group, and a session's reserved reply port is bound to a scope-matched target address (link-local for `ff02::c`, routable for `ff05::c`). Deduping on the searcher merged a searcher's two-scope search into one session, so the second scope's device replies arrived at an unwatched address and were dropped.
- **Warn on a hard multicast-join failure (mDNS/SSDP/WSD).** All three logged every join failure at `debug` as "deferred", but only `EADDRNOTAVAIL` (no address of that family yet) is deferrable — the joiner retries it on the next address change. A hard failure hid behind the same `debug` line, so a group that will never join went silently unreflected. A shared `join_group_logged` warns on anything but `EADDRNOTAVAIL`.

Testing: `cargo fmt` + `clippy --all-targets -D warnings` + full `cargo test --lib` green on macOS, Linux, and FreeBSD (clippy), plus the Linux rustdoc gate. The session-key change was also validated with the full Docker e2e suite (45/45).
