### PR TITLE
sys: fix the startup crash in statically linked FreeBSD binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,9 +238,9 @@ jobs:
             export RUSTFLAGS="${{ matrix.profile.rustflags }}"
             cargo test --locked ${{ matrix.profile.flags }}
 
-  # The native e2e suite on a real FreeBSD kernel: epair segments, probes in vnet jails, the daemon
-  # on the VM's host stack -- the BPF capture/inject and PF_ROUTE monitor paths end to end, which no
-  # Linux lane can reach. Same vmactions mechanics as the freebsd test job; python3 comes from pkg.
+  # The native e2e suite on a real FreeBSD kernel: epair segments, every participant in its own
+  # vnet jail -- the BPF capture/inject and PF_ROUTE monitor paths end to end, which no Linux lane
+  # can reach. Same vmactions mechanics as the freebsd test job; python3 comes from pkg.
   freebsd-native-e2e:
     name: Native e2e (freebsd-amd64)
     needs: gate
@@ -260,8 +260,15 @@ jobs:
           run: |
             rustc --version
             python3 --version
-            cargo build --release --locked
-            python3 e2e/run.py --backend native --binary target/release/reflector
+            # The shipped FreeBSD configuration exactly: static (+crt-static) on the LTO release
+            # profile, as release.yml publishes it -- runtime behavior differs there (the null
+            # environ that sys::process_env works around, the pair tests' spawn skip), and this
+            # lane is the only one that runs that artifact. --target (even ==host) keeps the
+            # flag off the host proc-macro graph, like the freebsd test job's release lane.
+            RUSTFLAGS="-C target-feature=+crt-static" \
+              cargo build --release --locked --target x86_64-unknown-freebsd
+            python3 e2e/run.py --backend native \
+              --binary target/x86_64-unknown-freebsd/release/reflector
 
   # Build the scratch image and drive the Docker-bridge e2e suite (the data path: capture -> reflect across
   # two bridges, multi-protocol). --skip-build reuses the image built here with the gha cache.

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -78,13 +78,15 @@ impl InterfacePair {
     fn create() -> Option<Self> {
         use std::sync::atomic::{AtomicU8, Ordering};
         static NEXT_SUBNET: AtomicU8 = AtomicU8::new(1);
-        // The fixture is built on ifconfig shell-outs, and std::process::Command SIGSEGVs in a
-        // statically-linked LTO release binary on FreeBSD (the lto + crt-static + spawn class
-        // of rust-lang/rust#94564; deterministic in CI, fine dynamic and fine on static musl).
-        // FreeBSD coverage comes from the dynamic (debug) lane; the static lane keeps proving
-        // the +crt-static build for the rest of the suite.
+        // The fixture is built on ifconfig shell-outs, and a plain std::process::Command spawn
+        // SIGSEGVs in a statically-linked (+crt-static) binary on FreeBSD since rustc 1.96:
+        // std resolves `environ` via dlsym (null without a dynamic symbol table) and
+        // posix_spawn dereferences it to capture the inherited env -- the same std bug
+        // sys::process_env works around for the daemon's config path. FreeBSD coverage comes
+        // from the dynamic (debug) lane; the static lane keeps proving the +crt-static build
+        // for the rest of the suite.
         if cfg!(all(target_os = "freebsd", target_feature = "crt-static")) {
-            eprintln!("skip pair test: process spawning crashes static LTO FreeBSD binaries");
+            eprintln!("skip pair test: process spawning crashes static FreeBSD binaries");
             return None;
         }
         // SAFETY: geteuid takes no arguments and cannot fail.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,9 @@ use self::reflector::InterfaceMap;
 pub fn run(args: &[OsString]) -> Result<()> {
     let path = config_path(args)?;
     let toml_text = path.map(config::read_config_file).transpose()?;
-    let env: Vec<(String, String)> = std::env::vars().collect();
+    // sys::process_env, not std::env::vars: vars() segfaults in statically
+    // linked FreeBSD binaries (see process_env).
+    let env = sys::process_env();
 
     // Resolve the log level first from a minimal read of env + file, so the full parse below
     // logs at the configured verbosity (see resolve_log_level).

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -199,6 +199,47 @@ pub(crate) fn set_nonblock(fd: RawFd) -> io::Result<()> {
     Ok(())
 }
 
+/// The process environment as UTF-8 key/value pairs; entries that are not
+/// valid UTF-8 (or lack a `=`) are skipped.
+///
+/// On FreeBSD this walks the CRT-provided `environ` table itself instead of
+/// calling `std::env::vars`: std resolves `environ` via
+/// `dlsym(RTLD_DEFAULT, ..)`, which returns null in a statically linked
+/// binary (no dynamic symbol table), and std dereferences the null -- the
+/// shipped static binary segfaulted on startup. An `extern` reference links
+/// against the crt1-provided symbol in any executable, static or dynamic.
+#[cfg(target_os = "freebsd")]
+pub(crate) fn process_env() -> Vec<(String, String)> {
+    unsafe extern "C" {
+        static mut environ: *mut *const libc::c_char;
+    }
+    let mut entries = Vec::new();
+    // SAFETY: crt1 points `environ` at the null-terminated environment before
+    // `main` and libc's setenv keeps it valid; the process is single-threaded
+    // (project invariant), so the table cannot change mid-walk; each entry is
+    // a valid C string.
+    unsafe {
+        let mut entry = environ;
+        while !entry.is_null() && !(*entry).is_null() {
+            let bytes = std::ffi::CStr::from_ptr(*entry).to_bytes();
+            if let Some((key, value)) = str::from_utf8(bytes).ok().and_then(|s| s.split_once('=')) {
+                entries.push((key.to_owned(), value.to_owned()));
+            }
+            entry = entry.add(1);
+        }
+    }
+    entries
+}
+
+/// The process environment as UTF-8 key/value pairs; entries that are not
+/// valid UTF-8 are skipped.
+#[cfg(not(target_os = "freebsd"))]
+pub(crate) fn process_env() -> Vec<(String, String)> {
+    std::env::vars_os()
+        .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -252,5 +293,17 @@ mod tests {
     #[test]
     fn owned_fd_from_rejects_a_negative_return() {
         assert!(owned_fd_from(-1).is_err());
+    }
+
+    #[test]
+    fn process_env_sees_a_set_variable() {
+        // SAFETY: nothing else in the test binary reads or writes the process
+        // environment concurrently (config tests take env as a parameter).
+        unsafe { std::env::set_var("REFLECTOR_SYS_ENV_PROBE", "probe-value") };
+        let env = process_env();
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "REFLECTOR_SYS_ENV_PROBE" && v == "probe-value")
+        );
     }
 }


### PR DESCRIPTION
Statically linked FreeBSD binaries segfault on startup since rustc 1.96: rust-lang/rust#153718 made std resolve `environ` through dlsym(RTLD_DEFAULT, ..), which returns null without a dynamic symbol table, and std::env::vars dereferences it. The v0.11.0 freebsd-amd64 release asset died on exec; the unit suites never caught it because the config tests take env as a parameter, so nothing ever iterated the real process environment. The same null capture crashes plain Command::spawn (posix_spawn envp), which is what the pair tests' static skip was actually hitting.

sys::process_env collects the environment instead: on FreeBSD it walks the crt1-provided `environ` extern, which links in any executable, static or dynamic; elsewhere vars_os, skipping non-UTF-8 entries instead of panicking.

The freebsd-native-e2e lane now builds the daemon in the shipped configuration (+crt-static on the LTO release profile), the only gap through which this could ship; the probe version of this lane is what caught the crash.

Testing: a new sys unit test exercises the walk on every lane including FreeBSD static release; CI probes on FreeBSD 14.2 confirmed the mechanism (static vars_os repro segfaults, getenv works, env_clear spawn works) and the fixed daemon passed the full 46-case native e2e in the exact shipped configuration (run 28911529685).
