### PR TITLE
Rename AddressMonitor to InterfaceMonitor

### DIFF
--- a/e2e/run.py
+++ b/e2e/run.py
@@ -1392,7 +1392,7 @@ class NativeFreeBSDBackend(NativeBackend):
     # FreeBSD's network namespace: its own stack, with interfaces, routes, PF_ROUTE events,
     # and /dev/bpf attachment all per-vnet, and the host filesystem shared via path=/. Per-jail
     # stacks keep every probe packet on the wire (nothing short-circuits over lo0), and jailing
-    # the daemon too means its address monitor hears only test-interface events -- the same
+    # the daemon too means its interface monitor hears only test-interface events -- the same
     # shape as the Linux dut namespace.
 
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
@@ -2099,7 +2099,7 @@ class AddressChangeRunner(CaseRunner):
 
     def _assert_address_changes_logged(self) -> None:
         # Full-parity log check (the Rust equivalent of the C++'s capability-down assertion):
-        # every phase removed then restored a source address, so the reflector's AddressMonitor
+        # every phase removed then restored a source address, so the reflector's InterfaceMonitor
         # must have logged both transitions -- with the monitor off it logs neither. And no
         # reflect-failure WARN may appear: a send attempted on an addressless egress would mean
         # the per-packet gate failed to catch the drop.
@@ -2112,7 +2112,7 @@ class AddressChangeRunner(CaseRunner):
                 needle = f"interface {ifname}: {verb} {family}"
                 if needle not in text:
                     raise RuntimeError(
-                        f"{self.ac.name}: reflector never logged \"{needle}\" -- the address monitor "
+                        f"{self.ac.name}: reflector never logged \"{needle}\" -- the interface monitor "
                         f"did not observe the change"
                     )
         if "cannot reflect" in text:

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -36,7 +36,7 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
 use crate::capture::Capture;
-use crate::interface::{AddressMonitor, InterfaceAddresses};
+use crate::interface::{InterfaceAddresses, InterfaceMonitor};
 use crate::net::LinkType;
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
@@ -52,7 +52,7 @@ use self::interface_table::InterfaceTable;
 /// wait won't re-fire for those already-read records.
 const MAX_FRAMES_PER_EVENT: u32 = 64;
 
-/// The reactor `user_data` for the address monitor's fd. A [`CaptureKey`] packs a `u32`
+/// The reactor `user_data` for the interface monitor's fd. A [`CaptureKey`] packs a `u32`
 /// (via [`to_u64`](CaptureKey::to_u64)), so `u64::MAX` never collides with a real capture.
 const MONITOR_TAG: u64 = u64::MAX;
 
