### PR TITLE
docker: key the cargo registry cache mount per arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,12 @@ EOF
 
 COPY Cargo.toml Cargo.lock ./
 COPY src/ ./src/
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+# The cache mount is keyed per arch: multi-platform builds run the per-arch builder stages in
+# parallel, and cargo cannot coordinate concurrent registry unpacks across them (its lock file
+# is $CARGO_HOME/.package-cache, outside the mounted path) -- two arches racing to unpack the
+# same crate into a shared default-id mount fail with "File exists" whenever the mount is cold
+# (in CI it always is: RUN-mount contents are not part of the exported layer cache).
+RUN --mount=type=cache,id=cargo-registry-${TARGETARCH}${TARGETVARIANT},target=/usr/local/cargo/registry \
     triple="$(cat /triple)"; \
     cargo build --release --locked --target "${triple}"; \
     install -D "target/${triple}/release/reflector" /out/reflector
@@ -58,7 +63,8 @@ RUN apt-get update \
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY src/ ./src/
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+# Its own cache id: this stage is amd64-only, but the default id would alias the builder's mount.
+RUN --mount=type=cache,id=cargo-registry-valgrind,target=/usr/local/cargo/registry \
     CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_STRIP=false \
     cargo build --release --locked \
     && install -D target/release/reflector /usr/local/bin/reflector


### PR DESCRIPTION
The v0.11.1 image build failed with "failed to unpack package ... File exists": multi-platform builds run the per-arch builder stages in parallel against one shared default-id cache mount, and cargo cannot coordinate the concurrent registry unpacks (its lock file is $CARGO_HOME/.package-cache, outside the mounted path). The mount is cold on every CI run (RUN-mount contents are not part of the exported layer cache), so any release whose build layer misses the cache rolls these dice; earlier releases just won. Keying the mount id per arch (plus a distinct id for the valgrind stage) removes the sharing and keeps the stages parallel.

Testing: local docker build (amd64) and a three-arch buildx build (amd64/arm64/armv7, the racing configuration) both pass with cold keyed mounts; CI runs the docker-e2e and valgrind lanes on the changed Dockerfile.