### PR TITLE
Default linkers where they exist; execute every shipped configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,14 +376,15 @@ jobs:
       - name: Run e2e
         run: python3 e2e/run.py --skip-build --image reflector:e2e
 
-  # The same e2e suite without Docker: netns + veth segments and plain processes. The native-arch
-  # lanes run a release binary built directly on the runner (amd64 exercises the glibc build,
-  # arm64 the deployment arch). The 32-bit ARM lanes run the release configuration -- the static
-  # musl binary, lld-cross-linked like the Dockerfile/release builds -- with the daemon executing
-  # under qemu-user via binfmt_misc: the harness, probes, and every kernel primitive (netns, veth,
-  # AF_PACKET, netlink) are native; only the reflector is emulated. That puts real 32-bit
-  # pointer-width traffic through the whole capture -> classify -> re-emit path, which the QEMU
-  # unit-test lanes can't (unit-only) and the docker-e2e lane can't (amd64 image).
+  # The same e2e suite without Docker: netns + veth segments and plain processes. The glibc lanes
+  # run a release binary built directly on the runner -- the from-source configuration. The 64-bit
+  # musl lanes run the shipped release-asset configuration: static musl, rustc's default
+  # toolchain, built and run natively. The 32-bit ARM lanes run that shipped configuration too,
+  # lld-cross-linked like the Dockerfile's cross layers, with the daemon executing under qemu-user
+  # via binfmt_misc: the harness, probes, and every kernel primitive (netns, veth, AF_PACKET,
+  # netlink) are native; only the reflector is emulated. That puts real 32-bit pointer-width
+  # traffic through the whole capture -> classify -> re-emit path, which the QEMU unit-test lanes
+  # can't (unit-only) and the docker-e2e lanes can't (64-bit images).
   native-e2e:
     name: Native e2e (${{ matrix.target.name }})
     needs: gate
@@ -393,12 +394,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # triple '' = the runner's native toolchain; otherwise that static musl target under QEMU.
+        # triple '' = the runner's native gnu toolchain; a triple without `emulated` is that musl
+        # target built and run natively; `emulated` lanes cross-link and run under qemu binfmt.
         target:
-          - { name: linux-amd64, runner: ubuntu-24.04, triple: '' }
-          - { name: linux-arm64, runner: ubuntu-24.04-arm, triple: '' }
-          - { name: linux-armv7, runner: ubuntu-24.04, triple: armv7-unknown-linux-musleabihf }
-          - { name: linux-armv5, runner: ubuntu-24.04, triple: armv5te-unknown-linux-musleabi }
+          - { name: linux-amd64-glibc, runner: ubuntu-24.04, triple: '' }
+          - { name: linux-arm64-glibc, runner: ubuntu-24.04-arm, triple: '' }
+          - { name: linux-amd64-musl, runner: ubuntu-24.04, triple: x86_64-unknown-linux-musl }
+          - { name: linux-arm64-musl, runner: ubuntu-24.04-arm, triple: aarch64-unknown-linux-musl }
+          - { name: linux-armv7-musl, runner: ubuntu-24.04, triple: armv7-unknown-linux-musleabihf, emulated: true }
+          - { name: linux-armv5-musl, runner: ubuntu-24.04, triple: armv5te-unknown-linux-musleabi, emulated: true }
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -413,7 +417,7 @@ jobs:
           key: cargo-native-e2e-${{ matrix.target.name }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: cargo-native-e2e-${{ matrix.target.name }}-
       - name: Install lld + QEMU user-mode
-        if: matrix.target.triple != ''
+        if: matrix.target.emulated
         run: |
           # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
           # the packages come from the Ubuntu archive, and a broken archive still fails the
@@ -423,10 +427,11 @@ jobs:
       - name: Add the Rust target
         if: matrix.target.triple != ''
         run: rustup target add ${{ matrix.target.triple }}
-      # The same lld cross-link config the Dockerfile and the QEMU test lanes write; binfmt_misc
-      # (from qemu-user-static) execs the ARM binary under qemu transparently, netns exec included.
-      - name: Configure the musl cross-linker
-        if: matrix.target.triple != ''
+      # The same lld cross-link config the Dockerfile writes for cross layers; binfmt_misc (from
+      # qemu-user-static) execs the ARM binary under qemu transparently, netns exec included. The
+      # native musl lanes write no config: rustc's default toolchain, like release.yml's rows.
+      - name: Configure the arm32 cross-linker
+        if: matrix.target.emulated
         run: |
           mkdir -p .cargo
           cat > .cargo/config.toml <<'EOF'
@@ -435,7 +440,9 @@ jobs:
           rustflags = ["-C", "linker-flavor=ld.lld"]
           EOF
       - name: Build release binary
-        run: cargo build --release --locked ${{ matrix.target.triple != '' && format('--target {0}', matrix.target.triple) || '' }}
+        run: |
+          triple='${{ matrix.target.triple }}'
+          cargo build --release --locked ${triple:+--target "$triple"}
       - name: Run e2e natively
         run: |
           triple='${{ matrix.target.triple }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,13 +334,22 @@ jobs:
         run: ci/freebsd-vm.sh console
 
   # Build the scratch image and drive the Docker-bridge e2e suite (the data path: capture -> reflect across
-  # two bridges, multi-protocol). --skip-build reuses the image built here with the gha cache.
+  # two bridges, multi-protocol). One lane per shipped 64-bit image arch, each on its native runner, so
+  # both released layer sets are executed in exactly the configuration release.yml publishes (native =
+  # default-toolchain link, per the Dockerfile). The cache scopes match the release image jobs', so a
+  # release build reuses layers CI built for the same commit. --skip-build reuses the image built here.
   docker-e2e:
-    name: Docker e2e
+    name: Docker e2e (${{ matrix.arch.name }})
     needs: gate
     if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.arch.runner }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - { name: amd64, runner: ubuntu-24.04 }