@@ -225,7 +225,7 @@ pub(crate) struct PacketDispatcher {
     route_keys: Vec<RegistrationKey>,
     /// The address-change monitor, opened best-effort in [`new`](Self::new). `None` is a
     /// degraded mode: addresses stay at their startup-resolved values.
-    monitor: Option<AddressMonitor>,
+    monitor: Option<InterfaceMonitor>,
     /// The DIAL proxy registry, shared across the SSDP advertisement/response reflectors. Empty unless a
     /// DIAL reflector is configured; the dispatcher evicts its past-grace proxies on the deadline sweep.
     dial: DialContext,
@@ -236,7 +236,7 @@ pub(crate) struct PacketDispatcher {
 }
 
 impl PacketDispatcher {
-    /// A dispatcher with no captures yet. Opens the address monitor up front, before the
+    /// A dispatcher with no captures yet. Opens the interface monitor up front, before the
     /// first [`add_capture`](Self::add_capture) resolve, so a change during startup is
     /// already queued rather than missed.
     pub(crate) fn new() -> Self {
@@ -263,14 +263,14 @@ impl PacketDispatcher {
 
     /// Open the address-change monitor. Best-effort: a failure logs and yields `None`, and the
     /// daemon then runs on its startup-resolved addresses (no live updates), never aborting.
-    fn open_monitor() -> Option<AddressMonitor> {
-        match AddressMonitor::open() {
+    fn open_monitor() -> Option<InterfaceMonitor> {
+        match InterfaceMonitor::open() {
             Ok(monitor) => {
-                log::debug!("address monitor installed");
+                log::debug!("interface monitor installed");
                 Some(monitor)
             }
             Err(e) => {
-                log::warn!("address monitor unavailable; addresses won't refresh on change: {e}");
+                log::warn!("interface monitor unavailable; addresses won't refresh on change: {e}");
                 None
             }
         }
@@ -570,7 +570,7 @@ impl PacketDispatcher {
         }
     }
 
-    /// Drain the address monitor and re-resolve each interface a notification names,
+    /// Drain the interface monitor and re-resolve each interface a notification names,
     /// coalescing duplicates so one interface re-resolves at most once per wakeup. A `0`
     /// (the overflow signal) re-resolves every interface. Best-effort: a read or resolution
     /// failure logs and is dropped, and the daemon keeps its last-known addresses.
@@ -587,7 +587,9 @@ impl PacketDispatcher {
             // The drain already consumed and collected these notifications before failing, so refresh
             // what we have rather than discard it; the socket's unread remainder stays readable and the
             // level-triggered wait re-drains it.
-            log::warn!("address monitor read failed mid-drain; refreshing what was collected: {e}");
+            log::warn!(
+                "interface monitor read failed mid-drain; refreshing what was collected: {e}"
+            );
         }
         if changed.is_empty() {
             return; // nothing collected (a spurious wakeup, or a drain error before the first read)
@@ -597,7 +599,7 @@ impl PacketDispatcher {
         let mut v4_moved: Vec<u32> = Vec::new();
         if changed.contains(&0) {
             // 0 is the overflow signal: notifications were dropped, so re-resolve every interface.
-            log::debug!("address monitor overflow; re-resolving all interfaces");
+            log::debug!("interface monitor overflow; re-resolving all interfaces");
             for (ifindex, result) in self.table.refresh_all() {
                 match result {
                     Ok(change) if change.v4 => v4_moved.push(ifindex),

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,5 +1,5 @@
 //! Interface address resolution: the source MAC / IPv4 / IPv6 an interface currently has.
-//! A reflector re-emits from these, so they must be read fresh (the address monitor keeps
+//! A reflector re-emits from these, so they must be read fresh (the interface monitor keeps
 //! them current). Any may be absent: a loopback / `DLT_NULL` link has no MAC, and a link
 //! may be v4-only or v6-only.
 //!
@@ -15,13 +15,13 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::net::mac::MacAddr;
 
-mod address_monitor;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod getifaddrs;
+mod interface_monitor;
 #[cfg(target_os = "linux")]
 mod rtnetlink;
 
-pub(crate) use self::address_monitor::AddressMonitor;
+pub(crate) use self::interface_monitor::InterfaceMonitor;
 
 /// An interface's current source addresses; any may be absent. The fields are private so a sender
 /// reaches a v6 source only through [`v6`](Self::v6), naming the destination's scope: the stored

--- a/src/interface/interface_monitor.rs
+++ b/src/interface/interface_monitor.rs
@@ -1,6 +1,6 @@
 //! Interface address-change monitoring: a routing socket whose readiness means some
 //! interface's addresses (or MAC) changed, so the dispatcher should re-resolve it.
-//! `NETLINK_ROUTE` on Linux, `PF_ROUTE` on the BSDs. One [`AddressMonitor`] over a
+//! `NETLINK_ROUTE` on Linux, `PF_ROUTE` on the BSDs. One [`InterfaceMonitor`] over a
 //! per-platform backend, mirroring the resolver's rtnetlink/getifaddrs split.
 //!
 //! Best-effort: only keeps already-resolved addresses fresh. A failed open (or a read error)
@@ -28,7 +28,7 @@ const MAX_CONSECUTIVE_OVERFLOWS: u32 = 16;
 
 /// A routing-socket monitor for interface address and link changes. The dispatcher watches
 /// its fd and calls [`drain`](Self::drain) on readiness.
-pub(crate) struct AddressMonitor {
+pub(crate) struct InterfaceMonitor {
     sock: OwnedFd,
     /// Reused across drains, sized once at open and never grown. Each notification is a single
     /// bounded message (not a coalesced dump), so a fixed buffer fits with headroom. No
@@ -36,7 +36,7 @@ pub(crate) struct AddressMonitor {
     buf: Box<[u8]>,
 }
 
-impl AddressMonitor {
+impl InterfaceMonitor {
     /// Open and subscribe a routing socket, non-blocking and close-on-exec.
     ///
     /// # Errors
@@ -91,12 +91,12 @@ impl AddressMonitor {
                     // re-resolve-all once per burst; the dispatcher coalesces the 0, so repeating
                     // it per ENOBUFS is redundant.
                     log::warn!(
-                        "address monitor overflowed; notifications were dropped, re-resolving every interface"
+                        "interface monitor overflowed; notifications were dropped, re-resolving every interface"
                     );
                     on_change(0);
                 } else if overflows >= MAX_CONSECUTIVE_OVERFLOWS {
                     log::warn!(
-                        "address monitor overflow did not clear after {overflows} reads; ending the drain"
+                        "interface monitor overflow did not clear after {overflows} reads; ending the drain"
                     );
                     return Ok(());
                 }
@@ -112,7 +112,7 @@ impl AddressMonitor {
                         backend::for_each_change(&self.buf[..len], &mut on_change);
                     } else {
                         log::debug!(
-                            "address monitor: dropping a notification from a non-kernel sender"
+                            "interface monitor: dropping a notification from a non-kernel sender"
                         );
                     }
                 }
@@ -130,7 +130,7 @@ mod tests {
     // degrades to no live updates, so there's nothing to drain and we skip.
     #[test]
     fn opens_and_drains_without_blocking() {
-        let mut monitor = match AddressMonitor::open() {
+        let mut monitor = match InterfaceMonitor::open() {
             Ok(monitor) => monitor,
             Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
                 eprintln!("skip: the routing socket could not be opened: {e}");

--- a/src/interface/interface_monitor/route.rs
+++ b/src/interface/interface_monitor/route.rs
@@ -91,7 +91,7 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
             // 0 names no interface (kernel indices are >= 1) and is the parent's "re-resolve
             // everything" overflow signal, so a stray 0 must never be forwarded.
             if index != 0 {
-                log::trace!("address monitor: change for ifindex {index}");
+                log::trace!("interface monitor: change for ifindex {index}");
                 on_change(u32::from(index));
             }
         }

--- a/src/interface/interface_monitor/rtnetlink.rs
+++ b/src/interface/interface_monitor/rtnetlink.rs
@@ -109,7 +109,7 @@ pub(super) fn sender_ok(src: &libc::sockaddr_storage, len: socklen_t) -> bool {
 /// 0 must never be forwarded.
 fn report(index: u32, on_change: &mut impl FnMut(u32)) {
     if index != 0 {
-        log::trace!("address monitor: change for ifindex {index}");
+        log::trace!("interface monitor: change for ifindex {index}");
         on_change(index);
     }
 }

--- a/src/libcex/netlink.rs
+++ b/src/libcex/netlink.rs
@@ -9,7 +9,7 @@ pub(crate) const NLM_F_DUMP: u16 = 0x0300; // NLM_F_ROOT | NLM_F_MATCH
 pub(crate) const NLMSG_DONE: u16 = 0x03;
 pub(crate) const NLMSG_ERROR: u16 = 0x02;
 
-/// `struct nlmsghdr`. Shared with the address monitor (`len`/`msg_type` drive its walk).
+/// `struct nlmsghdr`. Shared with the interface monitor (`len`/`msg_type` drive its walk).
 #[repr(C)]
 pub(crate) struct NlMsgHdr {
     pub(crate) len: u32,
@@ -23,7 +23,7 @@ pub(crate) struct NlMsgHdr {
 const _: () = assert!(size_of::<NlMsgHdr>() == 16);
 
 /// `struct ifaddrmsg`: the body of an `RTM_*ADDR` message. A zeroed value (family
-/// `AF_UNSPEC`) is the dump request body. The address monitor reads `index` from it.
+/// `AF_UNSPEC`) is the dump request body. The interface monitor reads `index` from it.
 #[repr(C)]
 #[derive(Default)]
 pub(crate) struct IfAddrMsg {


### PR DESCRIPTION
Prep for interface hot-swap recovery: the monitor's netlink/route sockets already carry interface lifecycle events, not just address changes, and the hot-swap work is about to consume them. Mechanical rename: type, module files, docs, log wording, two e2e comments. `AddressChange` keeps its name.

Testing: clippy/test/doc gates on macOS and Linux (docker); no behavior change.