### PR TITLE
docs + libcex: fix stale doc claims, pin FFI struct sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ describing one `source_if` → `target_if` bridge that enables any combination o
 top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_interval_secs`:
 
 ```toml
-log_level = "info"                 # optional; one of debug | info | warning | error (default: info)
+log_level = "info"                 # optional; one of off | error | warning | info | debug | trace (default: info)
 debug_memory_interval_secs = 0     # optional; seconds between memory (RSS/peak) diagnostic reports; 0 disables (default 0)
 counters_interval_secs = 0         # optional; seconds between per-interface packet-counter summaries; 0 disables (default 0)
 
@@ -257,7 +257,7 @@ then optional; with none, the environment is the whole configuration. Variables 
 - `<TAG>` ties one entry's parameters together: any alphanumeric string (`1`, `2`, `TV`, …). It also
   becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
-  `WOL`, `MDNS`, `SSDP`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
+  `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
 
 The globals are `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
 `REFLECTOR_COUNTERS_INTERVAL_SECS`, so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are
@@ -288,19 +288,19 @@ rejected at startup.
 ### The `macs` field
 
 `macs` is an optional list naming the device(s) an entry is scoped to, coherently across WoL, mDNS,
-and SSDP, because a device's NIC MAC is both the target of its Wake-on-LAN magic packet and the L2
-source of its mDNS/SSDP advertisements. A single device is just a one-entry list
+SSDP, and WSD, because a device's NIC MAC is both the target of its Wake-on-LAN magic packet and the L2
+source of its mDNS/SSDP/WSD advertisements. A single device is just a one-entry list
 (`macs = ["B0:37:95:C5:60:BE"]`); list several to scope one entry to a set of devices
 (`macs = ["B0:37:95:C5:60:BE", "C4:9D:8F:11:22:33"]`). Below, "the allow-set" means the configured
 devices:
 
 - **WoL** re-emits only magic packets whose payload targets a device in the allow-set.
-- **mDNS / SSDP** relay, in the target→source direction, only frames whose L2 source MAC is in the
+- **mDNS / SSDP / WSD** relay, in the target→source direction, only frames whose L2 source MAC is in the
   allow-set (exposing just those devices); the source→target direction is never MAC-filtered. For SSDP
-  the same filter scopes the proxied unicast `200 OK` replies: only the allow-set's responses are
+  and WSD the same filter scopes the proxied unicast replies: only the allow-set's responses are
   carried back to a searcher.
 
-Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP reflect all
+Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP/WSD reflect all
 traffic in both directions.
 
 ### `address_family`

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -9,8 +9,8 @@
 # The send/receive verbs cover WoL and the verbatim-relay protocols (mDNS, one-way SSDP). The
 # respond/search verbs drive the SSDP M-SEARCH round trip: a `respond` device unicasts a 200 OK back to
 # whoever searched, and a `search` searcher awaits that reply proxied across segments by the reflector.