+          - { name: arm64, runner: ubuntu-24.04-arm }
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -352,8 +361,8 @@ jobs:
           context: .
           tags: reflector:e2e
           load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.arch.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch.name }}
       - name: Run e2e
         run: python3 e2e/run.py --skip-build --image reflector:e2e
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,14 +117,17 @@ jobs:
       - name: rustdoc (intra-doc link gate)
         run: cargo doc --locked --target ${{ matrix.target }} --no-deps --document-private-items
 
-  # The unit suite in both profiles, per OS/arch. macOS exercises the cfg(macos) BSD path; the two
-  # Linux arches exercise cfg(linux) on 64-bit. armv7/armv5 have no native runner, but 32-bit ARM is
-  # a deployment target (MikroTik), so those lanes (triple != '') run the suite under QEMU rather
-  # than only cross-building it -- catching pointer-width / alignment / cast bugs the 64-bit lanes
-  # can't. The static musl test binary needs no target sysroot under qemu-user: lld cross-links it
-  # (the same config the Dockerfile uses, no per-arch gcc) and the cargo target runner executes it
-  # via qemu-arm-static (armv7 = armhf, hard-float; armv5 = armel, soft-float, the EN7562 boxes).
-  # Privileged tests (raw-socket capture) self-skip without CAP_NET_RAW, as they do on the dev host.
+  # The unit suite in both profiles, per OS/arch/libc. The glibc lanes (triple '') cover the
+  # from-source configuration -- what `cargo build` gives users and contributors, rustc's default
+  # toolchain included; macOS among them exercises the cfg(macos) BSD path. The 64-bit musl lanes
+  # run the shipped-binary configuration (static musl, rustc's default self-contained link, the
+  # same as release.yml's native rows) natively and as root, so the privileged tests also cover
+  # musl's std/libc. armv7/armv5 have no native runner, but 32-bit ARM is a deployment target
+  # (MikroTik), so those lanes run the shipped musl configuration under QEMU rather than only
+  # cross-building it -- catching pointer-width / alignment / cast bugs the 64-bit lanes can't.
+  # There lld cross-links (the same config the Dockerfile uses for cross layers, no per-arch gcc)
+  # and the cargo target runner executes via qemu-arm-static (armv7 = armhf, hard-float; armv5 =
+  # armel, soft-float, the EN7562 boxes).
   test:
     name: Test (${{ matrix.target.name }}, ${{ matrix.profile.name }})
     needs: gate
@@ -139,13 +142,16 @@ jobs:
         profile:
           - { name: debug, flags: '' }
           - { name: release, flags: '--release' }
