### PR TITLE
build: pin the Rust toolchain and Docker base; cache rustup in docker_test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@
 # images don't crawl under QEMU. The crate is pure Rust (libc FFI only), so LLVM's lld cross-links
 # it for any arch with no per-arch gcc toolchain — just the one lld package.
 
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:slim AS builder
+# Pin the shared base image by digest: reproducible builds, no drift under the floating tag. Renovate
+# keeps it current. Referenced by both the builder and the valgrind runtime below so they stay in lockstep.
+ARG RUST_IMAGE=docker.io/library/rust:slim@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523
+FROM --platform=$BUILDPLATFORM ${RUST_IMAGE} AS builder
 ARG TARGETARCH
 ARG TARGETVARIANT
 WORKDIR /src
@@ -48,7 +51,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # daemon so Valgrind reports leaks at a clean exit; --track-fds catches a leaked socket in the live daemon;
 # --error-exitcode=1 fails on any leak, leaked fd, or memcheck error. "reachable" is allowed (the logger and
 # other process-lifetime statics live to exit by design).
-FROM docker.io/library/rust:slim AS runtime-valgrind
+FROM ${RUST_IMAGE} AS runtime-valgrind
 RUN apt-get update \
     && apt-get install -y --no-install-recommends valgrind \
     && rm -rf /var/lib/apt/lists/*

--- a/docker_test.sh
+++ b/docker_test.sh
@@ -8,9 +8,11 @@
 #   ./docker_test.sh test epoll                            # filter to epoll tests
 #   ./docker_test.sh clippy --all-targets -- -D warnings   # Linux clippy/lints
 #
-# Named volumes hold the Linux target dir (so the macOS ./target is untouched)
-# and the crate registry, keeping re-runs fast. The capture layer will later need
-# raw-socket privileges — add `--cap-add=NET_RAW` here when those tests land.
+# Named volumes hold the Linux target dir (so the macOS ./target is untouched),
+# the crate registry, and the rustup home -- the last so the pinned toolchain's
+# rustfmt/clippy components (absent from rust:slim) download once, not every run.
+# The capture layer will later need raw-socket privileges -- add `--cap-add=NET_RAW`
+# here when those tests land.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -20,6 +22,7 @@ exec docker run --rm \
     -v "$PWD":/reflector \
     -v reflector-linux-target:/linux-target \
     -v reflector-cargo-registry:/usr/local/cargo/registry \
+    -v reflector-rustup:/usr/local/rustup \
     -e CARGO_TARGET_DIR=/linux-target \
     -w /reflector \
     rust:slim \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,7 @@
 [toolchain]
-channel = "stable"
+# Pinned (not "stable") so every environment -- host, the rust:slim Docker builds, and the rustup CI
+# lanes -- compiles with one known rustc, and a new stable can't silently change codegen or fail a
+# release build on a fresh warn-by-default lint. Renovate's rust-toolchain manager bumps this via a
+# CI-gated PR. (The FreeBSD VM lanes install rust from pkg and don't read this file.)
+channel = "1.96.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
The infra audit group: reproducible builds + a faster docker_test.sh.

- rust-toolchain.toml: pin stable -> 1.96.1 so host, Docker, and the rustup
  CI lanes share one compiler; a new stable can no longer shift codegen or
  fail a release on a fresh warn-by-default lint. Renovate's rust-toolchain
  manager bumps it via CI-gated PRs.
- Dockerfile: pin the base image by digest (shared ARG for builder + valgrind
  runtime). Renovate keeps it current.
- docker_test.sh: mount a rustup-home volume so the toolchain's rustfmt/clippy
  components download once, not every run.

Scope notes: the FreeBSD VM lanes install rust from pkg and don't read the
toolchain file (they still float; freebsd-target warnings are still gated by
the pinned x86_64-unknown-freebsd clippy lane). docker_test.sh keeps the
rust:slim tag -- the compiler is pinned via the mounted toolchain file, and no
default Renovate manager tracks a shell-script image ref.

Testing: pin resolves to 1.96.1 on host + in-container (clippy clean both);
rustup volume caches (no second-run download); both Dockerfile stages build
with the pinned digest; fmt clean.