-# The DIAL probe verbs (dial-device/dial-client) from the C++ harness are intentionally absent: DIAL is
-# unimplemented in this project.
+# The DIAL probe verbs (dial-device/dial-client) from the C++ harness are absent because the DIAL cases
+# (see DIAL_CASES in run.py) drive a dedicated HTTP emulator rather than this prober.
 
 from __future__ import annotations
 

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -793,10 +793,10 @@ ADDRESS_CHANGE_CASES = [
         name="mdns_address_change",
         config="config-addrchange.toml",
         phases=(
-            # source IPv4: knocking out the source's v4 invalidates its kernel multicast membership,
-            # so the source capture stops seeing v4 queries -- reflection stops at the ingress; the
-            # monitor rejoins on restore. target IPv6: the target is the egress, so the per-packet
-            # source-address gate drops the v6 re-emit; the monitor refreshes egress addrs on restore.
+            # source IPv4: the source is the egress for mDNS responses, so knocking out its v4 makes the
+            # per-packet source-address gate drop the v4 response re-emit -- reflection stops at the
+            # egress; the monitor refreshes source addrs on restore. target IPv6: the target is the
+            # egress for queries, so the gate drops the v6 re-emit; the monitor refreshes egress addrs.
             Phase(label="source IPv4", protocol="mdns", family=4, interface="source"),
             Phase(label="target IPv6", protocol="mdns", family=6, interface="target"),
         ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! reflector: reflects link-local service traffic (Wake-on-LAN, mDNS, SSDP,
+//! reflector: reflects link-local service traffic (Wake-on-LAN, mDNS, SSDP, WS-Discovery,
 //! and an optional DIAL proxy) between two network interfaces.
 //!
 //! The behavior lives in this library crate so it stays testable in-process;

--- a/src/libcex/bpf.rs
+++ b/src/libcex/bpf.rs
@@ -12,7 +12,11 @@ pub(crate) struct BpfInsn {
     pub(crate) k: u32,
 }
 
-// On Linux this same struct installs as a `sock_filter` via `SO_ATTACH_FILTER`;
-// pin its layout to libc's.
+// This same struct installs as a `sock_filter` on Linux (`SO_ATTACH_FILTER`) and a `bpf_insn` on the
+// BSDs (`BIOCSETF`). Anchor to libc where it has the type; apple has neither, so pin the size directly.
 #[cfg(target_os = "linux")]
 const _: () = assert!(size_of::<BpfInsn>() == size_of::<libc::sock_filter>());
+#[cfg(target_os = "freebsd")]
+const _: () = assert!(size_of::<BpfInsn>() == size_of::<libc::bpf_insn>());
+#[cfg(target_os = "macos")]
+const _: () = assert!(size_of::<BpfInsn>() == 8);

--- a/src/libcex/bpf_device.rs
+++ b/src/libcex/bpf_device.rs
@@ -15,10 +15,10 @@ const _: () = assert!(DLT_EN10MB == libc::DLT_EN10MB);
 #[cfg(target_os = "macos")]
 const _: () = assert!(DLT_NULL == libc::DLT_NULL);
 
-/// `struct bpf_program`: the filter handed to `BIOCSETF`. libc provides this
-/// (and `bpf_insn`) on FreeBSD but not apple, so define it for both; the asserts
-/// anchor the layout to libc where it exists. The per-frame header is read as
-/// `libc::bpf_hdr` (apple + FreeBSD both have it, with the right per-OS timestamp).
+/// `struct bpf_program`: the filter handed to `BIOCSETF`. libc provides it on FreeBSD but not apple, so
+/// define it for both; the FreeBSD assert anchors the layout to libc, the macOS one pins the size. The
+/// per-frame header is read as `libc::bpf_hdr` (apple + FreeBSD both have it, with the right per-OS
+/// timestamp).
 #[repr(C)]
 pub(crate) struct BpfProgram {
     pub(crate) bf_len: c_uint,
@@ -26,8 +26,9 @@ pub(crate) struct BpfProgram {
 }
 #[cfg(target_os = "freebsd")]
 const _: () = assert!(size_of::<BpfProgram>() == size_of::<libc::bpf_program>());
-#[cfg(target_os = "freebsd")]
-const _: () = assert!(size_of::<BpfInsn>() == size_of::<libc::bpf_insn>());
+// apple has no libc `bpf_program` to anchor to; pin the size (u_int + pointer = 16 on 64-bit macOS).
+#[cfg(target_os = "macos")]
+const _: () = assert!(size_of::<BpfProgram>() == 16);
 
 // `BPF_ALIGNMENT` as a usize. libc types it differently per platform (`c_int` on
 // apple, `usize` on FreeBSD), so normalize it once here.

--- a/src/libcex/netlink.rs
+++ b/src/libcex/netlink.rs
@@ -1,5 +1,5 @@
-//! rtnetlink (`NETLINK_ROUTE`) message-framing FFI, hand-rolled because `libc` exposes it for Android
-//! only, not glibc/musl.
+//! rtnetlink (`NETLINK_ROUTE`) message-framing FFI, hand-rolled because `libc` does not expose it for
+//! glibc/musl.
 
 use libc::c_int;
 
@@ -19,6 +19,9 @@ pub(crate) struct NlMsgHdr {
     pub(crate) pid: u32,
 }
 
+// libc exposes no netlink structs to anchor against on glibc/musl, so pin the on-wire sizes directly.
+const _: () = assert!(size_of::<NlMsgHdr>() == 16);
+
 /// `struct ifaddrmsg`: the body of an `RTM_*ADDR` message. A zeroed value (family
 /// `AF_UNSPEC`) is the dump request body. The address monitor reads `index` from it.
 #[repr(C)]
@@ -31,12 +34,16 @@ pub(crate) struct IfAddrMsg {
     pub(crate) index: u32,
 }
 
+const _: () = assert!(size_of::<IfAddrMsg>() == 8);
+
 /// `struct rtattr`: a type-length-value attribute header within a message.
 #[repr(C)]
 pub(crate) struct RtAttr {
     pub(crate) len: u16,
     pub(crate) attr_type: u16,
 }
+
+const _: () = assert!(size_of::<RtAttr>() == 4);
 
 /// `struct sockaddr_nl`.
 #[repr(C)]
@@ -47,6 +54,8 @@ pub(crate) struct SockAddrNl {
     pub(crate) pid: u32,
     pub(crate) groups: u32,
 }
+
+const _: () = assert!(size_of::<SockAddrNl>() == 12);
 
 /// `NLMSG_ALIGN`: netlink's 4-byte alignment for message and attribute lengths.
 pub(crate) const fn nl_align(n: usize) -> usize {

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -18,8 +18,8 @@ use super::{
     UDP_HEADER_SIZE,
 };
 
-/// A parsed UDP datagram: the endpoints, the TTL/hop-limit to preserve on re-emit, the
-/// L2 addresses (for filtering), and the payload borrowed from the capture buffer.
+/// A parsed UDP datagram: the endpoints, the captured TTL/hop-limit, the L2 addresses
+/// (for filtering), and the payload borrowed from the capture buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Packet<'a> {
     pub(crate) source: SocketAddr,

--- a/src/reactor/poll.rs
+++ b/src/reactor/poll.rs
@@ -1,7 +1,7 @@
 //! Readiness backend: an OS-uniform [`Poller`] over the platform's readiness
 //! syscalls. A wait reports which registered fds are ready, each tagged with the
 //! reactor [`Key`] handed to the kernel, so dispatch needs no fd-to-handler side
-//! table. kqueue backend (macOS/FreeBSD) implemented; epoll (Linux) follows.
+//! table. Backends: kqueue (macOS/FreeBSD) and epoll (Linux).
 
 use super::{Key, Readiness};
 

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -4,6 +4,11 @@
 //! capture's own-egress drop, this breaks the reflection loop. Each re-emits to the same group at
 //! TTL 255 (RFC 6762 §11), sourced from the egress interface. The dispatcher's filter pins the
 //! group, so the reflector only gates on the query/response classifier.
+//!
+//! Limitation: this is a multicast-only relay. A one-shot / legacy querier — one that asks from an
+//! ephemeral source port, or sets the unicast-response (QU) bit — is answered *unicast* to that port,
+//! off the group, so its answer is never captured or reflected across the link. (SSDP and WSD instead
+//! proxy each searcher's unicast reply through a per-searcher session; mDNS does not.)
 
 use std::net::SocketAddr;
 

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -1,4 +1,4 @@
-//! The shared search direction for the unicast-reply discovery protocols (SSDP, and next WSD).
+//! The shared search direction for the unicast-reply discovery protocols (SSDP and WSD).
 //!
 //! A search (SSDP `M-SEARCH`, WSD `Probe` / `Resolve`) is reflected source → target, and each
 //! searcher's *unicast* reply (SSDP `200 OK`, WSD `ProbeMatches` / `ResolveMatches`) is routed back


### PR DESCRIPTION
Two low-priority audit cleanups on one branch.

Stale docs (commit 1): factual corrections across README, e2e comments,
and module docs -- add WS-Discovery where omitted, correct the poll.rs
backend status, the packet.rs TTL-preservation claim, the log_level range,
and the e2e address-change/DIAL comments that described the wrong mechanism.

libcex FFI asserts (commit 2): the netlink framing structs and macOS
BpfInsn/BpfProgram had no compile-time size check (libc exposes no
equivalent to anchor against there). Add literal-size const asserts,
consolidate BpfInsn's per-target anchors in bpf.rs, drop the stale
"Android only" from the netlink comment.

Testing: fmt, clippy (host/FreeBSD/Linux), doc (host/Linux) all clean.