### PR TITLE
Stop baking interface ifindexes outside the interface table

### DIFF
--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -8,13 +8,13 @@
 //! (e.g. IGMP from a multicast join) queue. The BSD backend instead binds first
 //! and relies on `BIOCSETF` flushing the kernel buffer.
 
-use std::ffi::CString;
 use std::io;
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 
 use libc::{c_int, c_void};
 
 use super::filter::{DROP_OUTGOING_PROLOGUE, ETHERNET_UDP_FILTER};
+use crate::interface::if_index;
 use crate::libcex::BpfInsn;
 use crate::net::LinkType;
 use crate::sys::{IoStatus, socklen_of};
@@ -44,7 +44,14 @@ impl Capture {
     /// Returns an error if the interface is unknown, the socket can't be created,
     /// the filter can't be attached, or the bind fails.
     pub(crate) fn open(if_name: &str) -> io::Result<Self> {
-        let ifindex = if_index(if_name)?;
+        let ifindex = if_index(if_name).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("interface {if_name} not found"),
+            )
+        })?;
+        let ifindex =
+            c_int::try_from(ifindex).map_err(|_| io::Error::other("interface index too large"))?;
 
         // Protocol 0: capture nothing until the filter + loop-prevention are in place.
         // SAFETY: a `socket` call with a valid domain/type/protocol returns a fresh fd or -1.
@@ -195,20 +202,6 @@ fn link_addr(ifindex: c_int) -> libc::sockaddr_ll {
     addr.sll_family = u16::try_from(libc::AF_PACKET).expect("AF_PACKET fits u16");
     addr.sll_ifindex = ifindex;
     addr
-}
-
-/// Resolve an interface name to its kernel index.
-fn if_index(if_name: &str) -> io::Result<c_int> {
-    let cname = CString::new(if_name).map_err(|_| {
-        io::Error::new(io::ErrorKind::InvalidInput, "interface name contains a NUL")
-    })?;
-    // SAFETY: `cname` is a valid NUL-terminated C string for the call's duration.
-    let index = unsafe { libc::if_nametoindex(cname.as_ptr()) };
-    if index == 0 {
-        // POSIX: 0 is never a valid index; `if_nametoindex` set errno.
-        return Err(io::Error::last_os_error());
-    }
-    c_int::try_from(index).map_err(|_| io::Error::other("interface index too large"))
 }
 
 /// Ask the kernel to drop locally-sent frames on this socket (`PACKET_IGNORE_OUTGOING`).

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -29,11 +29,11 @@ const RECV_BUFFER_SIZE: usize = 2048;
 /// The fallback filter length: the egress-drop prologue plus the UDP classifier.
 const DROP_OUTGOING_FILTER_LEN: usize = DROP_OUTGOING_PROLOGUE.len() + ETHERNET_UDP_FILTER.len();
 
-/// A raw-capture handle on one interface.
+/// A raw-capture handle on one interface. The socket's bind is the only holder of the
+/// interface's kernel index: sends rely on it, so nothing here goes stale if the index changes.
 pub(crate) struct Capture {
     fd: OwnedFd,
     buf: Box<[u8]>,
-    send_addr: libc::sockaddr_ll,
     name: String,
 }
 
