### PR TITLE
capture: cap the AF_PACKET receive buffer at the send limit

### DIFF
--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -19,8 +19,12 @@ use crate::libcex::BpfInsn;
 use crate::net::LinkType;
 use crate::sys::{IoStatus, socklen_of};
 
-/// Receive buffer sized for one frame at a typical Ethernet MTU plus headers.
-const RECV_BUFFER_SIZE: usize = 4096;
+/// Receive buffer for one frame, matched to the dispatcher's send scratch
+/// ([`SCRATCH_LEN`](crate::dispatch::SCRATCH_LEN)) — the forwarding limit. Capturing no more than can be
+/// re-emitted means a jumbo frame beyond it drops here at trace (see [`next_frame`](Capture::next_frame)),
+/// instead of being captured and then warned per packet when the send scratch rejects it. 2048
+/// comfortably holds a standard ~1518-byte Ethernet frame.
+const RECV_BUFFER_SIZE: usize = 2048;
 
 /// The fallback filter length: the egress-drop prologue plus the UDP classifier.
 const DROP_OUTGOING_FILTER_LEN: usize = DROP_OUTGOING_PROLOGUE.len() + ETHERNET_UDP_FILTER.len();


### PR DESCRIPTION
The AF_PACKET receive buffer (`RECV_BUFFER_SIZE = 4096`) exceeded the dispatcher's send scratch (`SCRATCH_LEN = 2048`, the forwarding limit). A frame between the two was captured but `build_udp` couldn't fit its re-emit into the 2048 scratch, so the reflector logged `warn!` **per packet** — a log-flood vector, since a peer can spam jumbo-MTU frames.

Cap `RECV_BUFFER_SIZE` at the send limit (2048), doc-linked to `SCRATCH_LEN` so the two can't silently drift again. A frame beyond the forwarding limit now drops at *capture* (the existing `trace` oversized-drop) instead of being captured and then warned at send. 2048 still comfortably holds a standard ~1518-byte Ethernet frame, and frames >2048 were never forwardable (the scratch rejected them), so no reflection regression.

Testing: `cargo fmt` + Linux `clippy --all-targets -D warnings` + full `cargo test --lib` (403) + the Linux rustdoc gate, plus the full Docker e2e suite (45/45).