-        # triple '' = the runner's native toolchain; otherwise that static musl target under QEMU.
+        # triple '' = the runner's native gnu toolchain; a triple without `emulated` is that musl
+        # target built and run natively; `emulated` lanes cross-link and run under qemu-arm-static.
         target:
-          - { name: linux-amd64, runner: ubuntu-24.04, triple: '' }
-          - { name: linux-arm64, runner: ubuntu-24.04-arm, triple: '' }
+          - { name: linux-amd64-glibc, runner: ubuntu-24.04, triple: '' }
+          - { name: linux-arm64-glibc, runner: ubuntu-24.04-arm, triple: '' }
+          - { name: linux-amd64-musl, runner: ubuntu-24.04, triple: x86_64-unknown-linux-musl }
+          - { name: linux-arm64-musl, runner: ubuntu-24.04-arm, triple: aarch64-unknown-linux-musl }
+          - { name: linux-armv7-musl, runner: ubuntu-24.04, triple: armv7-unknown-linux-musleabihf, emulated: true }
+          - { name: linux-armv5-musl, runner: ubuntu-24.04, triple: armv5te-unknown-linux-musleabi, emulated: true }
           - { name: macos-arm64, runner: macos-15, triple: '' }
-          - { name: linux-armv7, runner: ubuntu-24.04, triple: armv7-unknown-linux-musleabihf }
-          - { name: linux-armv5, runner: ubuntu-24.04, triple: armv5te-unknown-linux-musleabi }
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -160,7 +166,7 @@ jobs:
           key: cargo-${{ matrix.target.name }}-${{ matrix.profile.name }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: cargo-${{ matrix.target.name }}-${{ matrix.profile.name }}-
       - name: Install lld + QEMU user-mode
-        if: matrix.target.triple != ''
+        if: matrix.target.emulated
         run: |
           # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
           # the packages come from the Ubuntu archive, and a broken archive still fails the
@@ -170,11 +176,13 @@ jobs:
       - name: Add the Rust target
         if: matrix.target.triple != ''
         run: rustup target add ${{ matrix.target.triple }}
-      # Link the musl target with lld (cross-capable, unlike the host gcc) and run the test binary under
-      # QEMU -- the same lld config the Dockerfile writes, plus a qemu-arm-static runner for the target.
-      # The cfg(target_env = "musl") scope leaves host build-scripts/proc-macros on the default linker.
+      # Link the arm32 musl target with lld (cross-capable, unlike the host gcc) and run the test
+      # binary under QEMU -- the same lld config the Dockerfile writes for cross layers, plus a
+      # qemu-arm-static runner for the target. The cfg(target_env = "musl") scope leaves host
+      # build-scripts/proc-macros on the default linker. The native musl lanes write no config at
+      # all: rustc's default toolchain links them, exactly like the release rows.
       - name: Configure the cross linker and QEMU runner
-        if: matrix.target.triple != ''
+        if: matrix.target.emulated
         run: |
           mkdir -p .cargo
           cat > .cargo/config.toml <<'EOF'
@@ -193,10 +201,12 @@ jobs:
       # lives in the native e2e lanes, and they double as the guard that the suite still runs (and
       # skips its privileged tests) without root, the way contributors run it.
       - name: cargo test (root)
-        if: matrix.target.triple == ''
-        run: sudo -E "$(command -v cargo)" test --locked ${{ matrix.profile.flags }}
+        if: ${{ !matrix.target.emulated }}
+        run: |
+          triple='${{ matrix.target.triple }}'
+          sudo -E "$(command -v cargo)" test --locked ${{ matrix.profile.flags }} ${triple:+--target "$triple"}
       - name: cargo test (under QEMU)
-        if: matrix.target.triple != ''
+        if: matrix.target.emulated
         run: cargo test --locked --target ${{ matrix.target.triple }} ${{ matrix.profile.flags }}
 
   # FreeBSD shares its BSD platform path (kqueue, BPF, route sockets, getifaddrs) with macOS but needs a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,20 +208,91 @@ jobs:
           path: dist/reflector-${{ github.ref_name }}-freebsd-arm64
           if-no-files-found: error
 
-  # One buildx multi-platform build on the amd64 runner: the Dockerfile cross-compiles every arch with lld
-  # (no QEMU), so a native arm64 runner buys nothing, and buildx assembles the manifest itself -- no
-  # per-arch digests to stitch. Pushes the multi-arch image to GHCR, tagged from the git tag.
+  # Each image arch builds on its own runner and pushes by digest; the manifest job stitches the
+  # digests into one multi-arch tag (the same shape the C++ reflector releases with). Native
+  # runners for amd64/arm64 mean those layers link with rustc's default toolchain -- the
+  # Dockerfile writes its lld config only for cross builds, i.e. the arm32 pair, which have no
+  # native runner and cross-compile on the amd64 host (no QEMU).
   image:
-    name: Image -> GHCR
+    name: Image (${{ matrix.arch }})
     needs: verify-ci
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+          - arch: armv7
+            runner: ubuntu-24.04
+            platform: linux/arm/v7
+          - arch: armv5
+            runner: ubuntu-24.04
+            platform: linux/arm/v5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The cache scopes are shared with the docker-e2e lanes, so a release build reuses layers
+      # CI already built for this commit.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/reflector,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}.digest"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*.digest
+          if-no-files-found: error
+          retention-days: 1
+
+  manifest:
+    name: Image manifest -> GHCR
+    needs: image
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write
     steps:
-      - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -243,20 +314,27 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push the multi-arch image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create and push the manifest list
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/reflector
+          METADATA: ${{ steps.meta.outputs.json }}
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA")
+          args=()
+          for tag in "${tags[@]}"; do args+=(--tag "$tag"); done
+          for f in *.digest; do args+=("${IMAGE}@sha256:${f%.digest}"); done
+          docker buildx imagetools create "${args[@]}"
+
+      - name: Inspect
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/reflector
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
   release:
     name: GitHub release
-    needs: [binaries, binaries-freebsd, image]
+    needs: [binaries, binaries-freebsd, manifest]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,12 @@ jobs:
           [ -n "$ok" ] || { echo "::error::Timed out waiting for $wf on $sha"; exit 1; }
           echo "$wf passed on $sha."
 
-  # Downloadable binaries. The Linux targets are static musl, cross-compiled on the amd64 runner with lld
-  # (no QEMU, no per-arch gcc -- the same path the Dockerfile uses); FreeBSD amd64 cross-compiles the same
-  # way against a base.txz sysroot (ci/freebsd-sysroot.sh) -- the exact configuration CI's freebsd lanes
-  # build AND run on every PR; macOS builds natively and ships dynamic (no static libSystem). FreeBSD
-  # arm64 is separate (no rustup std until Rust 1.98; see binaries-freebsd).
+  # Downloadable binaries, built with rustc's default toolchain wherever one exists: amd64 and
+  # arm64 are static musl on their native runners (the self-contained default, gcc-driven link),
+  # macOS native dynamic (no static libSystem). armv7/armv5 have no native runner, so they
+  # cross-compile on the amd64 runner with lld; FreeBSD amd64 likewise (clang+lld against a
+  # base.txz sysroot -- the exact configuration CI's freebsd lanes build AND run on every PR).
+  # FreeBSD arm64 is separate (no rustup std until Rust 1.98; see binaries-freebsd).
   binaries:
     name: Binary (${{ matrix.variant }})
     needs: verify-ci
@@ -76,7 +77,7 @@ jobs:
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
           - variant: linux-arm64
-            runner: ubuntu-24.04
+            runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
           - variant: linux-armv7
             runner: ubuntu-24.04
@@ -97,8 +98,8 @@ jobs:
       # A failing third-party repo (packages.microsoft.com flakes) must not kill a release
       # build; the packages come from the Ubuntu archive, and a broken archive still fails
       # the installs below loudly.
-      - name: Install lld (musl linker)
-        if: contains(matrix.target, 'musl')
+      - name: Install lld (arm32 cross-linker)
+        if: contains(matrix.target, 'armv')
         run: |
           sudo apt-get update || true
           sudo apt-get install -y --no-install-recommends lld
@@ -112,10 +113,12 @@ jobs:
       - name: Add the Rust target
         run: rustup target add ${{ matrix.target }}
 
-      # Link the musl targets with lld (cross-capable, unlike the host gcc) -- the same config the Dockerfile
-      # writes. cfg(target_env = "musl") leaves host build-scripts/proc-macros on the default linker.
-      - name: Configure the musl linker
-        if: contains(matrix.target, 'musl')
+      # Link the arm32 musl targets with lld (cross-capable, unlike the host gcc) -- the same config
+      # the Dockerfile writes for its cross layers. cfg(target_env = "musl") leaves host
+      # build-scripts/proc-macros on the default linker; amd64/arm64 musl build natively with no
+      # config at all (rustc's default).
+      - name: Configure the arm32 cross-linker
+        if: contains(matrix.target, 'armv')
         run: |
           mkdir -p .cargo
           cat > .cargo/config.toml <<'EOF'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@
 # Build the reflector as a fully static musl binary and ship it on scratch — nothing else to carry
 # or to grow CVEs. Architecture-agnostic: buildx's TARGETARCH/TARGETVARIANT select the musl target,
 # and the builder runs on the native build host (BUILDPLATFORM) and cross-compiles, so the arm
-# images don't crawl under QEMU. The crate is pure Rust (libc FFI only), so LLVM's lld cross-links
-# it for any arch with no per-arch gcc toolchain — just the one lld package.
+# images don't crawl under QEMU. Cross layers link with LLVM's lld (any arch, no per-arch gcc);
+# a layer built on its own arch uses rustc's default toolchain, following upstream defaults
+# where one exists.
 
 # Pin the shared base image by digest: reproducible builds, no drift under the floating tag. Renovate
 # keeps it current. Referenced by both the builder and the valgrind runtime below so they stay in lockstep.
@@ -28,13 +29,24 @@ RUN set -eux; \
     echo "${triple}" > /triple; \
     rustup target add "${triple}"
 
-# Link the musl targets with LLVM's lld (cross-capable, unlike the host gcc). Scoped to musl via
-# cfg, so the host's build scripts and proc-macros still link with the default toolchain.
+# Cross-compiled layers link with LLVM's lld (cross-capable, unlike the host gcc), scoped to musl
+# via cfg so the host's build scripts and proc-macros keep the default toolchain. A layer built on
+# its own arch (TARGETPLATFORM == BUILDPLATFORM: amd64, and arm64 on an arm64 host) writes no
+# config: rustc's default toolchain, per the policy of following upstream defaults where one
+# exists. lld installs either way so the layer stays shared across platforms.
 RUN apt-get update && apt-get install -y --no-install-recommends lld && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p .cargo && cat > .cargo/config.toml <<'EOF'
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+RUN <<'EOF'
+set -eu
+if [ "${TARGETPLATFORM}" != "${BUILDPLATFORM}" ]; then
+    mkdir -p .cargo
+    cat > .cargo/config.toml <<'CFG'
 [target.'cfg(target_env = "musl")']
 linker = "ld.lld"
 rustflags = ["-C", "linker-flavor=ld.lld"]
+CFG
+fi
 EOF
 
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
Linker policy: build with rustc's default toolchain wherever upstream defines one for the build host; lld only where forced (arm32 cross), clang+lld only cross-OS (FreeBSD). Riding defaults means the future musl-to-rust-lld migration arrives via an ordinary toolchain bump. Plus the coverage half: every shipped configuration is now executed in CI.

- Dockerfile: layers built on their own arch (TARGETPLATFORM == BUILDPLATFORM) skip the lld config and use the default toolchain; cross layers (arm32) keep lld.
- release binaries: linux-arm64 moves to the arm64 runner; amd64/arm64 musl link with the default (self-contained, gcc-driven); lld confined to the arm32 rows.
- release image: per-arch push-by-digest builds on native runners + an imagetools manifest job (the same shape reflector-cpp releases with); per-arch cache scopes shared with docker-e2e.
- docker-e2e: second lane on the arm64 runner -- the released arm64 image layers were built but never executed anywhere until now.
- test matrix: native linux-{amd64,arm64}-musl lanes run the shipped-binary configuration as root (privileged tests now cover musl std/libc); all Linux lane names state their libc; arm32 lanes get an explicit emulated flag, plumbing unchanged.

Testing: both Dockerfile branches built locally; the natively-linked arm64 musl binary executed on an arm64 host (clean daemon startup) and file-verified static. PR CI exercises the new musl lanes and both docker-e2e lanes. The release-side changes get their live run at the next tag.