### PR TITLE
soundness: unsafe commit, make_session tests, BSD getifaddrs tests

### DIFF
--- a/src/interface/getifaddrs.rs
+++ b/src/interface/getifaddrs.rs
@@ -183,3 +183,72 @@ fn v6_flags(sock: &OwnedFd, if_name: &str, addr: libc::sockaddr_in6) -> Option<c
     // SAFETY: a successful ioctl wrote `ifru_flags6` into the union.
     Some(unsafe { req.ifru.flags6 })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::mem::offset_of;
+
+    use super::*;
+
+    #[test]
+    fn canonical_v6_strips_the_embedded_scope_from_link_local() {
+        // The BSDs embed the scope id (ifindex) in bytes 2-3 of a fe80::/10 address (the KAME
+        // convention); the canonical form zeroes them to recover the on-the-wire fe80::/64.
+        let embedded = [
+            0xfe, 0x80, 0x00, 0x07, 0, 0, 0, 0, 0, 0, 0, 0, 0x02, 0x11, 0x22, 0x33,
+        ];
+        assert_eq!(
+            canonical_v6(embedded),
+            Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0x0211, 0x2233)
+        );
+        // A non-link-local address is untouched.
+        let global = [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+        assert_eq!(canonical_v6(global), Ipv6Addr::from(global));
+    }
+
+    /// A raw `AF_LINK` `sockaddr_dl`: an `nlen`-byte name then `mac`, with `sdl_alen`/`sdl_len` set as
+    /// given so the bounds branches can be exercised. Laid out via `offset_of` so it matches the real
+    /// struct.
+    fn dl_bytes(name: &[u8], mac: &[u8], alen: u8, sdl_len: u8) -> [u8; 32] {
+        let mut buf = [0u8; 32];
+        buf[offset_of!(libc::sockaddr_dl, sdl_family)] = u8::try_from(libc::AF_LINK).unwrap();
+        buf[offset_of!(libc::sockaddr_dl, sdl_nlen)] = u8::try_from(name.len()).unwrap();
+        buf[offset_of!(libc::sockaddr_dl, sdl_alen)] = alen;
+        buf[offset_of!(libc::sockaddr_dl, sdl_len)] = sdl_len;
+        let data = offset_of!(libc::sockaddr_dl, sdl_data);
+        buf[data..data + name.len()].copy_from_slice(name);
+        buf[data + name.len()..data + name.len() + mac.len()].copy_from_slice(mac);
+        buf
+    }
+
+    #[test]
+    fn read_mac_extracts_the_address_after_the_name() {
+        let mac = [0x02, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let data = offset_of!(libc::sockaddr_dl, sdl_data);
+        let len = u8::try_from(data + 3 + 6).unwrap(); // header + "en0" + 6-byte MAC
+        let buf = dl_bytes(b"en0", &mac, 6, len);
+        assert_eq!(
+            read_mac(buf.as_ptr().cast::<libc::sockaddr>()),
+            Some(MacAddr::from(mac))
+        );
+    }
+
+    #[test]
+    fn read_mac_is_none_without_a_link_address() {
+        // Loopback carries a name but no address (alen 0).
+        let data = offset_of!(libc::sockaddr_dl, sdl_data);
+        let len = u8::try_from(data + 3).unwrap();
+        let buf = dl_bytes(b"lo0", &[], 0, len);
+        assert_eq!(read_mac(buf.as_ptr().cast::<libc::sockaddr>()), None);
+    }
+
+    #[test]
+    fn read_mac_is_none_when_the_address_runs_past_the_sockaddr() {
+        // sdl_alen claims 6, but sdl_len stops short of the MAC: rejected, not over-read.
+        let mac = [0x02, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let data = offset_of!(libc::sockaddr_dl, sdl_data);
+        let short = u8::try_from(data + 3 + 3).unwrap(); // 3 bytes short of the MAC
+        let buf = dl_bytes(b"en0", &mac, 6, short);
+        assert_eq!(read_mac(buf.as_ptr().cast::<libc::sockaddr>()), None);
+    }
+}

--- a/src/net/stream_buffer.rs
+++ b/src/net/stream_buffer.rs
@@ -105,7 +105,12 @@ impl StreamBuffer {
     }
 
     /// Mark `n` bytes received into [`free_tail_mut`](Self::free_tail_mut) as filled.
-    pub(crate) fn commit(&mut self, n: usize) {
+    ///
+    /// # Safety
+    /// The first `n` bytes of the most recent [`free_tail_mut`](Self::free_tail_mut) must have been
+    /// initialized (written) before this call. [`pending`](Self::pending) then reads `[consumed..filled]`
+    /// as initialized `u8`, so committing bytes that were never written is undefined behavior.
+    pub(crate) unsafe fn commit(&mut self, n: usize) {
         debug_assert!(self.filled + n <= self.capacity, "commit past the capacity");
         self.filled += n;
     }
@@ -239,7 +244,8 @@ mod tests {
         let tail = b.free_tail_mut();
         assert_eq!(tail.len(), 6);
         fill(tail, b"xyz");
-        b.commit(3);
+        // SAFETY: `fill` wrote 3 bytes into the free_tail_mut region above.
+        unsafe { b.commit(3) };
         assert_eq!(b.pending(), b"abxyz");
     }
 
@@ -251,7 +257,8 @@ mod tests {
         let tail = b.free_tail_mut(); // compacts: "cd" slides to the front
         assert_eq!(tail.len(), 2);
         fill(tail, b"ef");
-        b.commit(2);
+        // SAFETY: `fill` wrote 2 bytes into the free_tail_mut region above.
+        unsafe { b.commit(2) };
         assert_eq!(b.pending(), b"cdef");
     }
 

--- a/src/reflector/dial/connection.rs
+++ b/src/reflector/dial/connection.rs
@@ -124,7 +124,10 @@ impl DirectionContext<'_> {
                 return Forwarded::Failed;
             }
         };