@@ -45,7 +45,6 @@ impl Capture {
     /// the filter can't be attached, or the bind fails.
     pub(crate) fn open(if_name: &str) -> io::Result<Self> {
         let ifindex = if_index(if_name)?;
-        let send_addr = link_addr(ifindex);
 
         // Protocol 0: capture nothing until the filter + loop-prevention are in place.
         // SAFETY: a `socket` call with a valid domain/type/protocol returns a fresh fd or -1.
@@ -71,7 +70,7 @@ impl Capture {
 
         // Bind with ETH_P_ALL to start capturing. The filter is already installed, so
         // there is no unfiltered-capture window.
-        bind_interface(&fd, send_addr)?;
+        bind_interface(&fd, link_addr(ifindex))?;
 
         log::debug!(
             "opened AF_PACKET capture on {if_name} (fd {}, ifindex {ifindex})",
@@ -80,7 +79,6 @@ impl Capture {
         Ok(Self {
             fd,
             buf: vec![0u8; RECV_BUFFER_SIZE].into_boxed_slice(),
-            send_addr,
             name: if_name.into(),
         })
     }
@@ -133,18 +131,16 @@ impl Capture {
     /// # Errors
     /// Returns an error if the send fails or is short.
     pub(crate) fn send(&self, frame: &[u8]) -> io::Result<()> {
-        // SOCK_RAW carries the whole L2 frame, so the kernel needs only the egress
-        // interface (the prebuilt `send_addr`); the destination MAC is in the frame.
-        // SAFETY: `frame` is a valid readable slice; `send_addr` is a fully-initialized
-        // `sockaddr_ll` of the given length.
+        // SOCK_RAW carries the whole L2 frame and the socket is bound to its interface, so a
+        // plain `send` suffices: the kernel takes the egress from the bind, and the
+        // destination MAC is in the frame.
+        // SAFETY: `frame` is a valid readable slice of `frame.len()` bytes.
         let sent = unsafe {
-            libc::sendto(
+            libc::send(
                 self.fd.as_raw_fd(),
                 frame.as_ptr().cast::<c_void>(),
                 frame.len(),
                 0,
-                (&raw const self.send_addr).cast::<libc::sockaddr>(),
-                socklen_of::<libc::sockaddr_ll>(),
             )
         };
         if sent < 0 {
@@ -191,7 +187,8 @@ fn drop_outgoing_filter() -> [BpfInsn; DROP_OUTGOING_FILTER_LEN] {
     })
 }
 
-/// A zeroed `sockaddr_ll` addressed to `ifindex` (family set, protocol left zero).
+/// A zeroed `sockaddr_ll` addressed to `ifindex` for the bind (family set, protocol left zero;
+/// [`bind_interface`] adds it).
 fn link_addr(ifindex: c_int) -> libc::sockaddr_ll {
     // SAFETY: all-zero is a valid `sockaddr_ll`: integer and byte-array fields only.
     let mut addr: libc::sockaddr_ll = unsafe { core::mem::zeroed() };

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -362,14 +362,21 @@ impl PacketDispatcher {
     }
 
     /// The DIAL proxy registry, shared by the SSDP advertisement/response reflectors so a device gets
-    /// one proxy across both paths (see [`rewrite_location`](crate::reflector::dial::rewrite_location)).
-    pub(crate) fn dial_context(&mut self) -> &mut DialContext {
-        &mut self.dial
+    /// one proxy across both paths (see [`rewrite_location`](crate::reflector::dial::rewrite_location)),
+    /// paired with the name of the interface behind `target` (the proxy's egress pin). One call
+    /// returns both because they come from disjoint fields of one `&mut self`: a caller could not
+    /// hold the borrowed name across a second `&mut` accessor.
+    pub(crate) fn dial_context(&mut self, target: CaptureKey) -> (&mut DialContext, Option<&str>) {
+        let target_iface = self
+            .table
+            .interface_of(target)
+            .and_then(|interface| self.table.interface_name(interface));
+        (&mut self.dial, target_iface)
     }
 
     /// The kernel ifindex of the interface behind `capture`, its stable identity (the address
-    /// resolver caches it at open, and the joiners bake it too). The SSDP search reflector bakes the
-    /// target's for its IPv6 link-local reserved-port binds. `None` if the key is unknown.
+    /// resolver caches it at open, and the joiners bake it too). The SSDP/WSD search reflectors read
+    /// it per session for their IPv6 link-local reserved-port binds. `None` if the key is unknown.
     pub(crate) fn capture_ifindex(&self, capture: CaptureKey) -> Option<u32> {
         self.table.ifindex_of(capture)
     }

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -29,8 +29,8 @@ struct CaptureEntry {
 }
 
 /// One interface paired with its multicast joiner. Bundling them keeps the two from desyncing (one
-/// push adds both) and bakes in the relationship the joiner relies on: it carries the interface's
-/// ifindex, stable for the interface's lifetime, and a refresh re-attempts its joins.
+/// push adds both) and pins the relationship the joiner relies on: every join/rejoin passes THIS
+/// interface's ifindex, so the [`Interface`] stays the single cached copy.
 struct InterfaceEntry {
     interface: Interface,
     joiner: MulticastJoiner,
@@ -57,7 +57,7 @@ impl InterfaceTable {
     fn add_interface(&mut self, interface: Interface) -> InterfaceKey {
         let key =
             InterfaceKey(u32::try_from(self.entries.len()).expect("interface count fits a u32"));
-        let joiner = MulticastJoiner::new(interface.ifindex);
+        let joiner = MulticastJoiner::new();
         self.entries.push(InterfaceEntry { interface, joiner });
         key
     }
@@ -67,7 +67,8 @@ impl InterfaceTable {
     /// deferred to [`rejoin`](MulticastJoiner::rejoin), not an error).
     pub(super) fn join_on(&mut self, interface: InterfaceKey, group: IpAddr) -> io::Result<()> {
         // Startup-only with a freshly-minted key, so the index is always in range.
-        self.entries[interface.0 as usize].joiner.join(group)
+        let entry = &mut self.entries[interface.0 as usize];
+        entry.joiner.join(group, entry.interface.ifindex)
     }
 
     /// The key of the interface named `name`, opening and resolving it if absent, so captures on
@@ -201,7 +202,7 @@ impl InterfaceTable {
         let change = entry.interface.refresh()?;
         // Re-resolved addresses may have made a deferred join (a v4 group that had no address)
         // viable; re-attempt this interface's memberships.
-        entry.joiner.rejoin();
+        entry.joiner.rejoin(entry.interface.ifindex);
         Ok(Some(change))
     }
 
@@ -217,7 +218,7 @@ impl InterfaceTable {
             .map(|entry| (entry.interface.ifindex, entry.interface.refresh()))
             .collect();
         for entry in &mut self.entries {
-            entry.joiner.rejoin();
+            entry.joiner.rejoin(entry.interface.ifindex);
         }
         results
     }

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -15,56 +15,52 @@ use crate::libcex::{GroupReq, MCAST_JOIN_GROUP};
 use crate::sys::{open_socket, sockaddr_for, socklen_of};
 
 /// One capture interface's multicast memberships: one unbound `SOCK_DGRAM` fd per family, opened on
-/// that family's first join, under a fixed `ifindex`. `desired` records requested groups so they can
-/// be re-attempted when the interface re-resolves (a v4 group joined before its address existed
-/// becomes joinable then).
+/// that family's first join. The joiner holds no ifindex of its own -- the caller passes the
+/// interface's current one per call, so the table's [`Interface`](crate::interface::Interface) stays
+/// the single cached copy. `desired` records requested groups so they can be re-attempted when the
+/// interface re-resolves (a v4 group joined before its address existed becomes joinable then).
 pub(crate) struct MulticastJoiner {
-    ifindex: u32,
     v4: Option<OwnedFd>,
     v6: Option<OwnedFd>,
     desired: Vec<IpAddr>,
 }
 
 impl MulticastJoiner {
-    pub(crate) fn new(ifindex: u32) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            ifindex,
             v4: None,
             v6: None,
             desired: Vec::new(),
         }
     }
 
-    /// Join `group` on this interface and record it, so a later interface change re-attempts it.
-    /// Idempotent: the kernel keys memberships by `(group, ifindex)`.
+    /// Join `group` on the interface `ifindex` and record it, so a later interface change
+    /// re-attempts it. Idempotent: the kernel keys memberships by `(group, ifindex)`.
     ///
     /// # Errors
     /// The OS error if the socket can't open or the membership can't be added. `EADDRNOTAVAIL` (no
     /// address of that family yet) is deferrable: the group is recorded and [`rejoin`](Self::rejoin)
     /// retries it on the next address-up event.
-    pub(crate) fn join(&mut self, group: IpAddr) -> io::Result<()> {
+    pub(crate) fn join(&mut self, group: IpAddr, ifindex: u32) -> io::Result<()> {
         if !self.desired.contains(&group) {
             self.desired.push(group);
         }
-        self.apply(group)
+        self.apply(group, ifindex)
     }
 
     /// Re-attempt every recorded membership after the interface re-resolves. A group not joinable
     /// before its address existed succeeds now; an already-held one is a no-op. Best-effort: a
     /// still-unavailable family logs and waits for the next change.
-    pub(crate) fn rejoin(&mut self) {
+    pub(crate) fn rejoin(&mut self, ifindex: u32) {
         for i in 0..self.desired.len() {
             let group = self.desired[i];
-            if let Err(e) = self.apply(group) {
-                log::debug!(
-                    "re-join of {group} on ifindex {} deferred: {e}",
-                    self.ifindex
-                );
+            if let Err(e) = self.apply(group, ifindex) {
+                log::debug!("re-join of {group} on ifindex {ifindex} deferred: {e}");
             }
         }
     }
 
-    fn apply(&mut self, group: IpAddr) -> io::Result<()> {
+    fn apply(&mut self, group: IpAddr, ifindex: u32) -> io::Result<()> {
         let (slot, family, level) = match group {
             IpAddr::V4(_) => (&mut self.v4, libc::AF_INET, libc::IPPROTO_IP),
             IpAddr::V6(_) => (&mut self.v6, libc::AF_INET6, libc::IPPROTO_IPV6),
@@ -79,7 +75,7 @@ impl MulticastJoiner {
         // uninitialised, and `setsockopt` reads the whole struct (Valgrind flags them).
         // SAFETY: `group_req` is plain data; all-zero is valid.
         let mut req: GroupReq = unsafe { std::mem::zeroed() };
-        req.gr_interface = self.ifindex;
+        req.gr_interface = ifindex;
         // Interface is selected by `gr_interface`, so the group sockaddr carries no scope id.
         req.gr_group = sockaddr_for(group, 0, 0).0;
         // SAFETY: `req` is a fully-initialised `group_req` (padding zeroed), passed by address + size.
@@ -149,12 +145,13 @@ mod tests {
         // Exercises the full MCAST_JOIN_GROUP FFI against the kernel (per-OS const, group_req layout,
         // by-index selection; by-index doesn't require the interface's IFF_MULTICAST flag). QEMU
         // doesn't implement the setsockopt, so self-skip there.
-        let mut joiner = MulticastJoiner::new(loopback_ifindex());
+        let mut joiner = MulticastJoiner::new();
+        let ifindex = loopback_ifindex();
         for group in [
             IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251)),
             IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb)),
         ] {
-            match joiner.join(group) {
+            match joiner.join(group, ifindex) {
                 Ok(()) => {}
                 Err(e) if join_unsupported(&e) => {
                     eprintln!(

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -630,9 +630,12 @@ fn pair_join_announces_membership_on_the_wire() -> io::Result<()> {
     // (and only those) through the production joiner, so its device accepts the arriving report
     // packets for the observers. Its own joins announce 224.0.0.22/ff02::16 -- never the test
     // groups -- so a test-group match below can only come from the inject side's announcements.
-    let mut receive_joiner = MulticastJoiner::new(receive_ifindex);
-    receive_joiner.join(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 22)))?;
-    receive_joiner.join(IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x16)))?;
+    let mut receive_joiner = MulticastJoiner::new();
+    receive_joiner.join(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 22)), receive_ifindex)?;
+    receive_joiner.join(
+        IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x16)),
+        receive_ifindex,
+    )?;
     let igmp = raw_observer(libc::AF_INET, libc::IPPROTO_IGMP)?;
     let mld = raw_observer(libc::AF_INET6, libc::IPPROTO_ICMPV6)?;
     #[cfg(target_os = "linux")]
@@ -649,9 +652,10 @@ fn pair_join_announces_membership_on_the_wire() -> io::Result<()> {
         )?;
     }
 
-    let mut joiner = MulticastJoiner::new(if_index(&pair.inject).expect("inject ifindex"));
-    joiner.join(IpAddr::V4(group_v4))?;
-    joiner.join(IpAddr::V6(group_v6))?;
+    let mut joiner = MulticastJoiner::new();
+    let inject_ifindex = if_index(&pair.inject).expect("inject ifindex");
+    joiner.join(IpAddr::V4(group_v4), inject_ifindex)?;
+    joiner.join(IpAddr::V6(group_v6), inject_ifindex)?;
 
     assert!(
         saw_membership_report(&igmp, &group_v4.octets()),
@@ -673,12 +677,13 @@ fn pair_joins_multicast_groups_idempotently() -> io::Result<()> {
     let Some(pair) = InterfacePair::create() else {
         return Ok(());
     };
-    let mut joiner = MulticastJoiner::new(if_index(&pair.inject).expect("inject ifindex"));
+    let mut joiner = MulticastJoiner::new();
+    let inject_ifindex = if_index(&pair.inject).expect("inject ifindex");
     let mdns_v4: IpAddr = "224.0.0.251".parse().expect("mDNS v4 group");
     let mdns_v6: IpAddr = "ff02::fb".parse().expect("mDNS v6 group");
-    joiner.join(mdns_v4)?;
-    joiner.join(mdns_v6)?;
-    joiner.join(mdns_v4)?;
-    joiner.join(mdns_v6)?;
+    joiner.join(mdns_v4, inject_ifindex)?;
+    joiner.join(mdns_v6, inject_ifindex)?;
+    joiner.join(mdns_v4, inject_ifindex)?;
+    joiner.join(mdns_v6, inject_ifindex)?;
     Ok(())
 }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -65,19 +65,23 @@ impl TcpSocket {
         }))
     }
 
-    /// Open a connection to `dst`, egress-pinned to the target interface (`source` address + scope
-    /// `ifindex`) so the route can't leak onto the wrong segment. Non-blocking: the socket is
+    /// Open a connection to `dst`, egress-pinned to the target interface (`source` address + the
+    /// `iface` name) so the route can't leak onto the wrong segment. Non-blocking: the socket is
     /// [`is_connecting`](Self::is_connecting) until a writable edge and [`finish_connect`](Self::finish_connect).
     ///
     /// # Errors
     /// Propagates the socket / pin / `bind` / `connect` failure (other than the in-progress sentinel).
-    pub(crate) fn connect(dst: SocketAddrV4, source: Ipv4Addr, ifindex: u32) -> io::Result<Self> {
+    pub(crate) fn connect(
+        dst: SocketAddrV4,
+        source: Ipv4Addr,
+        iface: Option<&str>,
+    ) -> io::Result<Self> {
         let fd = open_socket(libc::AF_INET, libc::SOCK_STREAM)?;
         // FreeBSD has no egress-pin primitive; the source-address bind below steers egress.
         #[cfg(not(target_os = "freebsd"))]
-        pin_egress(fd.as_raw_fd(), ifindex)?;
+        pin_egress(fd.as_raw_fd(), iface)?;
         #[cfg(target_os = "freebsd")]
-        let _ = ifindex;
+        let _ = iface;
         bind_v4(fd.as_raw_fd(), source, 0)?;
         let local_addr = local_addr_v4(fd.as_raw_fd())?;
         let connecting = connect_v4(fd.as_raw_fd(), dst)?;
@@ -294,34 +298,33 @@ fn so_error(fd: RawFd) -> io::Result<c_int> {
     Ok(err)
 }
 
-/// Constrain `fd`'s egress to interface `ifindex` so a route lookup can't leak the connect onto the
-/// wrong segment; `ifindex == 0` skips the pin. Linux uses `SO_BINDTODEVICE` (needs `CAP_NET_RAW`),
-/// macOS `IP_BOUND_IF`. FreeBSD has no pin primitive, so the caller skips it and relies on the
-/// source-address bind.
+/// Constrain `fd`'s egress to the interface named `iface` so a route lookup can't leak the connect
+/// onto the wrong segment; `None` skips the pin. Linux uses `SO_BINDTODEVICE` (needs `CAP_NET_RAW`),
+/// which takes the name directly; macOS resolves the name to its current ifindex for `IP_BOUND_IF`,
+/// so the pin follows the name across an interface recreation. FreeBSD has no pin primitive, so the
+/// caller skips it and relies on the source-address bind.
 #[cfg(not(target_os = "freebsd"))]
-fn pin_egress(fd: RawFd, ifindex: u32) -> io::Result<()> {
-    if ifindex == 0 {
+fn pin_egress(fd: RawFd, iface: Option<&str>) -> io::Result<()> {
+    let Some(name) = iface else {
         return Ok(());
-    }
+    };
     #[cfg(target_os = "linux")]
     {
-        // `SO_BINDTODEVICE` takes the interface name.
-        let mut name = [0u8; libc::IF_NAMESIZE];
-        // SAFETY: `name` is a writable `IF_NAMESIZE` buffer; `if_indextoname` fills it or returns null.
-        if unsafe { libc::if_indextoname(ifindex, name.as_mut_ptr().cast::<libc::c_char>()) }
-            .is_null()
-        {
-            return Err(io::Error::last_os_error());
+        if name.len() >= libc::IF_NAMESIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "interface name too long",
+            ));
         }
-        let name_len = name.iter().position(|&b| b == 0).unwrap_or(name.len());
-        // SAFETY: `name[..name_len]` is the interface name of the passed length for `fd`.
+        // SAFETY: `name` points at `name.len()` valid bytes; the kernel NUL-terminates its copy.
         let rc = unsafe {
             libc::setsockopt(
                 fd,
                 libc::SOL_SOCKET,
                 libc::SO_BINDTODEVICE,
                 name.as_ptr().cast::<c_void>(),
-                libc::socklen_t::try_from(name_len).expect("interface name length fits socklen_t"),
+                libc::socklen_t::try_from(name.len())
+                    .expect("interface name length fits socklen_t"),
             )
         };
         if rc != 0 {
@@ -330,7 +333,13 @@ fn pin_egress(fd: RawFd, ifindex: u32) -> io::Result<()> {
     }
     #[cfg(target_os = "macos")]
     {
-        let index = c_int::try_from(ifindex).map_err(|_| io::Error::other("ifindex too large"))?;
+        let index = crate::interface::if_index(name).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("interface {name} not found"),
+            )
+        })?;
+        let index = c_int::try_from(index).map_err(|_| io::Error::other("ifindex too large"))?;
         // SAFETY: `&index` is a valid `c_int` option value for `fd`.
         let rc = unsafe {
             libc::setsockopt(
@@ -388,8 +397,8 @@ mod tests {
         let server_addr = listener.local_addr();
         assert_ne!(server_addr.port(), 0, "an ephemeral port is assigned");
 
-        let mut client =
-            TcpSocket::connect(server_addr, Ipv4Addr::LOCALHOST, 0).expect("connect to loopback");
+        let mut client = TcpSocket::connect(server_addr, Ipv4Addr::LOCALHOST, None)
+            .expect("connect to loopback");
         let server = spin(|| listener.accept()); // completes the handshake
         client.finish_connect().expect("the connect completed");
         assert!(!client.is_connecting());
@@ -410,7 +419,7 @@ mod tests {
     #[test]
     fn loopback_send_vectored_concatenates_the_slices() {
         let listener = TcpSocket::listen(Ipv4Addr::LOCALHOST).expect("listen on loopback");
-        let mut client = TcpSocket::connect(listener.local_addr(), Ipv4Addr::LOCALHOST, 0)
+        let mut client = TcpSocket::connect(listener.local_addr(), Ipv4Addr::LOCALHOST, None)
             .expect("connect to loopback");
         let server = spin(|| listener.accept());
         client.finish_connect().expect("the connect completed");
@@ -433,7 +442,7 @@ mod tests {
     fn shutdown_write_half_closes_keeping_the_read_half() {
         let listener = TcpSocket::listen(Ipv4Addr::LOCALHOST).expect("listen on loopback");
         let mut client =
-            TcpSocket::connect(listener.local_addr(), Ipv4Addr::LOCALHOST, 0).expect("connect");
+            TcpSocket::connect(listener.local_addr(), Ipv4Addr::LOCALHOST, None).expect("connect");
         let server = spin(|| listener.accept());
         client.finish_connect().expect("the connect completed");
 

--- a/src/reflector/dial/connection.rs
+++ b/src/reflector/dial/connection.rs
@@ -550,7 +550,7 @@ mod tests {
         let listener =
             TcpSocket::listen(std::net::Ipv4Addr::LOCALHOST).expect("listen on loopback");
         let mut initiator =
-            TcpSocket::connect(listener.local_addr(), std::net::Ipv4Addr::LOCALHOST, 0)
+            TcpSocket::connect(listener.local_addr(), std::net::Ipv4Addr::LOCALHOST, None)
                 .expect("connect");
         let accepted = spin(|| listener.accept());
         initiator.finish_connect().expect("the connect completed");

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -62,8 +62,10 @@ pub(super) struct DialDeviceProxy {
     /// The target-interface address device connections bind, so the device sees a same-segment peer
     /// and replies via the target interface (on the BSDs the bind is the only egress steer).
     target: Ipv4Addr,
-    /// The target interface index, egress-pinning device connections to that segment.
-    target_ifindex: u32,
+    /// The target interface's name, egress-pinning device connections to that segment (`None` skips
+    /// the pin). The name, not an ifindex: `SO_BINDTODEVICE` wants it directly, and a name stays
+    /// valid across an interface recreation where a cached index would not.
+    target_iface: Option<String>,
     /// The description listener (source side); its connections proxy to `desc_endpoint`.
     desc: TcpSocket,
     /// The proxy's identity: the device's description endpoint (`device-ip:desc_port`).
@@ -79,10 +81,10 @@ pub(super) struct DialDeviceProxy {
 
 impl DialDeviceProxy {
     /// A proxy fronting `desc_endpoint` via the source-side `desc` listener (already bound by the caller).
-    /// Device connections bind the target-interface `target` and egress-pin `target_ifindex`.
+    /// Device connections bind the target-interface `target` and egress-pin `target_iface`.
     pub(super) fn new(
         target: Ipv4Addr,
-        target_ifindex: u32,
+        target_iface: Option<String>,
         desc: TcpSocket,
         desc_endpoint: SocketAddrV4,
         rest: TcpSocket,
@@ -90,7 +92,7 @@ impl DialDeviceProxy {
         Self {
             key: None,
             target,
-            target_ifindex,
+            target_iface,
             desc,
             desc_endpoint,
             rest,
@@ -159,13 +161,14 @@ impl DialDeviceProxy {
     ) {
         let key = self.own_key();
         let rest_listener = self.rest.local_addr();
-        let device = match TcpSocket::connect(device_endpoint, self.target, self.target_ifindex) {
-            Ok(device) => device,
-            Err(e) => {
-                log::warn!("dial: connect to {device_endpoint} failed: {e}");
-                return;
-            }
-        };
+        let device =
+            match TcpSocket::connect(device_endpoint, self.target, self.target_iface.as_deref()) {
+                Ok(device) => device,
+                Err(e) => {
+                    log::warn!("dial: connect to {device_endpoint} failed: {e}");
+                    return;
+                }
+            };
         let client_fd = client.as_raw_fd();
         let device_fd = device.as_raw_fd();
         // Insert first so the connection's arena key can tag both fds' `user_data`; the regs are
@@ -341,7 +344,7 @@ mod tests {
         let rest_addr = rest.local_addr();
         let mut proxy = DialDeviceProxy::new(
             Ipv4Addr::LOCALHOST,
-            0, // no egress pin on loopback
+            None, // no egress pin on loopback
             desc,
             SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 5), 8008),
             rest,
@@ -361,7 +364,7 @@ mod tests {
 
         // A client reaches the REST listener; drive accept until the loopback handshake lands.
         let _client =
-            TcpSocket::connect(rest_addr, Ipv4Addr::LOCALHOST, 0).expect("client connect");
+            TcpSocket::connect(rest_addr, Ipv4Addr::LOCALHOST, None).expect("client connect");
         for _ in 0..2000 {
             proxy.accept_rest(&mut reactor);
             if proxy.conns.iter().count() == 1 {
@@ -386,7 +389,8 @@ mod tests {
     fn accept_rest_drops_a_client_before_the_rest_endpoint_is_learned() {
         let mut reactor = Reactor::new().expect("reactor");
         let (mut proxy, rest_addr) = watched_proxy(&mut reactor); // rest_endpoint stays None
-        let client = TcpSocket::connect(rest_addr, Ipv4Addr::LOCALHOST, 0).expect("client connect");
+        let client =
+            TcpSocket::connect(rest_addr, Ipv4Addr::LOCALHOST, None).expect("client connect");
 
         // accept_rest accepts the client (draining the listener) but, with no learned endpoint, drops
         // it. The client observes EOF and no connection is recorded.

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -35,16 +35,17 @@ const MAX_DESC_GRACE: Duration = Duration::from_hours(2);
 pub(crate) const REWRITE_BUF_LEN: usize = crate::dispatch::SCRATCH_LEN;
 
 /// Where a minted DIAL description proxy sits across the two interfaces: it binds its source-side
-/// listeners on `source`, egress-pins device connections to `target`/`target_ifindex`, and is evicted if
+/// listeners on `source`, egress-pins device connections to `target`/`target_iface`, and is evicted if
 /// either `source_capture`'s or `target_capture`'s IPv4 address later changes. Bundling the two
 /// same-typed capture/address pairs keeps them from being transposed at the call.
 #[derive(Clone, Copy)]
-pub(crate) struct ProxyPlacement {
+pub(crate) struct ProxyPlacement<'a> {
     pub(crate) source_capture: CaptureKey,
     pub(crate) source: Ipv4Addr,
     pub(crate) target_capture: CaptureKey,
     pub(crate) target: Ipv4Addr,
-    pub(crate) target_ifindex: u32,
+    /// The target interface's name (the durable identity; `None` skips the egress pin).
+    pub(crate) target_iface: Option<&'a str>,
 }
 
 /// Rewrite a DIAL discovery message's `LOCATION` to a source-side description proxy, minting and
@@ -58,7 +59,7 @@ pub(crate) fn rewrite_location(
     ctx: &mut DialContext,
     reactor: &mut Reactor,
     payload: &[u8],
-    placement: ProxyPlacement,
+    placement: ProxyPlacement<'_>,
     out: &mut impl io::Write,
 ) -> bool {
     if !is_dial_service_message(payload) {
@@ -118,7 +119,7 @@ pub(crate) fn rewrite_location(
 fn mint_proxy(
     ctx: &mut DialContext,
     reactor: &mut Reactor,
-    placement: ProxyPlacement,
+    placement: ProxyPlacement<'_>,
     endpoint: SocketAddrV4,
     desc_grace: Instant,
 ) -> Option<SocketAddrV4> {
@@ -132,7 +133,7 @@ fn mint_proxy(
     let watches = [(desc.as_raw_fd(), 0), (rest.as_raw_fd(), 0)];
     let proxy = DialDeviceProxy::new(
         placement.target,
-        placement.target_ifindex,
+        placement.target_iface.map(str::to_owned),
         desc,
         endpoint,
         rest,
@@ -204,7 +205,7 @@ mod tests {
             source: Ipv4Addr::LOCALHOST,
             target_capture: advert_target(),
             target: Ipv4Addr::LOCALHOST,
-            target_ifindex: 0,
+            target_iface: None,
         };
         rewrite_location(ctx, reactor, payload, placement, &mut buf).then_some(buf)
     }

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -127,8 +127,6 @@ pub(crate) struct SearchReflector {
     source: CaptureKey,
     /// The target capture: where the search is re-emitted and the replies are captured.
     target: CaptureKey,
-    /// The target interface's index, for the IPv6 link-local reserved-port bind.
-    target_ifindex: u32,
     /// The configured device allow-set, scoping the response capture as the announcement direction is.
     device_macs: Option<MacSet>,
     /// Protocol label for logs, e.g. `"SSDP"`.
@@ -151,7 +149,6 @@ impl SearchReflector {
     pub(crate) fn new(
         source: CaptureKey,
         target: CaptureKey,
-        target_ifindex: u32,
         device_macs: Option<MacSet>,
         name: &'static str,
         response_type: MessageType,
@@ -163,7 +160,6 @@ impl SearchReflector {
         Self {
             source,
             target,
-            target_ifindex,
             device_macs,
             name,
             response_type,
@@ -226,7 +222,10 @@ impl SearchReflector {
             );
             return Err(Outcome::Stalled(message_type));
         };
-        let reservation = match PortReservation::create(our_addr, self.target_ifindex) {
+        // The scope id for an IPv6 link-local bind: read per session, not cached at build, so it
+        // tracks the interface table.
+        let target_ifindex = dispatcher.capture_ifindex(self.target).unwrap_or(0);
+        let reservation = match PortReservation::create(our_addr, target_ifindex) {
             Ok(reservation) => reservation,
             Err(e) => {
                 log::warn!(
@@ -421,7 +420,6 @@ mod tests {
         SearchReflector::new(
             CaptureKey::from_u64(1),
             CaptureKey::from_u64(0),
-            0,
             None,
             "TEST",
             MessageType::SsdpResponse,
@@ -698,7 +696,6 @@ mod tests {
         let mut reflector = SearchReflector::new(
             CaptureKey::from_u64(999), // synthetic source: no reply comes back in this test
             target,
-            0,
             None,
             "TEST",
             MessageType::SsdpResponse,

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -27,22 +27,20 @@ use super::{
 };
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
-/// target capture the device sits behind (for its address), that interface's egress-pin ifindex, and a
-/// reused scratch sink the rewritten datagram is built in. Owned per rewriting reflector (the
-/// advertisement direction, and one per M-SEARCH session's response reflector), so it isn't `Copy`.
+/// target capture the device sits behind (its address and interface name resolve through it per
+/// rewrite) and a reused scratch sink the rewritten datagram is built in. Owned per rewriting reflector
+/// (the advertisement direction, and one per M-SEARCH session's response reflector), so it isn't `Copy`.
 struct DialRewrite {
     target: CaptureKey,
-    target_ifindex: u32,
     /// Reused sink for the rewritten datagram; see the [`ReplyRewrite`] impl.
     scratch: UninitBuf,
 }
 
 impl DialRewrite {
-    /// A rewriter for the device behind `target` (`target_ifindex` scopes the IPv6 reserved-port bind).
-    fn new(target: CaptureKey, target_ifindex: u32) -> Self {
+    /// A rewriter for the device behind `target`.
+    fn new(target: CaptureKey) -> Self {
         Self {
             target,
-            target_ifindex,
             scratch: UninitBuf::with_capacity(REWRITE_BUF_LEN),
         }
     }
@@ -69,21 +67,16 @@ impl ReplyRewrite for DialRewrite {
         ) else {
             return payload; // a family the proxy can't bridge yet
         };
+        let (ctx, target_iface) = dispatcher.dial_context(self.target);
         let placement = ProxyPlacement {
             source_capture: egress,
             source,
             target_capture: self.target,
             target,
-            target_ifindex: self.target_ifindex,
+            target_iface,
         };
         self.scratch.clear();
-        if rewrite_location(
-            dispatcher.dial_context(),
-            reactor,
-            payload,
-            placement,
-            &mut self.scratch,
-        ) {
+        if rewrite_location(ctx, reactor, payload, placement, &mut self.scratch) {
             self.scratch.filled()
         } else {
             payload
@@ -169,10 +162,6 @@ pub(crate) fn build(
         reflector.target_if.as_str(),
     )?;
 
-    // The reserved-port bind for an IPv6 link-local target source needs the target's scope id; use
-    // the ifindex the capture already cached (the single source of truth the joiners bake too).
-    let target_ifindex = dispatcher.capture_ifindex(target).unwrap_or(0);
-
     // Advertisements are captured on target, searches on source; join every group on both. A family
     // with no address yet is recorded and re-attempted on the next address change.
     let groups = used_groups(reflector.address_family);
@@ -193,7 +182,7 @@ pub(crate) fn build(
         advertisement_verdict,
     );
     let advertisement = if ssdp.dial {
-        advertisement.with_rewrite(Box::new(DialRewrite::new(target, target_ifindex)))
+        advertisement.with_rewrite(Box::new(DialRewrite::new(target)))
     } else {
         advertisement
     };
@@ -211,9 +200,7 @@ pub(crate) fn build(
     // 200-OK replies route back through a per-searcher session. With `dial`, each session's reply
     // rewrites the device's DIAL `LOCATION` (a fresh DialRewrite per session); else it passes through.
     let make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>> = if ssdp.dial {
-        Box::new(move || {
-            Box::new(DialRewrite::new(target, target_ifindex)) as Box<dyn ReplyRewrite>
-        })
+        Box::new(move || Box::new(DialRewrite::new(target)) as Box<dyn ReplyRewrite>)
     } else {
         Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>)
     };
@@ -227,7 +214,6 @@ pub(crate) fn build(
         Box::new(SearchReflector::new(
             source,
             target,
-            target_ifindex,
             reflector.macs.clone(),
             "SSDP",
             MessageType::SsdpResponse,

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -86,10 +86,6 @@ pub(crate) fn build(
         reflector.target_if.as_str(),
     )?;
 
-    // The reserved-port bind for an IPv6 link-local target source needs the target's scope id; use the
-    // ifindex the capture already cached (the same value the joiners use).
-    let target_ifindex = dispatcher.capture_ifindex(target).unwrap_or(0);
-
     // Announcements are captured on target, searches on source, so join the group on both. A family with
     // no address yet is recorded and re-attempted on the next address change.
     let groups = used_groups(reflector.address_family);
@@ -129,7 +125,6 @@ pub(crate) fn build(
         Box::new(SearchReflector::new(
             source,
             target,
-            target_ifindex,
             reflector.macs.clone(),
             "WSD",
             MessageType::WsdResponse,


### PR DESCRIPTION
Prep for interface hot-swap recovery: after this, the table's `Interface.ifindex` is the process's only persistent copy of an interface index.

- `SearchReflector`/`DialRewrite` stop snapshotting `capture_ifindex(target)` at build; they read through the dispatcher at use time (`dial_context` hands back the DIAL registry and the interface name from one split borrow).
- The DIAL egress pin switches from index to interface name: `SO_BINDTODEVICE` takes a name directly (dropping the per-connect `if_indextoname` round-trip), macOS resolves the name to its current index per connect, FreeBSD unchanged (no pin). `DialDeviceProxy` keeps a mint-time copy and is evicted on interface change, as before.
- The Linux capture drops its cached `sockaddr_ll`: a bound packet socket's plain `send(2)` takes the egress from the bind (`saddr == NULL` -> `packet_cached_dev_get`, ENXIO if the device died -- verified in af_packet.c). `skb->protocol` moves from 0 to the bound ETH_P_ALL; `packet_parse_headers` rewrites both from the frame on >= 5.1.
- `MulticastJoiner` drops its baked ifindex; `join`/`rejoin` take it per call from the table entry.
- af_packet's private `if_index` folds into the shared `interface::if_index`.

Testing: clippy/test/doc gates on macOS and Linux (docker); the veth pair tests (real frame injection through the new plain-send path, on-wire IGMP/MLD join observation) in a privileged container; the docker e2e suite in CI exercises the SSDP/WSD/DIAL paths end to end.