-        self.flow.recv.commit(n);
+        // SAFETY: `recv` wrote `n` bytes into the `free_tail_mut` region above, initializing them.
+        unsafe {
+            self.flow.recv.commit(n);
+        }
         loop {
             let framed = match self.flow.framer.feed(self.flow.recv.pending()) {
                 Ok(framed) => framed,

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -401,6 +401,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use super::*;
+    use crate::capture::Capture;
     use crate::reflector::NoRewrite;
 
     const TEST_TTL: u8 = 2;
@@ -605,5 +606,127 @@ mod tests {
         let site_local: SocketAddr = "[ff05::c]:1900".parse().unwrap();
         assert!(session_for(&mut reflector.sessions, searcher, link_local).is_some());
         assert!(session_for(&mut reflector.sessions, searcher, site_local).is_none());
+    }
+
+    #[test]
+    fn make_session_drops_a_search_with_no_source_mac() {
+        // No source MAC means no L2 address to reply to, so make_session drops the search rather than
+        // open a session it could never answer.
+        let mut dispatcher = PacketDispatcher::new();
+        let reflector = test_reflector();
+        let packet = Packet {
+            source: "10.0.0.1:5".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: None,
+            payload: b"search",
+        };
+        let outcome = reflector.make_session(
+            &packet,
+            &mut dispatcher,
+            Instant::now(),
+            MessageType::SsdpSearch,
+        );
+        assert!(matches!(
+            outcome,
+            Err(Outcome::Dropped(MessageType::SsdpSearch))
+        ));
+    }
+
+    #[test]
+    fn make_session_drops_at_the_session_cap() {
+        // At MAX_SESSIONS in flight a new searcher is dropped; no live session is evicted early.
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reflector = test_reflector();
+        for _ in 0..MAX_SESSIONS {
+            push_session(
+                &mut reflector,
+                &mut dispatcher,
+                "10.0.0.1:5",
+                "239.255.255.250:1900",
+                Instant::now(),
+            );
+        }
+        assert_eq!(reflector.sessions.len(), MAX_SESSIONS);
+        let packet = Packet {
+            source: "10.0.0.9:5".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
+            payload: b"search",
+        };
+        let outcome = reflector.make_session(
+            &packet,
+            &mut dispatcher,
+            Instant::now(),
+            MessageType::SsdpSearch,
+        );
+        assert!(matches!(
+            outcome,
+            Err(Outcome::Dropped(MessageType::SsdpSearch))
+        ));
+    }
+
+    /// Open a loopback capture, or `None` (skip) without `CAP_NET_RAW`. A real capture gives the target
+    /// a resolvable address, so `make_session` can succeed.
+    fn open_loopback_or_skip() -> Option<Capture> {
+        match Capture::open(crate::interface::LOOPBACK_IFACE) {
+            Ok(cap) => Some(cap),
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skip: no CAP_NET_RAW to open a loopback capture ({e})");
+                None
+            }
+            Err(e) => panic!("unexpected loopback capture open failure: {e}"),
+        }
+    }
+
+    #[test]
+    fn a_failed_reflect_rolls_back_the_session_registration() {
+        // make_session registers the response capture before reflecting; if the reflect then fails, that
+        // registration must be rolled back, not leaked. A real loopback target lets make_session succeed;
+        // an oversized payload then makes build_udp reject the reflect deterministically.
+        let Some(target_cap) = open_loopback_or_skip() else {
+            return;
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let target = dispatcher
+            .add_capture(target_cap)
+            .expect("add the loopback capture");
+        let mut reactor = Reactor::new().expect("reactor");
+        let mut reflector = SearchReflector::new(
+            CaptureKey::from_u64(999), // synthetic source: no reply comes back in this test
+            target,
+            0,
+            None,
+            "TEST",
+            MessageType::SsdpResponse,
+            TEST_TTL,
+            always_reflect,
+            fixed_window,
+            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+        );
+        let before = dispatcher.registration_count();
+        let packet = Packet {
+            source: "10.0.0.1:5".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
+            payload: &[0u8; 4096], // too large to build, so the reflect fails and rolls back
+        };
+        let outcome = reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
+        assert!(matches!(outcome, Outcome::Dropped(_)));
+        assert_eq!(
+            reflector.sessions.len(),
+            0,
+            "no session survives a failed reflect"
+        );
+        assert_eq!(
+            dispatcher.registration_count(),
+            before,
+            "make_session's response capture was rolled back"
+        );
     }
 }


### PR DESCRIPTION
Soundness + test-coverage fixes from the audit.

- **`StreamBuffer::commit` is now an `unsafe fn`.** It advances `filled`, and the *safe* `pending()` reads `[consumed..filled]` as initialized `u8` via `from_raw_parts` — so committing bytes that were never written to the `free_tail_mut` region is UB reachable from safe code. The contract was comment-only; it now lives at the call sites (the DIAL recv path, which writes exactly `n` bytes first, plus the tests).
- **Test `make_session`'s failure branches.** Cover the `MAX_SESSIONS` cap, the no-source-MAC drop, and the reflect-failure rollback (a real loopback target so `make_session` succeeds, then an oversized payload to fail `build_udp`, asserting the response-capture registration is rolled back, not leaked).
- **Unit-test the BSD `getifaddrs` helpers.** `getifaddrs.rs` (macOS/FreeBSD) had zero tests; cover `canonical_v6` (KAME scope-id stripping) and `read_mac` (MAC parse plus the `sockaddr_dl` bounds checks: no address, and a length running past the sockaddr).

Testing: `cargo fmt` + `clippy --all-targets -D warnings` + full `cargo test --lib` green on macOS, Linux, and FreeBSD (clippy), plus the Linux rustdoc gate. The CAP_NET_RAW-gated rollback test runs (not skips) on both host and Linux.
