### PR TITLE
Recover from interface destroy+recreate (ifindex hot-swap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ interface loses its address and brought back up once both can send it again.
 
 ### Reacting to address changes
 
-The reflector watches the kernel for interface address changes (a `NETLINK_ROUTE` socket on Linux, a
-`PF_ROUTE` socket on the BSDs) and adapts at runtime, without a restart. mDNS and SSDP bring a family
+The reflector watches the kernel for interface address and lifecycle changes (a `NETLINK_ROUTE`
+socket on Linux, a `PF_ROUTE` socket on the BSDs) and adapts at runtime, without a restart. mDNS and SSDP bring a family
 up (joining its multicast group(s) and installing its capture registrations) once that family becomes
 reflectable (a source address for it is present on **both** interfaces), and tear it down when either
 interface loses the address; the family resumes automatically when the address returns. WoL keeps its
@@ -332,11 +332,16 @@ appears. Gaining a family logs at `info`; losing a *required* family logs at `er
 `info`. The monitor is best-effort: if it cannot start, the reflector logs a warning and runs without
 address refresh.
 
-It does not, however, adapt to an interface being destroyed and recreated (a fresh kernel ifindex,
-e.g. a PPPoE reconnect or a bridge/VLAN rebuild): the ifindex and capture are pinned when the interface
-is opened, so reflection on a recreated interface stays dead until you restart the daemon. The interfaces
-a reflector bridges are normally stable LAN segments, so this rarely bites, and it matches avahi, which
-likewise needs a restart when an interface disappears and returns.
+It also survives an interface being destroyed and recreated (a fresh kernel identity, e.g. a PPPoE
+reconnect or a bridge/VLAN rebuild). Lifecycle events -- backed by a periodic reconcile, so recovery
+never depends on one notification surviving -- detect that the name's kernel identity moved; the
+captures are then re-bound in place, addresses re-resolved, and multicast groups re-joined on the new
+interface, while its DIAL proxies are evicted to re-mint on the next advertisement. While the
+interface is absent its reflection parks (sends drop quietly, as on an address loss) and resumes when
+the name returns (`interface <name>: returned as ifindex B`, or `recreated (ifindex A -> B)` when the
+replacement appeared within one event batch). On macOS the route socket
+has no lifecycle messages and can drop notifications silently, so detection there may fall back to
+the periodic reconcile (up to ~30 s).
 
 ### Per-protocol behavior
 

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -223,6 +223,12 @@ def search(args: argparse.Namespace) -> int:
         sock.sendto(args.payload_hex, dest)
         print(f"searcher sent {len(args.payload_hex)} bytes to {args.address}:{args.port}", flush=True)
 
+        if args.no_wait:
+            # Fire-and-forget: the caller only needs the M-SEARCH sent (e.g. to trigger a reflected
+            # re-emit), not the reply -- which may be routed elsewhere (a reused session's cached MAC).
+            print("searcher: not waiting for a reply", flush=True)
+            return 0
+
         sock.settimeout(args.timeout)
         try:
             payload, peer = sock.recvfrom(4096)
@@ -669,6 +675,7 @@ def main() -> int:
     search_expectation = search_parser.add_mutually_exclusive_group(required=True)
     search_expectation.add_argument("--expect-payload-hex", type=parse_payload_hex, help="expected 200 OK payload")
     search_expectation.add_argument("--expect-none", action="store_true", help="fail if any reply is received")
+    search_expectation.add_argument("--no-wait", action="store_true", help="send the M-SEARCH and exit without awaiting a reply")
     search_parser.set_defaults(func=search)
 
     device_parser = subparsers.add_parser(

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -735,18 +735,18 @@ ROUNDTRIP_CASES = [
 
 @dataclasses.dataclass(frozen=True)
 class SearchRecreateCase:
-    # A search session cleared across an interface recreation. One searcher opens a session; the
-    # target interface is then destroyed and recreated. Its reserved port and response registration
-    # died with the interface, so the dispatcher drops every session bound to it (and logs
-    # `cleared_log`) via the on_iface_change push path; a fresh searcher then re-opens and round-trips
-    # against the recovered interface. Run both without and with a decoy that grabs the freed index:
-    # on FreeBSD (which reuses the lowest-free index) that is the difference between a same-index and a
-    # changed-index recreation -- two distinct detection paths (the attached() BIOCGDLT probe vs the
-    # index comparison), both of which must clear the session. On Linux the index always changes, so
-    # the decoy is inert there. This is the search-session path the passive mDNS and DIAL recreate
-    # cases never reach (mDNS is sessionless, the DIAL cases discover via NOTIFY). A wide MX keeps the
-    # first session alive until the recreation so there is something to clear.
+    # A search session across an interface recreation. One searcher opens a session; a reflector
+    # interface is then destroyed and recreated. The session's reserved port and response registration
+    # live on the TARGET, so recreating the target drops every session (logged, via on_iface_change) and
+    # the retransmit opens a fresh one; recreating the SOURCE leaves the session intact (the reply leg
+    # re-resolves the source at send time), so the retransmit re-reflects on the SAME reserved port. Run
+    # each interface both without and with a decoy that grabs the freed index: on FreeBSD (which reuses
+    # the lowest-free index) that is a same-index vs changed-index recreation, pinning both detection
+    # paths (the attached() BIOCGDLT probe vs the index comparison); on Linux the index always changes,
+    # so the decoy is inert there. The wide MX keeps the first session alive until the recreation. This
+    # is the search-session path the passive mDNS and DIAL recreate cases never reach.
     name: str
+    interface: str = "target"  # which reflector interface is destroyed + recreated
     family: int = 4
     group: str = SSDP_GROUP_V4
     port: int = SSDP_PORT
@@ -755,14 +755,13 @@ class SearchRecreateCase:
     config: str = "config.toml"
     timeout_seconds: float = 8.0
     decoy: bool = False  # plant a decoy on the freed index so the recreation lands on a different one
-    cleared_log: str = "cleared all sessions"
 
 
 SEARCH_RECREATE_CASES = [
-    # Same index on FreeBSD (reused), reached via the attached() probe.
-    SearchRecreateCase(name="ssdp_search_interface_recreate"),
-    # Different index everywhere, via the index comparison.
-    SearchRecreateCase(name="ssdp_search_interface_recreate_decoy", decoy=True),
+    SearchRecreateCase(name="ssdp_search_interface_recreate_source", interface="source"),
+    SearchRecreateCase(name="ssdp_search_interface_recreate_target", interface="target"),
+    SearchRecreateCase(name="ssdp_search_interface_recreate_source_decoy", interface="source", decoy=True),
+    SearchRecreateCase(name="ssdp_search_interface_recreate_target_decoy", interface="target", decoy=True),
 ]
 
 
@@ -808,13 +807,15 @@ DIAL_ADDRESS_CHANGE_CASES = [
 
 @dataclasses.dataclass(frozen=True)
 class DialRecreateCase:
-    # A full DIAL pass, then the same pass again after the reflector's target interface is
-    # destroyed and recreated, then again after the source's. The hardest DIAL recovery
-    # scenario: an address change replaces values, a recreation replaces the kernel objects
-    # underneath them -- the minted proxy's listener binds, target-address snapshot, and
-    # egress-pin all belong to the dead interface's world, so a passing re-run proves the
-    # recreation evicted the proxy and re-minted against the recreated interface.
+    # A full DIAL pass, then the same pass again after one reflector interface is destroyed and
+    # recreated. The hardest DIAL recovery scenario: a recreation replaces the kernel objects
+    # underneath the minted proxy -- its listener binds, target-address snapshot, and egress-pin all
+    # belong to the dead interface's world -- so a passing re-run proves the recreation evicted the
+    # proxy and re-minted against the recreated interface. One case per (interface, decoy): the decoy
+    # forces a changed-index recreation (vs FreeBSD's same-index reuse), pinning both detection paths.
     name: str
+    interface: str = "target"  # which reflector interface is destroyed + recreated
+    decoy: bool = False  # plant a decoy on the freed index so the recreation lands on a different one
     family: int = 4
     group: str = SSDP_GROUP_V4
     timeout_seconds: float = 8.0
@@ -824,7 +825,10 @@ class DialRecreateCase:
 
 
 DIAL_RECREATE_CASES = [
-    DialRecreateCase(name="dial_interface_recreate"),
+    DialRecreateCase(name="dial_interface_recreate_source", interface="source"),
+    DialRecreateCase(name="dial_interface_recreate_target", interface="target"),
+    DialRecreateCase(name="dial_interface_recreate_source_decoy", interface="source", decoy=True),
+    DialRecreateCase(name="dial_interface_recreate_target_decoy", interface="target", decoy=True),
 ]
 
 # Per-protocol probe parameters for the address-change phases: wol sends a magic packet (no payload
@@ -885,30 +889,21 @@ class RecreateCase:
     phases: tuple[Phase, ...]  # interface = which reflector interface is destroyed+recreated
 
 
+# One case per (interface, decoy) so a failure names the exact scenario. All probe forward
+# (source -> target): recreating the source kills the forward INGRESS (queries no longer enter),
+# the target the forward EGRESS (re-emits no longer leave), proving both halves of the capture
+# rebind. The decoy flavor forces a different-index recreation on FreeBSD, where the plain flavors
+# reuse the freed index (see Phase.decoy) -- pinning both detection paths (index comparison vs the
+# capture attachment probe).
 RECREATE_CASES = [
-    RecreateCase(
-        name="mdns_interface_recreate",
-        config="config-addrchange.toml",
-        phases=(
-            # All phases probe forward (source -> target). Unlike the address-change cases
-            # (which can only exercise the egress send-gate), recreation kills the capture
-            # itself: recreating the source kills the forward INGRESS (queries no longer
-            # enter), recreating the target kills the forward EGRESS (re-emits no longer
-            # leave). Together they prove both halves of the capture rebind. The decoy
-            # flavor forces a different-index recreation on FreeBSD, where the plain
-            # flavors reuse the freed index (see Phase.decoy).
-            Phase(label="source recreate", protocol="mdns", family=4, interface="source"),
-            Phase(label="target recreate", protocol="mdns", family=4, interface="target"),
-            Phase(
-                label="source recreate behind a decoy", protocol="mdns", family=4,
-                interface="source", decoy=True,
-            ),
-            Phase(
-                label="target recreate behind a decoy", protocol="mdns", family=4,
-                interface="target", decoy=True,
-            ),
-        ),
-    ),
+    RecreateCase(name="mdns_interface_recreate_source", config="config-addrchange.toml",
+        phases=(Phase(label="source recreate", protocol="mdns", family=4, interface="source"),)),
+    RecreateCase(name="mdns_interface_recreate_target", config="config-addrchange.toml",
+        phases=(Phase(label="target recreate", protocol="mdns", family=4, interface="target"),)),
+    RecreateCase(name="mdns_interface_recreate_source_decoy", config="config-addrchange.toml",
+        phases=(Phase(label="source recreate", protocol="mdns", family=4, interface="source", decoy=True),)),
+    RecreateCase(name="mdns_interface_recreate_target_decoy", config="config-addrchange.toml",
+        phases=(Phase(label="target recreate", protocol="mdns", family=4, interface="target", decoy=True),)),
 ]
 
 ALL_CASES: list[
@@ -2040,21 +2035,26 @@ class RoundTripRunner(CaseRunner):
 
 class SearchRecreateRunner(RoundTripRunner):
     # See SearchRecreateCase. Reuses RoundTripRunner's segment/reflector/responder setup (the shim
-    # __init__ reads only the fields both cases share), but opens a session, recreates the target, and
-    # re-searches, asserting the dispatcher dropped the orphaned session. The one-shot responder is
-    # restarted after the recreation -- on the native fabrics its wire died with the interface (docker
-    # keeps it, but the responder had already answered and exited) -- mirroring the DIAL recreate
-    # case's device restart.
+    # __init__ reads only the fields both cases share), but opens a session, recreates one interface,
+    # and re-searches. A target recreation drops the session (asserted via the cleared-sessions log); a
+    # source recreation leaves it, so the retransmit re-reflects on the same reserved port (asserted
+    # via the re-reflected log). The target retransmit expects the 200 OK (a fresh session carries the
+    # retransmit's own MAC); the source retransmit is fire-and-forget -- it reuses the surviving session
+    # whose cached searcher MAC is the baseline container's, so on docker (a separate retransmit
+    # container / MAC but a reused IP) the reply is routed to the baseline, and survival is proven by the
+    # re-reflected log, not a round trip. The responder is restarted only for the target.
 
-    def _search(self, role: str) -> None:
-        # One M-SEARCH, asserting the 200 OK proxies back.
+    def _search(self, role: str, *, no_wait: bool = False) -> None:
+        # One M-SEARCH; with no_wait, send and exit (any reply is routed elsewhere), else assert the
+        # 200 OK proxies back.
+        expectation = ["--no-wait"] if no_wait else ["--expect-payload-hex", self.rt.reply_hex]
         ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
         self.backend.start_probe(role, "source", ifname, [
             "search",
             "--source-port", str(SEARCHER_SOURCE_PORT), "--port", str(self.rt.port),
             "--address", self.rt.group, "--interface", ifname, "--family", str(self.rt.family),
             "--payload-hex", self.rt.probe_hex, "--timeout", str(self.rt.timeout_seconds),
-            "--expect-payload-hex", self.rt.reply_hex,
+            *expectation,
         ])
         exit_code = self.backend.wait(role)
         out, err = self.backend.logs(role)
@@ -2065,17 +2065,20 @@ class SearchRecreateRunner(RoundTripRunner):
         if exit_code != 0:
             raise RuntimeError(f"{role} failed with exit code {exit_code}")
 
-    def _recreate_target(self) -> None:
-        # With the decoy, occupy the freed index before recreating so the target returns on a different
-        # one (the changed-index path); without it, FreeBSD reuses the index (the same-index path). The
-        # dispatcher clears sessions on either, so both variants must pass.
-        ifname = REFLECTOR_IFNAMES["target"]
-        self.backend.delete_interface("target")
-        self.wait_for_log("reflector", f"interface {ifname} is gone", "target deletion")
+    def _recreate(self) -> None:
+        # With the decoy, occupy the freed index before recreating so the interface returns on a
+        # different one (the changed-index path); without it, FreeBSD reuses the index (the same-index
+        # path). Both must behave the same, so both variants run.
+        interface = self.rt.interface
+        ifname = REFLECTOR_IFNAMES[interface]
+        self.backend.delete_interface(interface)
+        self.wait_for_log("reflector", f"interface {ifname} is gone", f"{interface} deletion")
         if self.rt.decoy:
             self.backend.add_decoy_interface()
-        self.backend.recreate_interface("target")
-        self.wait_for_log("reflector", f"interface {ifname}: returned as ifindex", "target recreation")
+        self.backend.recreate_interface(interface)
+        self.wait_for_log(
+            "reflector", f"interface {ifname}: returned as ifindex", f"{interface} recreation"
+        )
         if self.rt.decoy:
             self.backend.remove_decoy_interface()
 
@@ -2084,26 +2087,34 @@ class SearchRecreateRunner(RoundTripRunner):
         self.backend.setup_segments()
         self.start_reflector()
 
-        # First search: opens a session on the target.
+        # First search: opens a session (its reservation + response registration are on the target).
         self.start_responder()
         self._search("searcher-baseline")
         print(f"{self.rt.name}: baseline round trip before the recreation", flush=True)
 
-        # Destroy + recreate the target: its reserved port and response registration die with it, so
-        # the dispatcher drops the session (asserted via cleared_log below). The wide MX keeps the
-        # session alive until the parking so there is something to clear.
-        self._recreate_target()
+        # Destroy + recreate one interface. Target: the reservation + response registration die with it,
+        # so the dispatcher drops the session; a fresh searcher re-opens and round-trips. Source: nothing
+        # session-side lives there, so the session survives and the retransmit re-reflects on the same
+        # reserved port. The wide MX keeps the first session alive across the recreation either way.
+        self._recreate()
 
-        # A fresh responder for the retransmit: the baseline's exited after its one reply, and on the
-        # native fabrics its wire died with the target regardless.
-        self.backend.remove("responder")
-        self.start_responder()
-
-        # A fresh search re-opens a session against the recovered interface and round-trips.
-        self._search("searcher-retransmit")
-        print(f"{self.rt.name}: round trip after the recreation", flush=True)
-        self.wait_for_log("reflector", self.rt.cleared_log, "session clear")
-        print(f"{self.rt.name}: sessions cleared across the recreation", flush=True)
+        if self.rt.interface == "target":
+            # A fresh responder answers the retransmit's fresh session (the baseline's exited, and on the
+            # native fabrics the target's wire died with it).
+            self.backend.remove("responder")
+            self.start_responder()
+            self._search("searcher-retransmit")
+            self.wait_for_log(
+                "reflector", "cleared all sessions after the target interface changed", "session cleared"
+            )
+            print(f"{self.rt.name}: session cleared, round trip resumed after the target recreation", flush=True)
+        else:
+            # Fire-and-forget: the retransmit reuses the surviving session (same reserved port); its
+            # reply routes to the baseline's MAC, so this container needn't receive it. The re-reflected
+            # log proves the session survived and that the source ingress rebound and re-joined its group.
+            self._search("searcher-retransmit", no_wait=True)
+            self.wait_for_log("reflector", "re-reflected SSDP search", "session reused")
+            print(f"{self.rt.name}: session survived the source recreation", flush=True)
         print(f"PASS {self.rt.name}", flush=True)
         if self.args.show_reflector_logs:
             time.sleep(0.5)
@@ -2317,17 +2328,21 @@ class DialAddressChangeRunner(DialRunner):
 
 class DialRecreateRunner(DialAddressChangeRunner):
     # See DialRecreateCase. Inherits the pass machinery; only the mutation differs: instead of
-    # replacing addresses, each phase destroys and recreates a whole reflector interface,
-    # synchronized on the daemon's own parking/recreation log lines.
+    # replacing addresses, it destroys and recreates one reflector interface (optionally behind a
+    # decoy), synchronized on the daemon's own parking/recreation log lines.
 
     def _recreate(self, interface: str) -> None:
         ifname = REFLECTOR_IFNAMES[interface]
         self.backend.delete_interface(interface)
         self.wait_for_log("reflector", f"interface {ifname} is gone", f"{interface} deletion")
+        if self.dial.decoy:
+            self.backend.add_decoy_interface()
         self.backend.recreate_interface(interface)
         self.wait_for_log(
             "reflector", f"interface {ifname}: returned as ifindex", f"{interface} recreation"
         )
+        if self.dial.decoy:
+            self.backend.remove_decoy_interface()
 
     def run(self) -> None:
         print(f"\n=== {self.dial.name} ===", flush=True)
@@ -2339,20 +2354,19 @@ class DialRecreateRunner(DialAddressChangeRunner):
 
         self._dial_pass("baseline", source_ip, device_ip)
 
-        # Target first: the baseline's proxy egress-pins its device connects to the target
-        # interface, so the recreation must evict it and the fresh pass re-mint. The device is
-        # restarted: on the native fabrics its wire died with the interface (Docker keeps its
-        # endpoint; a fresh device is harmless and keeps the flow identical across backends).
-        self._recreate("target")
-        self.backend.remove("device")
-        self.start_device()
-        device_ip = self.backend.probe_ip("device", "target")
-        self._dial_pass("after target recreation", source_ip, device_ip)
-
-        # Then the source: the proxy's listeners live on it; eviction + re-mint again.
-        self._recreate("source")
-        source_ip = self.backend.reflector_ip("source")  # re-pinned to the same address
-        self._dial_pass("after source recreation", source_ip, device_ip)
+        # Recreate one interface; the baseline's proxy -- listeners on the source, egress-pin and
+        # target-address snapshot on the target -- must be evicted and the fresh pass re-mint.
+        interface = self.dial.interface
+        self._recreate(interface)
+        if interface == "target":
+            # The device sits on the target segment: on the native fabrics its wire died with the
+            # interface (Docker keeps its endpoint; a fresh device is harmless and uniform).
+            self.backend.remove("device")
+            self.start_device()
+            device_ip = self.backend.probe_ip("device", "target")
+        else:
+            source_ip = self.backend.reflector_ip("source")  # re-pinned to the same address
+        self._dial_pass(f"after {interface} recreation", source_ip, device_ip)
 
         print(f"PASS {self.dial.name}", flush=True)
         if self.args.show_reflector_logs:

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -73,6 +73,16 @@ SSDP_MSEARCH_HEX = (
     "MX: 2\r\n"
     "ST: ssdp:all\r\n\r\n"
 ).encode().hex()
+# An M-SEARCH with the maximum MX (clamped to 5s by the reflector), so its session lives ~7s (MX + the
+# 2s reply grace). The interface-recreate round trip needs that width: it destroys and recreates the
+# target between the searcher's two sends, and the second must land while the first's session is alive.
+SSDP_MSEARCH_MX5_HEX = (
+    "M-SEARCH * HTTP/1.1\r\n"
+    "HOST: 239.255.255.250:1900\r\n"
+    'MAN: "ssdp:discover"\r\n'
+    "MX: 5\r\n"
+    "ST: ssdp:all\r\n\r\n"
+).encode().hex()
 SSDP_NOTIFY_HEX = (
     "NOTIFY * HTTP/1.1\r\n"
     "HOST: 239.255.255.250:1900\r\n"
@@ -226,6 +236,8 @@ VALGRIND_STOP_GRACE_SECONDS = 60
 REFLECTOR_SOURCE_IFNAME = "wol_src"
 REFLECTOR_TARGET_IFNAME = "wol_dst"
 RECEIVER_IFNAME = "probe0"
+REFLECTOR_IFNAMES = {"source": REFLECTOR_SOURCE_IFNAME, "target": REFLECTOR_TARGET_IFNAME}
+DECOY_IFNAME = "rfxdecoy"
 
 IPV6_ALL_NODES = "ff02::1"
 
@@ -720,6 +732,35 @@ ROUNDTRIP_CASES = [
         evict_log="evicted WSD session"),
 ]
 
+
+@dataclasses.dataclass(frozen=True)
+class SearchRecreateCase:
+    # A search session surviving an interface recreation. One searcher, from a fixed source port,
+    # sends an M-SEARCH (opening a session), then -- after the target interface is destroyed and
+    # recreated on a different ifindex (a decoy grabs the freed index so even FreeBSD, which reuses
+    # the lowest free one, hands back a new index) -- retransmits from that same port while the
+    # session is still alive. The address is re-pinned unchanged, so only the index moved: this
+    # isolates the ifindex clause of the re-mint gate, which a zoneless address compare alone would
+    # miss (the motivating harm -- a reservation bound to a dead link-local zone -- is v6-only, but
+    # the fabrics cannot hold a link-local address across the MAC change a recreation brings). The
+    # gate must re-mint, and the second round trip must still return the 200 OK. This is the
+    # search-session path the passive mDNS and DIAL recreate cases never reach; logs `remint_log`.
+    name: str
+    family: int = 4
+    group: str = SSDP_GROUP_V4
+    port: int = SSDP_PORT
+    probe_hex: str = SSDP_MSEARCH_MX5_HEX  # wide MX window: room for the recreation between the two sends
+    reply_hex: str = SSDP_OK_HEX
+    config: str = "config.toml"
+    timeout_seconds: float = 8.0
+    remint_log: str = "re-minting the session"
+
+
+SEARCH_RECREATE_CASES = [
+    SearchRecreateCase(name="ssdp_search_interface_recreate"),
+]
+
+
 @dataclasses.dataclass(frozen=True)
 class DialCase:
     name: str
@@ -759,6 +800,28 @@ DIAL_ADDRESS_CHANGE_CASES = [
     DialAddressChangeCase(name="dial_address_change"),
 ]
 
+
+@dataclasses.dataclass(frozen=True)
+class DialRecreateCase:
+    # A full DIAL pass, then the same pass again after the reflector's target interface is
+    # destroyed and recreated, then again after the source's. The hardest DIAL recovery
+    # scenario: an address change replaces values, a recreation replaces the kernel objects
+    # underneath them -- the minted proxy's listener binds, target-address snapshot, and
+    # egress-pin all belong to the dead interface's world, so a passing re-run proves the
+    # recreation evicted the proxy and re-minted against the recreated interface.
+    name: str
+    family: int = 4
+    group: str = SSDP_GROUP_V4
+    timeout_seconds: float = 8.0
+    serve_seconds: float = 120.0  # device serves across passes and the recreation waits
+    passive: bool = True
+    unreachable: bool = False
+
+
+DIAL_RECREATE_CASES = [
+    DialRecreateCase(name="dial_interface_recreate"),
+]
+
 # Per-protocol probe parameters for the address-change phases: wol sends a magic packet (no payload
 # or group); mdns sends a query to its family's group, relayed verbatim.
 PROBE_SPECS = {
@@ -781,6 +844,11 @@ class Phase:
     protocol: str  # "wol" | "mdns" -> PROBE_SPECS
     family: int  # 4 | 6
     interface: str  # "source" (wol_src) | "target" (wol_dst): which reflector interface to toggle
+    # Recreate cases only: plant a throwaway interface between the delete and the recreate. It
+    # occupies the freed slot, so FreeBSD's lowest-free index allocator is forced to hand the
+    # recreated interface a DIFFERENT index; without it the same index comes back. The two
+    # flavors pin both detection paths (index comparison vs the capture attachment probe).
+    decoy: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -805,9 +873,46 @@ ADDRESS_CHANGE_CASES = [
     ),
 ]
 
-ALL_CASES: list[TestCase | RoundTripCase | DialCase | DialAddressChangeCase | AddressChangeCase] = [
-    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *WSD_CASES, *ROUNDTRIP_CASES, *DIAL_CASES,
-    *DIAL_ADDRESS_CHANGE_CASES, *ADDRESS_CHANGE_CASES]
+@dataclasses.dataclass(frozen=True)
+class RecreateCase:
+    name: str
+    config: str  # config file (relative to e2e/), defining a dual-family reflector set
+    phases: tuple[Phase, ...]  # interface = which reflector interface is destroyed+recreated
+
+
+RECREATE_CASES = [
+    RecreateCase(
+        name="mdns_interface_recreate",
+        config="config-addrchange.toml",
+        phases=(
+            # All phases probe forward (source -> target). Unlike the address-change cases
+            # (which can only exercise the egress send-gate), recreation kills the capture
+            # itself: recreating the source kills the forward INGRESS (queries no longer
+            # enter), recreating the target kills the forward EGRESS (re-emits no longer
+            # leave). Together they prove both halves of the capture rebind. The decoy
+            # flavor forces a different-index recreation on FreeBSD, where the plain
+            # flavors reuse the freed index (see Phase.decoy).
+            Phase(label="source recreate", protocol="mdns", family=4, interface="source"),
+            Phase(label="target recreate", protocol="mdns", family=4, interface="target"),
+            Phase(
+                label="source recreate behind a decoy", protocol="mdns", family=4,
+                interface="source", decoy=True,
+            ),
+            Phase(
+                label="target recreate behind a decoy", protocol="mdns", family=4,
+                interface="target", decoy=True,
+            ),
+        ),
+    ),
+]
+
+ALL_CASES: list[
+    TestCase | RoundTripCase | SearchRecreateCase | DialCase | DialAddressChangeCase
+    | AddressChangeCase | RecreateCase | DialRecreateCase
+] = [
+    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *WSD_CASES, *ROUNDTRIP_CASES, *SEARCH_RECREATE_CASES,
+    *DIAL_CASES, *DIAL_ADDRESS_CHANGE_CASES, *ADDRESS_CHANGE_CASES, *RECREATE_CASES,
+    *DIAL_RECREATE_CASES]
 
 
 def format_command(command: list[str]) -> str:
@@ -854,6 +959,13 @@ def magic_packet_hex(mac: str) -> str:
 
 SEGMENTS = ("source", "target")
 
+# Fixed per-segment subnets: RFC 5737 test networks for v4, a ULA /64 for routable v6. The native
+# fabrics assign hosts from these directly; the docker backend hands them to `network create` as
+# user-configured subnets (required so the recreate cases can pin the same --ip/--ip6 on reconnect --
+# docker rejects a static address on an IPAM-auto subnet).
+SEGMENT_V4_SUBNET = {"source": "192.0.2", "target": "198.51.100"}
+SEGMENT_V6_PREFIX = {"source": "fd00:e2e0:1", "target": "fd00:e2e0:2"}
+
 
 class Backend:
     # The execution environment for one case: two isolated dual-stack segments, the reflector
@@ -862,6 +974,12 @@ class Backend:
     # containers; native (Linux) as netns + veth pairs and plain processes. Runners hold case
     # logic only and drive everything through this interface, so every case runs identically
     # under both backends.
+
+    # Whether the probe helpers keep working while a segment's reflector-side interface is
+    # deleted. Docker probes own separate bridge endpoints, so yes; the native fabrics realize
+    # a segment as one veth/epair pair, so deleting it takes the probe end with it and the
+    # recreate case skips its silence probe there (there is no wire left to probe on).
+    PROBES_SURVIVE_DELETE = False
 
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
         self.args = args
@@ -953,6 +1071,26 @@ class Backend:
         self.admin(f"ip route add {dest_ip}/32 dev {ifname}")
         return True
 
+    def delete_interface(self, segment: str) -> None:
+        # Destroy `segment`'s reflector-side interface outright (its far peer dies with it):
+        # the first half of an interface recreation, as a PPPoE drop or bridge teardown would
+        # produce. The reflector's capture is left bound to a dead kernel object.
+        raise NotImplementedError
+
+    def recreate_interface(self, segment: str) -> None:
+        # The second half: recreate the interface under the same name and addresses -- a fresh
+        # kernel identity the reflector must reconcile its capture onto.
+        raise NotImplementedError
+
+    def add_decoy_interface(self) -> None:
+        # Plant a throwaway interface in the reflector's network view, occupying the index a
+        # just-deleted interface freed (see Phase.decoy). Removed with
+        # [`remove_decoy_interface`]; the fabric teardown also covers it on failure.
+        raise NotImplementedError
+
+    def remove_decoy_interface(self) -> None:
+        raise NotImplementedError
+
     def reflector_ip(self, segment: str) -> str:
         raise NotImplementedError
 
@@ -964,10 +1102,14 @@ class Backend:
 
 
 class DockerBackend(Backend):
+    PROBES_SURVIVE_DELETE = True
+
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
         super().__init__(args, prefix)
         self.networks = {segment: f"{prefix}-{segment}" for segment in SEGMENTS}
         self.roles: dict[str, str] = {}  # role -> container name, in start order
+        # segment -> (v4, v6) captured at delete_interface, re-pinned at recreate_interface.
+        self._detached_addrs: dict[str, list[str]] = {}
 
     @staticmethod
     def require_available() -> None:
@@ -975,9 +1117,16 @@ class DockerBackend(Backend):
 
     def setup_segments(self) -> None:
         # Both networks are dual-stack: IPv4 cases are unaffected, and IPv6 cases need the
-        # bridges to carry IPv6 so the reflector can listen on / emit to ff02::1.
+        # bridges to carry IPv6 so the reflector can listen on / emit to ff02::1. The subnets are
+        # given explicitly (not IPAM-auto) so the recreate cases can pin the same --ip/--ip6 when
+        # they reconnect the endpoint -- docker rejects a static address on an auto-subnet network.
         for segment in SEGMENTS:
-            docker(["network", "create", "--driver", "bridge", "--ipv6", self.networks[segment]])
+            docker([
+                "network", "create", "--driver", "bridge", "--ipv6",
+                "--subnet", f"{SEGMENT_V4_SUBNET[segment]}.0/24",
+                "--subnet", f"{SEGMENT_V6_PREFIX[segment]}::/64",
+                self.networks[segment],
+            ])
 
     def cleanup(self) -> None:
         for container in reversed(self.roles.values()):
@@ -1097,6 +1246,43 @@ class DockerBackend(Backend):
             raise RuntimeError(f"no IPv4 address for {container} on {network}")
         return ip
 
+    def delete_interface(self, segment: str) -> None:
+        # Detaching the bridge endpoint destroys the veth pair, the in-container interface
+        # included. Capture the endpoint's addresses first, so the reconnect can pin them.
+        container = self.roles["reflector"]
+        network = self.networks[segment]
+        fmt = (
+            '{{(index .NetworkSettings.Networks "' + network + '").IPAddress}}'
+            '|{{(index .NetworkSettings.Networks "' + network + '").GlobalIPv6Address}}'
+        )
+        addrs = docker(["inspect", "-f", fmt, container], echo=False).stdout.strip()
+        self._detached_addrs[segment] = addrs.split("|")
+        docker(["network", "disconnect", network, container])
+
+    def recreate_interface(self, segment: str) -> None:
+        # Reconnect under the same pinned interface name and addresses: a fresh veth, a fresh
+        # kernel identity. The driver-opt on connect needs the same Docker 28.0+ as create
+        # (see start_reflector).
+        v4, v6 = self._detached_addrs.pop(segment)
+        command = [
+            "network", "connect",
+            "--driver-opt", f"com.docker.network.endpoint.ifname={REFLECTOR_IFNAMES[segment]}",
+            "--ip", v4,
+        ]
+        if v6:
+            command += ["--ip6", v6]
+        docker([*command, self.networks[segment], self.roles["reflector"]])
+
+    def add_decoy_interface(self) -> None:
+        # The privileged admin sidecar shares the reflector's network namespace, so the veth
+        # lands where the freed index lived. Linux never reuses indexes, so the decoy is inert
+        # here -- it runs anyway to keep the case uniform across backends (and exercises the
+        # reflector's unwatched-churn policy for free).
+        self.admin(f"ip link add {DECOY_IFNAME} type veth peer name {DECOY_IFNAME}p")
+
+    def remove_decoy_interface(self) -> None:
+        self.admin(f"ip link del {DECOY_IFNAME}")
+
     def reflector_ip(self, segment: str) -> str:
         return self._container_ip(self.roles["reflector"], self.networks[segment])
 
@@ -1126,12 +1312,9 @@ class DockerBackend(Backend):
                 print(inspect.stdout, end="", file=sys.stderr, flush=True)
 
 
-# Native segment addressing: the RFC 5737 test networks for v4 and a ULA /64 per segment for
-# routable v6 (Docker's --ipv6 IPAM provided that implicitly; the kernel adds fe80:: itself).
-# The reflector is always host 1 and a segment's helper host 2, replacing Docker's IPAM
-# discovery with a fixed plan.
-NATIVE_V4_SUBNET = {"source": "192.0.2", "target": "198.51.100"}
-NATIVE_V6_PREFIX = {"source": "fd00:e2e0:1", "target": "fd00:e2e0:2"}
+# Native segment addressing over SEGMENT_V4_SUBNET / SEGMENT_V6_PREFIX: the reflector is always host 1
+# and a segment's helper host 2, replacing Docker's IPAM discovery with a fixed plan (the kernel adds
+# fe80:: itself).
 NATIVE_REFLECTOR_HOST = 1
 NATIVE_HELPER_HOST = 2
 
@@ -1147,7 +1330,6 @@ class NativeBackend(Backend):
     # privileges, not the CAP_NET_RAW-only confinement of the scratch container -- a change that
     # grows a privilege requirement passes natively and only fails in the docker lane. CI runs
     # both, so the docker lane stays the privilege-contract gate.
-    REFLECTOR_IFNAMES = {"source": REFLECTOR_SOURCE_IFNAME, "target": REFLECTOR_TARGET_IFNAME}
 
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
         super().__init__(args, prefix)
@@ -1267,11 +1449,11 @@ class NativeBackend(Backend):
         return proc.returncode
 
     def reflector_ip(self, segment: str) -> str:
-        return f"{NATIVE_V4_SUBNET[segment]}.{NATIVE_REFLECTOR_HOST}"
+        return f"{SEGMENT_V4_SUBNET[segment]}.{NATIVE_REFLECTOR_HOST}"
 
     def probe_ip(self, role: str, segment: str) -> str:
         del role  # one helper per segment; the plan gives them all the same host number
-        return f"{NATIVE_V4_SUBNET[segment]}.{NATIVE_HELPER_HOST}"
+        return f"{SEGMENT_V4_SUBNET[segment]}.{NATIVE_HELPER_HOST}"
 
     def print_diagnostics(self) -> None:
         for logfile in sorted(self.logdir.iterdir()):
@@ -1290,8 +1472,9 @@ class NativeLinuxBackend(NativeBackend):
     # windows must only see the segment's traffic, unicast to the reflector must cross the wire
     # rather than short-circuit via lo, and the host's daemons (systemd-resolved speaks mDNS)
     # must not reach the test wires. Successive probe processes for a case run inside the same
-    # far namespace: the reflector caches its ifindexes at startup, so the veth ends on its side
-    # must never be recreated -- probes respawn, namespaces persist.
+    # far namespace: probes respawn, namespaces persist. The recreate cases delete and re-add
+    # whole pairs (fresh kernel identities under the same names), which the reflector survives
+    # by reconciling its captures; the probes are immune, resolving interfaces fresh at spawn.
 
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
         super().__init__(args, prefix)
@@ -1321,29 +1504,50 @@ class NativeLinuxBackend(NativeBackend):
             self._ip(["-n", ns, "link", "set", "lo", "up"])
 
         for segment in SEGMENTS:
-            dut_ifname = self.REFLECTOR_IFNAMES[segment]
-            self._ip([
-                "link", "add", dut_ifname, "netns", self.ns["dut"],
-                "type", "veth", "peer", "name", RECEIVER_IFNAME, "netns", self.ns[segment],
-            ])
-            v4, v6 = NATIVE_V4_SUBNET[segment], NATIVE_V6_PREFIX[segment]
-            dut, far = self.ns["dut"], self.ns[segment]
-            self._ip(["-n", dut, "addr", "add", f"{v4}.{NATIVE_REFLECTOR_HOST}/24", "dev", dut_ifname])
-            self._ip(["-n", dut, "addr", "add", f"{v6}::{NATIVE_REFLECTOR_HOST}/64", "dev", dut_ifname])
-            self._ip(["-n", far, "addr", "add", f"{v4}.{NATIVE_HELPER_HOST}/24", "dev", RECEIVER_IFNAME])
-            self._ip(["-n", far, "addr", "add", f"{v6}::{NATIVE_HELPER_HOST}/64", "dev", RECEIVER_IFNAME])
-            self._ip(["-n", dut, "link", "set", dut_ifname, "up"])
-            self._ip(["-n", far, "link", "set", RECEIVER_IFNAME, "up"])
-            # The probe's 255.255.255.255 sends are routed, not interface-pinned; single-homed
-            # plus this default route pins them to the segment (Docker's IPAM gateway did this).
-            self._ip(["-n", far, "route", "add", "default", "dev", RECEIVER_IFNAME])
+            self._setup_segment(segment)
 
         self._wait_carrier()
+
+    def _setup_segment(self, segment: str) -> None:
+        dut_ifname = REFLECTOR_IFNAMES[segment]
+        self._ip([
+            "link", "add", dut_ifname, "netns", self.ns["dut"],
+            "type", "veth", "peer", "name", RECEIVER_IFNAME, "netns", self.ns[segment],
+        ])
+        v4, v6 = SEGMENT_V4_SUBNET[segment], SEGMENT_V6_PREFIX[segment]
+        dut, far = self.ns["dut"], self.ns[segment]
+        self._ip(["-n", dut, "addr", "add", f"{v4}.{NATIVE_REFLECTOR_HOST}/24", "dev", dut_ifname])
+        self._ip(["-n", dut, "addr", "add", f"{v6}::{NATIVE_REFLECTOR_HOST}/64", "dev", dut_ifname])
+        self._ip(["-n", far, "addr", "add", f"{v4}.{NATIVE_HELPER_HOST}/24", "dev", RECEIVER_IFNAME])
+        self._ip(["-n", far, "addr", "add", f"{v6}::{NATIVE_HELPER_HOST}/64", "dev", RECEIVER_IFNAME])
+        self._ip(["-n", dut, "link", "set", dut_ifname, "up"])
+        self._ip(["-n", far, "link", "set", RECEIVER_IFNAME, "up"])
+        # The probe's 255.255.255.255 sends are routed, not interface-pinned; single-homed
+        # plus this default route pins them to the segment (Docker's IPAM gateway did this).
+        self._ip(["-n", far, "route", "add", "default", "dev", RECEIVER_IFNAME])
+
+    def delete_interface(self, segment: str) -> None:
+        # Deleting the dut end destroys the pair, the far probe0 included.
+        self._ip(["-n", self.ns["dut"], "link", "del", REFLECTOR_IFNAMES[segment]])
+
+    def recreate_interface(self, segment: str) -> None:
+        self._setup_segment(segment)
+        self._wait_carrier()
+
+    def add_decoy_interface(self) -> None:
+        # Inert on Linux (indexes are never reused); runs to keep the case uniform.
+        self._ip([
+            "-n", self.ns["dut"], "link", "add", DECOY_IFNAME,
+            "type", "veth", "peer", "name", f"{DECOY_IFNAME}p",
+        ])
+
+    def remove_decoy_interface(self) -> None:
+        self._ip(["-n", self.ns["dut"], "link", "del", DECOY_IFNAME])
 
     def _wait_carrier(self) -> None:
         # A veth reports operstate "up" only once BOTH ends are up; don't start the reflector
         # (or probes) on a link that hasn't settled.
-        pending = [(self.ns["dut"], ifname) for ifname in self.REFLECTOR_IFNAMES.values()]
+        pending = [(self.ns["dut"], ifname) for ifname in REFLECTOR_IFNAMES.values()]
         pending += [(self.ns[segment], RECEIVER_IFNAME) for segment in SEGMENTS]
         deadline = time.monotonic() + 5.0
         for ns, ifname in pending:
@@ -1400,6 +1604,8 @@ class NativeFreeBSDBackend(NativeBackend):
         # Jail names: play safe with the allowed character set.
         base = prefix.replace("-", "_")
         self.jails = {"dut": f"{base}_dut", "source": f"{base}_src", "target": f"{base}_dst"}
+        # The host-side end of a live decoy epair (see add_decoy_interface), for teardown.
+        self._decoy_host_end: str | None = None
 
     @staticmethod
     def require_available() -> None:
@@ -1437,32 +1643,70 @@ class NativeFreeBSDBackend(NativeBackend):
         self._make_jail(dut, *(a_end for a_end, _ in ends.values()))
         for segment in SEGMENTS:
             a_end, b_end = ends[segment]
-            dut_ifname = self.REFLECTOR_IFNAMES[segment]
             self._make_jail(self.jails[segment], b_end)
-            jexec_dut = ["jexec", dut]
-            jexec_far = ["jexec", self.jails[segment]]
-            run_command([*jexec_dut, "ifconfig", a_end, "name", dut_ifname])
-            run_command([*jexec_far, "ifconfig", b_end, "name", RECEIVER_IFNAME])
-            v4, v6 = NATIVE_V4_SUBNET[segment], NATIVE_V6_PREFIX[segment]
-            run_command([*jexec_dut, "ifconfig", dut_ifname, "inet", f"{v4}.{NATIVE_REFLECTOR_HOST}/24"])
-            run_command([*jexec_dut, "ifconfig", dut_ifname, "inet6", f"{v6}::{NATIVE_REFLECTOR_HOST}/64"])
-            run_command([*jexec_dut, "ifconfig", dut_ifname, "up"])
-            run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet", f"{v4}.{NATIVE_HELPER_HOST}/24"])
-            run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet6", f"{v6}::{NATIVE_HELPER_HOST}/64"])
-            run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "up"])
-            # The probe's 255.255.255.255 sends are routed, not interface-pinned; single-homed
-            # plus this default route pins them to the segment.
-            run_command([*jexec_far, "route", "add", "default", "-interface", RECEIVER_IFNAME])
+            self._configure_segment(segment, a_end, b_end)
+
+    def _configure_segment(self, segment: str, a_end: str, b_end: str) -> None:
+        # The epair ends already sit inside the dut/far jails; rename, address, and route them.
+        dut_ifname = REFLECTOR_IFNAMES[segment]
+        jexec_dut = ["jexec", self.jails["dut"]]
+        jexec_far = ["jexec", self.jails[segment]]
+        run_command([*jexec_dut, "ifconfig", a_end, "name", dut_ifname])
+        run_command([*jexec_far, "ifconfig", b_end, "name", RECEIVER_IFNAME])
+        v4, v6 = SEGMENT_V4_SUBNET[segment], SEGMENT_V6_PREFIX[segment]
+        run_command([*jexec_dut, "ifconfig", dut_ifname, "inet", f"{v4}.{NATIVE_REFLECTOR_HOST}/24"])
+        run_command([*jexec_dut, "ifconfig", dut_ifname, "inet6", f"{v6}::{NATIVE_REFLECTOR_HOST}/64"])
+        run_command([*jexec_dut, "ifconfig", dut_ifname, "up"])
+        run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet", f"{v4}.{NATIVE_HELPER_HOST}/24"])
+        run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet6", f"{v6}::{NATIVE_HELPER_HOST}/64"])
+        run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "up"])
+        # The probe's 255.255.255.255 sends are routed, not interface-pinned; single-homed
+        # plus this default route pins them to the segment.
+        run_command([*jexec_far, "route", "add", "default", "-interface", RECEIVER_IFNAME])
+
+    def delete_interface(self, segment: str) -> None:
+        # Destroying the dut end tears down the pair, the far probe0 included.
+        run_command(["jexec", self.jails["dut"], "ifconfig", REFLECTOR_IFNAMES[segment], "destroy"])
+
+    def recreate_interface(self, segment: str) -> None:
+        # A fresh epair, moved into the LIVE jails -- setup assigns interfaces at jail
+        # creation (vnet.interface=...); this is the move-into-a-running-vnet path -- then
+        # configured exactly as setup did.
+        a_end = run_command(["ifconfig", "epair", "create"]).stdout.strip()
+        if not a_end.endswith("a"):
+            raise RuntimeError(f"unexpected epair name: {a_end}")
+        b_end = f"{a_end[:-1]}b"
+        run_command(["ifconfig", a_end, "vnet", self.jails["dut"]])
+        run_command(["ifconfig", b_end, "vnet", self.jails[segment]])
+        self._configure_segment(segment, a_end, b_end)
+
+    def add_decoy_interface(self) -> None:
+        # The move into the dut vnet is what occupies the freed index there: FreeBSD's
+        # per-vnet allocator hands the mover the lowest free slot, exactly where the deleted
+        # interface sat. The b end stays on the host (destroyed with the pair later).
+        a_end = run_command(["ifconfig", "epair", "create"]).stdout.strip()
+        if not a_end.endswith("a"):
+            raise RuntimeError(f"unexpected epair name: {a_end}")
+        run_command(["ifconfig", a_end, "vnet", self.jails["dut"]])
+        run_command(["jexec", self.jails["dut"], "ifconfig", a_end, "name", DECOY_IFNAME])
+        self._decoy_host_end = f"{a_end[:-1]}b"
+
+    def remove_decoy_interface(self) -> None:
+        # Destroying the dut-side end tears down the pair, the host b end included.
+        run_command(["jexec", self.jails["dut"], "ifconfig", DECOY_IFNAME, "destroy"])
+        self._decoy_host_end = None
 
     def _teardown_fabric(self) -> None:
         # Destroy the a ends (from inside the dut jail) first: killing one end tears down the
         # whole pair, including the b end inside its probe jail -- so no jail removal can return
         # a probe0 to a stack where the other jail's probe0 already sits. The host-side destroy
         # covers a setup that failed before the interfaces moved into the dut jail.
-        for ifname in self.REFLECTOR_IFNAMES.values():
+        for ifname in REFLECTOR_IFNAMES.values():
             run_command(["jexec", self.jails["dut"], "ifconfig", ifname, "destroy"],
                         check=False, echo=False)
             run_command(["ifconfig", ifname, "destroy"], check=False, echo=False)
+        if self._decoy_host_end is not None:  # a case failed mid-decoy; free the pair
+            run_command(["ifconfig", self._decoy_host_end, "destroy"], check=False, echo=False)
         for jail in self.jails.values():
             run_command(["jail", "-r", jail], check=False, echo=False)
 
@@ -1789,8 +2033,84 @@ class RoundTripRunner(CaseRunner):
             self.print_reflector_logs()
 
 
+class SearchRecreateRunner(RoundTripRunner):
+    # See SearchRecreateCase. Reuses RoundTripRunner's segment/reflector/responder setup (the shim
+    # __init__ reads only the fields both cases share), but drives two searches from one source port
+    # with a target recreation between them, so the reflector must re-mint the persisted session onto
+    # the fresh interface rather than reuse a reservation bound to the dead ifindex. The one-shot
+    # responder is restarted after the recreation -- on the native fabrics its wire died with the
+    # interface (docker keeps it, but the responder had already answered and exited) -- mirroring the
+    # DIAL recreate case's device restart.
+
+    def _search(self, role: str) -> None:
+        # One M-SEARCH from the fixed source port, asserting the 200 OK proxies back. The shared port is
+        # what makes the second send a retransmit of the first's session, not a brand-new one.
+        ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
+        self.backend.start_probe(role, "source", ifname, [
+            "search",
+            "--source-port", str(SEARCHER_SOURCE_PORT), "--port", str(self.rt.port),
+            "--address", self.rt.group, "--interface", ifname, "--family", str(self.rt.family),
+            "--payload-hex", self.rt.probe_hex, "--timeout", str(self.rt.timeout_seconds),
+            "--expect-payload-hex", self.rt.reply_hex,
+        ])
+        exit_code = self.backend.wait(role)
+        out, err = self.backend.logs(role)
+        if out:
+            print(out, end="", flush=True)
+        if err:
+            print(err, end="", file=sys.stderr, flush=True)
+        if exit_code != 0:
+            raise RuntimeError(f"{role} failed with exit code {exit_code}")
+
+    def _recreate_target(self) -> None:
+        # Occupy the freed index with a decoy before recreating, so the target comes back on a
+        # different ifindex. Without it FreeBSD reuses the lowest free index, so the reply binding
+        # never moves and the session is (correctly) reused rather than re-minted -- the very thing
+        # this case asserts. Inert on Linux/docker (monotonic indexes), kept for a uniform flow.
+        ifname = REFLECTOR_IFNAMES["target"]
+        self.backend.delete_interface("target")
+        self.wait_for_log("reflector", f"interface {ifname} is gone", "target deletion")
+        self.backend.add_decoy_interface()
+        self.backend.recreate_interface("target")
+        self.wait_for_log("reflector", f"interface {ifname}: returned as ifindex", "target recreation")
+        self.backend.remove_decoy_interface()
+
+    def run(self) -> None:
+        print(f"\n=== {self.rt.name} ===", flush=True)
+        self.backend.setup_segments()
+        self.start_reflector()
+
+        # First search: opens the session, its reservation scoped to the target's current ifindex.
+        self.start_responder()
+        self._search("searcher-baseline")
+        print(f"{self.rt.name}: baseline round trip before the recreation", flush=True)
+
+        # Destroy + recreate the target (same v4 address, fresh ifindex). The session persists -- the
+        # reconcile never touches sessions -- with a reservation now bound to the vanished zone.
+        self._recreate_target()
+
+        # A fresh responder for the retransmit: the baseline's exited after its one reply, and on the
+        # native fabrics its wire died with the target regardless.
+        self.backend.remove("responder")
+        self.start_responder()
+
+        # Retransmit from the same source port while the session is still alive: the reflector must see
+        # the reply binding moved and re-mint, and the round trip must still complete against the new
+        # interface. A session that had (wrongly) been reused would keep the stale reservation.
+        self._search("searcher-retransmit")
+        print(f"{self.rt.name}: round trip after the recreation", flush=True)
+        self.wait_for_log("reflector", self.rt.remint_log, "session re-mint")
+        print(f"{self.rt.name}: session re-minted across the recreation", flush=True)
+        print(f"PASS {self.rt.name}", flush=True)
+        if self.args.show_reflector_logs:
+            time.sleep(0.5)
+            self.print_reflector_logs()
+
+
 class DialRunner(CaseRunner):
-    def __init__(self, args: argparse.Namespace, case: DialCase) -> None:
+    def __init__(
+        self, args: argparse.Namespace, case: DialCase | DialAddressChangeCase | DialRecreateCase
+    ) -> None:
         shim = TestCase(name=case.name, send_port=SSDP_PORT, receive_port=SSDP_PORT,
             expect_mac=None, timeout_seconds=case.timeout_seconds, family=case.family,
             group=case.group, direction="forward")
@@ -1992,6 +2312,51 @@ class DialAddressChangeRunner(DialRunner):
             self.print_reflector_logs()
 
 
+class DialRecreateRunner(DialAddressChangeRunner):
+    # See DialRecreateCase. Inherits the pass machinery; only the mutation differs: instead of
+    # replacing addresses, each phase destroys and recreates a whole reflector interface,
+    # synchronized on the daemon's own parking/recreation log lines.
+
+    def _recreate(self, interface: str) -> None:
+        ifname = REFLECTOR_IFNAMES[interface]
+        self.backend.delete_interface(interface)
+        self.wait_for_log("reflector", f"interface {ifname} is gone", f"{interface} deletion")
+        self.backend.recreate_interface(interface)
+        self.wait_for_log(
+            "reflector", f"interface {ifname}: returned as ifindex", f"{interface} recreation"
+        )
+
+    def run(self) -> None:
+        print(f"\n=== {self.dial.name} ===", flush=True)
+        self.backend.setup_segments()
+        self.start_reflector()
+        self.start_device()  # passive: advertises NOTIFY + serves HTTP
+        device_ip = self.backend.probe_ip("device", "target")
+        source_ip = self.backend.reflector_ip("source")
+
+        self._dial_pass("baseline", source_ip, device_ip)
+
+        # Target first: the baseline's proxy egress-pins its device connects to the target
+        # interface, so the recreation must evict it and the fresh pass re-mint. The device is
+        # restarted: on the native fabrics its wire died with the interface (Docker keeps its
+        # endpoint; a fresh device is harmless and keeps the flow identical across backends).
+        self._recreate("target")
+        self.backend.remove("device")
+        self.start_device()
+        device_ip = self.backend.probe_ip("device", "target")
+        self._dial_pass("after target recreation", source_ip, device_ip)
+
+        # Then the source: the proxy's listeners live on it; eviction + re-mint again.
+        self._recreate("source")
+        source_ip = self.backend.reflector_ip("source")  # re-pinned to the same address
+        self._dial_pass("after source recreation", source_ip, device_ip)
+
+        print(f"PASS {self.dial.name}", flush=True)
+        if self.args.show_reflector_logs:
+            time.sleep(0.5)
+            self.print_reflector_logs()
+
+
 class AddressChangeRunner(CaseRunner):
     # Proves the dynamic family bring-up/teardown end to end: with a dual-family reflector
     # running, knock out one (interface, family) source address at a time and verify -- with real
@@ -2134,14 +2499,120 @@ class AddressChangeRunner(CaseRunner):
             self.print_reflector_logs()
 
 
+class RecreateRunner(AddressChangeRunner):
+    # Proves interface hot-swap recovery end to end: destroy and recreate one reflector-side
+    # interface (same name and addresses, fresh kernel identity -- a PPPoE reconnect or bridge
+    # rebuild in miniature) and verify with real traffic that reflection through it resumes
+    # once the reconcile re-binds the capture. Inherits the probe/poll machinery; only the
+    # mutation (delete/recreate instead of address toggles), the always-forward probe
+    # direction, and the log assertion differ.
+
+    def _phase_case(self, phase: Phase, *, expect: bool, timeout: float) -> TestCase:
+        # Always probe forward, with the query payload: the recreated interface is the forward
+        # ingress (source phase) or the forward egress (target phase); the base runner's
+        # egress-derived direction flip does not apply.
+        spec = PROBE_SPECS[phase.protocol]
+        return TestCase(
+            name=self.ac.name,
+            send_port=spec["port"],
+            receive_port=spec["port"],
+            expect_mac=None,
+            timeout_seconds=timeout,
+            send_payload_hex=spec["payload"],
+            family=phase.family,
+            direction="forward",
+            group=spec["group_v6"] if phase.family == 6 else spec["group_v4"],
+            expect_payload_hex=(spec["payload"] if expect else None),
+        )
+
+    def _run_phase(self, phase: Phase) -> None:
+        desc = f"{self.ac.name} / {phase.label}"
+        print(f"--- phase: {desc} ({phase.protocol} IPv{phase.family}) ---", flush=True)
+
+        if not self._poll_reflected(phase):
+            raise RuntimeError(f"{desc}: no baseline reflection before the recreation")
+        print(f"{desc}: baseline reflected", flush=True)
+
+        self.backend.delete_interface(phase.interface)
+        if phase.decoy:
+            # Occupy the freed index before the recreation claims it (see Phase.decoy).
+            self.backend.add_decoy_interface()
+        if self.backend.PROBES_SURVIVE_DELETE:
+            if not self._poll_not_reflected(phase):
+                raise RuntimeError(
+                    f"{desc}: reflection continued after the {phase.interface} interface was "
+                    f"deleted"
+                )
+            print(f"{desc}: reflection stopped after interface deletion", flush=True)
+        else:
+            # The segment's wire died with the interface, so there is nothing to probe on;
+            # the "is gone" log assertion stands in as the observed-death proof. The pause
+            # lets the reflector see the departure and park before the name returns --
+            # otherwise it would (correctly) log only the recreation.
+            print(f"{desc}: segment wire gone; skipping the silence probe", flush=True)
+            time.sleep(2.0)
+
+        self.backend.recreate_interface(phase.interface)
+        if phase.decoy:
+            self.backend.remove_decoy_interface()
+        if not self._poll_reflected(phase):
+            raise RuntimeError(
+                f"{desc}: reflection did not resume after the {phase.interface} interface was "
+                f"recreated"
+            )
+        print(f"{desc}: reflection resumed after interface recreation", flush=True)
+
+    def _assert_recreations_logged(self) -> None:
+        # The reflector must have observed each phase as a real hot-swap, in its parts: the
+        # parking line when the interface vanished, the address losses parking implies (the
+        # egress gate closing), the recreation line when its capture re-bound, and the address
+        # gains of the re-resolve. Their absence would mean reflection "recovered" some other
+        # way than the reconcile.
+        out, err = self.backend.logs("reflector")
+        text = f"{out}\n{err}"
+        for phase in self.ac.phases:
+            ifname = REFLECTOR_IFNAMES[phase.interface]
+            needles = (
+                f"interface {ifname} is gone",
+                f"interface {ifname}: returned as ifindex",
+                f"interface {ifname}: lost IPv4",
+                f"interface {ifname}: gained IPv4",
+            )
+            for needle in needles:
+                if needle not in text:
+                    raise RuntimeError(
+                        f"{self.ac.name}: reflector never logged \"{needle}\" -- the reconcile "
+                        f"did not drive the recovery"
+                    )
+
+    def run(self) -> None:
+        print(f"\n=== {self.ac.name} ===", flush=True)
+        self.backend.setup_segments()
+        self.start_reflector()
+        for phase in self.ac.phases:
+            self._run_phase(phase)
+        self._assert_recreations_logged()
+        print(f"PASS {self.ac.name}", flush=True)
+        if self.args.show_reflector_logs:
+            time.sleep(0.5)
+            self.print_reflector_logs()
+
+
 def make_runner(args: argparse.Namespace,
-        case: TestCase | RoundTripCase | DialCase | DialAddressChangeCase | AddressChangeCase) -> CaseRunner:
+        case: TestCase | RoundTripCase | SearchRecreateCase | DialCase | DialAddressChangeCase
+        | AddressChangeCase | RecreateCase | DialRecreateCase) -> CaseRunner:
+    if isinstance(case, SearchRecreateCase):
+        return SearchRecreateRunner(args, case)
     if isinstance(case, RoundTripCase):
         return RoundTripRunner(args, case)
+    if isinstance(case, DialRecreateCase):
+        return DialRecreateRunner(args, case)
     if isinstance(case, DialAddressChangeCase):
         return DialAddressChangeRunner(args, case)
     if isinstance(case, DialCase):
         return DialRunner(args, case)
+    if isinstance(case, RecreateCase):
+        return RecreateRunner(args, case)
     if isinstance(case, AddressChangeCase):
         return AddressChangeRunner(args, case)
     return CaseRunner(args, case)
@@ -2152,7 +2623,9 @@ def build_reflector_image(image: str, target: str | None = None) -> None:
     docker(["build", *target_args, "-t", image, "."], capture=False)
 
 
-def select_cases(case_names: list[str]) -> list[TestCase | RoundTripCase | DialCase | DialAddressChangeCase | AddressChangeCase]:
+def select_cases(case_names: list[str]) -> list[
+        TestCase | RoundTripCase | SearchRecreateCase | DialCase | DialAddressChangeCase
+        | AddressChangeCase | RecreateCase | DialRecreateCase]:
     if not case_names:
         return ALL_CASES
 

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -735,29 +735,34 @@ ROUNDTRIP_CASES = [
 
 @dataclasses.dataclass(frozen=True)
 class SearchRecreateCase:
-    # A search session surviving an interface recreation. One searcher, from a fixed source port,
-    # sends an M-SEARCH (opening a session), then -- after the target interface is destroyed and
-    # recreated on a different ifindex (a decoy grabs the freed index so even FreeBSD, which reuses
-    # the lowest free one, hands back a new index) -- retransmits from that same port while the
-    # session is still alive. The address is re-pinned unchanged, so only the index moved: this
-    # isolates the ifindex clause of the re-mint gate, which a zoneless address compare alone would
-    # miss (the motivating harm -- a reservation bound to a dead link-local zone -- is v6-only, but
-    # the fabrics cannot hold a link-local address across the MAC change a recreation brings). The
-    # gate must re-mint, and the second round trip must still return the 200 OK. This is the
-    # search-session path the passive mDNS and DIAL recreate cases never reach; logs `remint_log`.
+    # A search session cleared across an interface recreation. One searcher opens a session; the
+    # target interface is then destroyed and recreated. Its reserved port and response registration
+    # died with the interface, so the dispatcher drops every session bound to it (and logs
+    # `cleared_log`) via the on_iface_change push path; a fresh searcher then re-opens and round-trips
+    # against the recovered interface. Run both without and with a decoy that grabs the freed index:
+    # on FreeBSD (which reuses the lowest-free index) that is the difference between a same-index and a
+    # changed-index recreation -- two distinct detection paths (the attached() BIOCGDLT probe vs the
+    # index comparison), both of which must clear the session. On Linux the index always changes, so
+    # the decoy is inert there. This is the search-session path the passive mDNS and DIAL recreate
+    # cases never reach (mDNS is sessionless, the DIAL cases discover via NOTIFY). A wide MX keeps the
+    # first session alive until the recreation so there is something to clear.
     name: str
     family: int = 4
     group: str = SSDP_GROUP_V4
     port: int = SSDP_PORT
-    probe_hex: str = SSDP_MSEARCH_MX5_HEX  # wide MX window: room for the recreation between the two sends
+    probe_hex: str = SSDP_MSEARCH_MX5_HEX  # wide MX window: the first session must outlive the recreation
     reply_hex: str = SSDP_OK_HEX
     config: str = "config.toml"
     timeout_seconds: float = 8.0
-    remint_log: str = "re-minting the session"
+    decoy: bool = False  # plant a decoy on the freed index so the recreation lands on a different one
+    cleared_log: str = "cleared all sessions"
 
 
 SEARCH_RECREATE_CASES = [
+    # Same index on FreeBSD (reused), reached via the attached() probe.
     SearchRecreateCase(name="ssdp_search_interface_recreate"),
+    # Different index everywhere, via the index comparison.
+    SearchRecreateCase(name="ssdp_search_interface_recreate_decoy", decoy=True),
 ]
 
 
@@ -2035,16 +2040,14 @@ class RoundTripRunner(CaseRunner):
 
 class SearchRecreateRunner(RoundTripRunner):
     # See SearchRecreateCase. Reuses RoundTripRunner's segment/reflector/responder setup (the shim
-    # __init__ reads only the fields both cases share), but drives two searches from one source port
-    # with a target recreation between them, so the reflector must re-mint the persisted session onto
-    # the fresh interface rather than reuse a reservation bound to the dead ifindex. The one-shot
-    # responder is restarted after the recreation -- on the native fabrics its wire died with the
-    # interface (docker keeps it, but the responder had already answered and exited) -- mirroring the
-    # DIAL recreate case's device restart.
+    # __init__ reads only the fields both cases share), but opens a session, recreates the target, and
+    # re-searches, asserting the dispatcher dropped the orphaned session. The one-shot responder is
+    # restarted after the recreation -- on the native fabrics its wire died with the interface (docker
+    # keeps it, but the responder had already answered and exited) -- mirroring the DIAL recreate
+    # case's device restart.
 
     def _search(self, role: str) -> None:
-        # One M-SEARCH from the fixed source port, asserting the 200 OK proxies back. The shared port is
-        # what makes the second send a retransmit of the first's session, not a brand-new one.
+        # One M-SEARCH, asserting the 200 OK proxies back.
         ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
         self.backend.start_probe(role, "source", ifname, [
             "search",
@@ -2063,30 +2066,32 @@ class SearchRecreateRunner(RoundTripRunner):
             raise RuntimeError(f"{role} failed with exit code {exit_code}")
 
     def _recreate_target(self) -> None:
-        # Occupy the freed index with a decoy before recreating, so the target comes back on a
-        # different ifindex. Without it FreeBSD reuses the lowest free index, so the reply binding
-        # never moves and the session is (correctly) reused rather than re-minted -- the very thing
-        # this case asserts. Inert on Linux/docker (monotonic indexes), kept for a uniform flow.
+        # With the decoy, occupy the freed index before recreating so the target returns on a different
+        # one (the changed-index path); without it, FreeBSD reuses the index (the same-index path). The
+        # dispatcher clears sessions on either, so both variants must pass.
         ifname = REFLECTOR_IFNAMES["target"]
         self.backend.delete_interface("target")
         self.wait_for_log("reflector", f"interface {ifname} is gone", "target deletion")
-        self.backend.add_decoy_interface()
+        if self.rt.decoy:
+            self.backend.add_decoy_interface()
         self.backend.recreate_interface("target")
         self.wait_for_log("reflector", f"interface {ifname}: returned as ifindex", "target recreation")
-        self.backend.remove_decoy_interface()
+        if self.rt.decoy:
+            self.backend.remove_decoy_interface()
 
     def run(self) -> None:
         print(f"\n=== {self.rt.name} ===", flush=True)
         self.backend.setup_segments()
         self.start_reflector()
 
-        # First search: opens the session, its reservation scoped to the target's current ifindex.
+        # First search: opens a session on the target.
         self.start_responder()
         self._search("searcher-baseline")
         print(f"{self.rt.name}: baseline round trip before the recreation", flush=True)
 
-        # Destroy + recreate the target (same v4 address, fresh ifindex). The session persists -- the
-        # reconcile never touches sessions -- with a reservation now bound to the vanished zone.
+        # Destroy + recreate the target: its reserved port and response registration die with it, so
+        # the dispatcher drops the session (asserted via cleared_log below). The wide MX keeps the
+        # session alive until the parking so there is something to clear.
         self._recreate_target()
 
         # A fresh responder for the retransmit: the baseline's exited after its one reply, and on the
@@ -2094,13 +2099,11 @@ class SearchRecreateRunner(RoundTripRunner):
         self.backend.remove("responder")
         self.start_responder()
 
-        # Retransmit from the same source port while the session is still alive: the reflector must see
-        # the reply binding moved and re-mint, and the round trip must still complete against the new
-        # interface. A session that had (wrongly) been reused would keep the stale reservation.
+        # A fresh search re-opens a session against the recovered interface and round-trips.
         self._search("searcher-retransmit")
         print(f"{self.rt.name}: round trip after the recreation", flush=True)
-        self.wait_for_log("reflector", self.rt.remint_log, "session re-mint")
-        print(f"{self.rt.name}: session re-minted across the recreation", flush=True)
+        self.wait_for_log("reflector", self.rt.cleared_log, "session clear")
+        print(f"{self.rt.name}: sessions cleared across the recreation", flush=True)
         print(f"PASS {self.rt.name}", flush=True)
         if self.args.show_reflector_logs:
             time.sleep(0.5)

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -44,14 +44,7 @@ impl Capture {
     /// Returns an error if the interface is unknown, the socket can't be created,
     /// the filter can't be attached, or the bind fails.
     pub(crate) fn open(if_name: &str) -> io::Result<Self> {
-        let ifindex = if_index(if_name).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("interface {if_name} not found"),
-            )
-        })?;
-        let ifindex =
-            c_int::try_from(ifindex).map_err(|_| io::Error::other("interface index too large"))?;
+        let ifindex = resolve_ifindex(if_name)?;
 
         // Protocol 0: capture nothing until the filter + loop-prevention are in place.
         // SAFETY: a `socket` call with a valid domain/type/protocol returns a fresh fd or -1.
@@ -88,6 +81,61 @@ impl Capture {
             buf: vec![0u8; RECV_BUFFER_SIZE].into_boxed_slice(),
             name: if_name.into(),
         })
+    }
+
+    /// Re-bind the socket to the interface currently named at open, re-hooking delivery to its
+    /// (possibly recreated) kernel object. The fd, filter, and loop prevention all persist
+    /// across a `bind(2)`, so the filter-before-bind init invariant holds with no unfiltered
+    /// window, and the reactor's watch stays valid.
+    ///
+    /// # Errors
+    /// [`io::ErrorKind::NotFound`] while no interface bears the name; otherwise the `bind`
+    /// failure.
+    #[allow(dead_code)] // wired up by the interface reconcile
+    pub(crate) fn rebind(&mut self) -> io::Result<()> {
+        let ifindex = resolve_ifindex(&self.name)?;
+        bind_interface(&self.fd, link_addr(ifindex))?;
+        // The kernel parked ENETDOWN on the socket when the old interface died; consume it so
+        // the first post-rebind recv surfaces frames, not the stale failure.
+        match crate::sys::so_error(self.fd.as_raw_fd()) {
+            Ok(0) => {}
+            Ok(errno) => log::debug!(
+                "cleared a pending error on the re-bound capture for {}: {}",
+                self.name,
+                io::Error::from_raw_os_error(errno)
+            ),
+            // Can't happen (SO_ERROR is a generic socket option on a live fd); if it somehow
+            // does, the stale error was left unconsumed and the next read will surface it.
+            Err(e) => log::warn!(
+                "could not clear the pending error on the re-bound capture for {}: {e}",
+                self.name
+            ),
+        }
+        log::debug!(
+            "re-bound AF_PACKET capture to {} (ifindex {ifindex})",
+            self.name
+        );
+        Ok(())
+    }
+
+    /// Whether the socket is still hooked to the live interface with kernel index `ifindex`.
+    /// `getsockname` reports the bound index, which the kernel resets to -1 when the bound
+    /// interface is unregistered, so a destroyed (or destroyed-and-recreated) interface
+    /// compares unequal. A `getsockname` failure counts as detached.
+    #[allow(dead_code)] // wired up by the interface reconcile
+    pub(crate) fn attached(&self, ifindex: u32) -> bool {
+        // SAFETY: an all-zero sockaddr_ll is a valid out-param; the kernel fills it up to `len`.
+        let mut addr: libc::sockaddr_ll = unsafe { core::mem::zeroed() };
+        let mut len = socklen_of::<libc::sockaddr_ll>();
+        // SAFETY: `addr`/`len` are valid out-params for the socket's own address.
+        let rc = unsafe {
+            libc::getsockname(
+                self.fd.as_raw_fd(),
+                (&raw mut addr).cast::<libc::sockaddr>(),
+                &raw mut len,
+            )
+        };
+        rc == 0 && u32::try_from(addr.sll_ifindex).is_ok_and(|bound| bound == ifindex)
     }
 
     /// The link framing: always Ethernet on Linux, loopback included.
@@ -192,6 +240,18 @@ fn drop_outgoing_filter() -> [BpfInsn; DROP_OUTGOING_FILTER_LEN] {
         Some(&prologue_insn) => prologue_insn,
         None => ETHERNET_UDP_FILTER[i - DROP_OUTGOING_PROLOGUE.len()],
     })
+}
+
+/// Resolve `if_name` to its kernel index as the `c_int` a `sockaddr_ll` carries, with a clear
+/// error while no interface bears the name.
+fn resolve_ifindex(if_name: &str) -> io::Result<c_int> {
+    let ifindex = if_index(if_name).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("interface {if_name} not found"),
+        )
+    })?;
+    c_int::try_from(ifindex).map_err(|_| io::Error::other("interface index too large"))
 }
 
 /// A zeroed `sockaddr_ll` addressed to `ifindex` for the bind (family set, protocol left zero;

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -91,7 +91,6 @@ impl Capture {
     /// # Errors
     /// [`io::ErrorKind::NotFound`] while no interface bears the name; otherwise the `bind`
     /// failure.
-    #[allow(dead_code)] // wired up by the interface reconcile
     pub(crate) fn rebind(&mut self) -> io::Result<()> {
         let ifindex = resolve_ifindex(&self.name)?;
         bind_interface(&self.fd, link_addr(ifindex))?;
@@ -122,7 +121,6 @@ impl Capture {
     /// `getsockname` reports the bound index, which the kernel resets to -1 when the bound
     /// interface is unregistered, so a destroyed (or destroyed-and-recreated) interface
     /// compares unequal. A `getsockname` failure counts as detached.
-    #[allow(dead_code)] // wired up by the interface reconcile
     pub(crate) fn attached(&self, ifindex: u32) -> bool {
         // SAFETY: an all-zero sockaddr_ll is a valid out-param; the kernel fills it up to `len`.
         let mut addr: libc::sockaddr_ll = unsafe { core::mem::zeroed() };

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -41,68 +41,13 @@ impl Capture {
     pub(crate) fn open(if_name: &str) -> io::Result<Self> {
         let fd = open_bpf_device()?;
 
-        // Bind to the interface. Capture starts here; the filter below flushes the
-        // buffer, so nothing slips through unfiltered.
-        // SAFETY: all-zero is a valid `ifreq`: `ifr_name` is a byte array and the
-        // `ifr_ifru` union holds only integers/pointers/sockaddr, none with an
-        // invalid zero bit pattern.
-        let mut ifr: libc::ifreq = unsafe { core::mem::zeroed() };
-        let name = if_name.as_bytes();
-        if name.len() >= ifr.ifr_name.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "interface name too long",
-            ));
-        }
-        // SAFETY: `ifr_name` is a `[c_char; IFNAMSIZ]`; we checked `name` fits with
-        // room for the zero terminator the zeroed `ifr` already provides.
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                name.as_ptr(),
-                ifr.ifr_name.as_mut_ptr().cast::<u8>(),
-                name.len(),
-            );
-        }
-        ioctl(&fd, libc::BIOCSETIF, (&raw mut ifr).cast())?;
-
-        // The link framing selects the filter and the see-sent handling below.
-        let mut dlt: c_uint = 0;
-        ioctl(&fd, libc::BIOCGDLT, (&raw mut dlt).cast())?;
-        let link_type = match dlt {
-            DLT_EN10MB => LinkType::Ethernet,
-            DLT_NULL => LinkType::DltNull,
-            other => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Unsupported,
-                    format!("unsupported BPF link type {other} (need DLT_EN10MB or DLT_NULL)"),
-                ));
-            }
-        };
+        // Bind to the interface. Capture starts here; the filter installed by `attach`
+        // flushes the buffer, so nothing slips through unfiltered.
+        let link_type = attach(&fd, if_name)?;
 
         // Deliver each frame as it arrives instead of blocking until the buffer fills.
         let mut immediate: c_uint = 1;
         ioctl(&fd, libc::BIOCIMMEDIATE, (&raw mut immediate).cast())?;
-
-        // Loop prevention on Ethernet: don't hand us our own egress, so two mirrored
-        // reflector entries don't ping-pong each other's frames. Skip it on DLT_NULL
-        // links: the BSD lo driver taps each frame once (and tags it outbound), so
-        // default BPF already delivers it; clearing see-sent (= receive-only) would
-        // instead silence the interface entirely.
-        if link_type == LinkType::Ethernet {
-            let mut see_sent: c_uint = 0;
-            ioctl(&fd, libc::BIOCSSEESENT, (&raw mut see_sent).cast())?;
-        }
-
-        // Install the link-appropriate UDP filter (and flush whatever queued before it).
-        let filter: &[BpfInsn] = match link_type {
-            LinkType::Ethernet => &ETHERNET_UDP_FILTER,
-            LinkType::DltNull => &DLT_NULL_UDP_FILTER,
-        };
-        let mut program = BpfProgram {
-            bf_len: c_uint::try_from(filter.len()).expect("filter length fits c_uint"),
-            bf_insns: filter.as_ptr().cast_mut(),
-        };
-        ioctl(&fd, libc::BIOCSETF, (&raw mut program).cast())?;
 
         // Size the read buffer to the kernel's preferred BPF buffer length.
         let mut blen: c_uint = 0;
@@ -122,6 +67,42 @@ impl Capture {
             link_type,
             name: if_name.into(),
         })
+    }
+
+    /// Re-attach the descriptor to the interface currently named at open. The kernel detaches
+    /// it when its interface is destroyed and never re-attaches it on its own, so this is the
+    /// recovery path after a recreation: `BIOCSETIF` from the detached state is the same path
+    /// as the initial attach, and it resets the kernel buffer. The fd is unchanged, so the
+    /// reactor's watch stays valid; the framing (and with it the filter and see-sent policy)
+    /// is re-derived in case the interface came back different.
+    ///
+    /// # Errors
+    /// The attach ioctl failure while no interface bears the name, or an unsupported link type.
+    #[allow(dead_code)] // wired up by the interface reconcile
+    pub(crate) fn rebind(&mut self) -> io::Result<()> {
+        self.link_type = attach(&self.fd, &self.name)?;
+        // The kernel reset its buffer at the re-attach; drop the drained-batch state to
+        // match, discarding any stale frames from the old interface.
+        self.filled = 0;
+        self.offset = 0;
+        log::debug!(
+            "re-bound BPF capture to {} ({:?})",
+            self.name,
+            self.link_type
+        );
+        Ok(())
+    }
+
+    /// Whether the descriptor is still attached to a live interface. The kernel clears the
+    /// attachment when the interface is destroyed, after which per-attachment ioctls fail --
+    /// and a recreated interface (same name, even a reused index) never re-attaches the old
+    /// descriptor, so this probe catches recreation where index comparison can't. `ifindex`
+    /// is unused: BPF attachment is to the kernel object itself; the parameter keeps the
+    /// signature uniform with the `AF_PACKET` backend, which compares bound indexes.
+    #[allow(dead_code)] // wired up by the interface reconcile
+    pub(crate) fn attached(&self, _ifindex: u32) -> bool {
+        let mut dlt: c_uint = 0;
+        ioctl(&self.fd, libc::BIOCGDLT, (&raw mut dlt).cast()).is_ok()
     }
 
     /// The link-layer framing of the captured frames, so a consumer can strip the
@@ -266,6 +247,69 @@ fn parse_record(record: &[u8]) -> io::Result<(Record, usize)> {
         ));
     }
     Ok((Record::Frame(frame_start..frame_end), advance))
+}
+
+/// Attach `fd` to `if_name` and normalize the per-attachment state: read the link framing,
+/// set the see-sent policy for it, and install the matching UDP filter (`BIOCSETF` also
+/// flushes anything captured since the bind, so nothing slips through unfiltered). Shared by
+/// [`Capture::open`] and [`Capture::rebind`]; per-descriptor settings (immediate mode, buffer
+/// size) stay in `open`, since they survive re-attachment.
+fn attach(fd: &OwnedFd, if_name: &str) -> io::Result<LinkType> {
+    // SAFETY: all-zero is a valid `ifreq`: `ifr_name` is a byte array and the `ifr_ifru`
+    // union holds only integers/pointers/sockaddr, none with an invalid zero bit pattern.
+    let mut ifr: libc::ifreq = unsafe { core::mem::zeroed() };
+    let name = if_name.as_bytes();
+    if name.len() >= ifr.ifr_name.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "interface name too long",
+        ));
+    }
+    // SAFETY: `ifr_name` is a `[c_char; IFNAMSIZ]`; we checked `name` fits with
+    // room for the zero terminator the zeroed `ifr` already provides.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            name.as_ptr(),
+            ifr.ifr_name.as_mut_ptr().cast::<u8>(),
+            name.len(),
+        );
+    }
+    ioctl(fd, libc::BIOCSETIF, (&raw mut ifr).cast())?;
+
+    // The link framing selects the filter and the see-sent handling below.
+    let mut dlt: c_uint = 0;
+    ioctl(fd, libc::BIOCGDLT, (&raw mut dlt).cast())?;
+    let link_type = match dlt {
+        DLT_EN10MB => LinkType::Ethernet,
+        DLT_NULL => LinkType::DltNull,
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("unsupported BPF link type {other} (need DLT_EN10MB or DLT_NULL)"),
+            ));
+        }
+    };
+
+    // Loop prevention on Ethernet: don't hand us our own egress, so two mirrored
+    // reflector entries don't ping-pong each other's frames. On DLT_NULL links see-sent
+    // stays on: the BSD lo driver taps each frame once (and tags it outbound), so
+    // default BPF already delivers it; receive-only would instead silence the interface
+    // entirely. Set explicitly both ways so a rebind onto different framing restores the
+    // right mode.
+    let mut see_sent: c_uint = c_uint::from(link_type == LinkType::DltNull);
+    ioctl(fd, libc::BIOCSSEESENT, (&raw mut see_sent).cast())?;
+
+    // Install the link-appropriate UDP filter (and flush whatever queued before it).
+    let filter: &[BpfInsn] = match link_type {
+        LinkType::Ethernet => &ETHERNET_UDP_FILTER,
+        LinkType::DltNull => &DLT_NULL_UDP_FILTER,
+    };
+    let mut program = BpfProgram {
+        bf_len: c_uint::try_from(filter.len()).expect("filter length fits c_uint"),
+        bf_insns: filter.as_ptr().cast_mut(),
+    };
+    ioctl(fd, libc::BIOCSETF, (&raw mut program).cast())?;
+    Ok(link_type)
 }
 
 /// Open the first available `/dev/bpfN`.

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -78,7 +78,6 @@ impl Capture {
     ///
     /// # Errors
     /// The attach ioctl failure while no interface bears the name, or an unsupported link type.
-    #[allow(dead_code)] // wired up by the interface reconcile
     pub(crate) fn rebind(&mut self) -> io::Result<()> {
         self.link_type = attach(&self.fd, &self.name)?;
         // The kernel reset its buffer at the re-attach; drop the drained-batch state to
@@ -99,7 +98,6 @@ impl Capture {
     /// descriptor, so this probe catches recreation where index comparison can't. `ifindex`
     /// is unused: BPF attachment is to the kernel object itself; the parameter keeps the
     /// signature uniform with the `AF_PACKET` backend, which compares bound indexes.
-    #[allow(dead_code)] // wired up by the interface reconcile
     pub(crate) fn attached(&self, _ifindex: u32) -> bool {
         let mut dlt: c_uint = 0;
         ioctl(&self.fd, libc::BIOCGDLT, (&raw mut dlt).cast()).is_ok()

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -56,6 +56,15 @@ const MAX_FRAMES_PER_EVENT: u32 = 64;
 /// (via [`to_u64`](CaptureKey::to_u64)), so `u64::MAX` never collides with a real capture.
 const MONITOR_TAG: u64 = u64::MAX;
 
+/// The reconcile's periodic floor: the guarantee that an interface recreation whose every
+/// event was lost (macOS's silent route-socket overflow) is still detected. Cheap while
+/// healthy -- one name lookup per watched interface plus one kernel probe per capture.
+const RECONCILE_TICK: Duration = Duration::from_secs(30);
+
+/// The reconcile cadence while an interface is parked absent or a rebuild step failed: the
+/// retry driver that picks up the interface's return and re-attempts failed re-binds.
+const RECONCILE_RETRY: Duration = Duration::from_secs(1);
+
 /// The dispatcher's reused send-buffer size. A standard-MTU datagram fits. One buffer serves
 /// every reflector: the single-threaded loop runs one [`send_udp_group`](PacketDispatcher::send_udp_group)
 /// at a time. An oversized payload is a `BufferTooSmall` error, not a truncation. It also caps a
@@ -233,6 +242,15 @@ pub(crate) struct PacketDispatcher {
     scratch: Box<[u8]>,
     /// The periodic counter-summary schedule, or `None` when the summary is disabled.
     report: Option<CounterReport>,
+    /// The largest kernel ifindex seen: the watched interfaces' own, raised by every drained
+    /// notification. On monotonic platforms ([`InterfaceMonitor::INDEXES_MONOTONIC`]) an
+    /// unknown-index Link event at or below this ceiling is churn on an existing unwatched
+    /// interface, not a creation, so it doesn't trigger the reconcile.
+    max_seen_ifindex: u32,
+    /// When the next reconcile pass is due: the [`RECONCILE_TICK`] floor when healthy,
+    /// [`RECONCILE_RETRY`] while an interface is parked absent or a rebuild step failed, `now`
+    /// when a capture read error pulls it forward.
+    next_reconcile: Instant,
 }
 
 impl PacketDispatcher {
@@ -248,6 +266,8 @@ impl PacketDispatcher {
             dial: DialContext::new(),
             scratch: vec![0u8; SCRATCH_LEN].into_boxed_slice(),
             report: None,
+            max_seen_ifindex: 0,
+            next_reconcile: Instant::now() + RECONCILE_TICK,
         }
     }
 
@@ -285,6 +305,10 @@ impl PacketDispatcher {
     pub(crate) fn add_capture(&mut self, capture: Capture) -> io::Result<CaptureKey> {
         let interface = self.table.find_or_add_interface(capture.if_name())?;
         let key = self.table.add_capture(capture, interface);
+        // Seed the seen-index ceiling with the watched interfaces' own identities.
+        self.max_seen_ifindex = self
+            .max_seen_ifindex
+            .max(self.table.interface_index(interface).unwrap_or(0));
         if let Some(name) = self.table.interface_name(interface) {
             log::debug!("watching {name} as capture {key:?}");
         }
@@ -480,6 +504,14 @@ impl PacketDispatcher {
                 Ok(None) => break,
                 Err(e) => {
                     log::error!("fd {fd}: capture read failed, abandoning batch: {e}");
+                    // A dead capture's read error (Linux parks ENETDOWN on the unregistered
+                    // packet socket; a detached BPF descriptor reads ENXIO): pull the
+                    // reconcile forward -- it must not run from here, mid-drain, with this
+                    // capture taken out of its slot. Other read errors are left to the tick;
+                    // they say nothing about the interface.
+                    if matches!(e.raw_os_error(), Some(libc::ENETDOWN | libc::ENXIO)) {
+                        self.next_reconcile = Instant::now();
+                    }
                     break;
                 }
             };
@@ -574,17 +606,27 @@ impl PacketDispatcher {
     /// coalescing duplicates so one interface re-resolves at most once per wakeup. An
     /// [`InterfaceEvent::Overflow`] re-resolves every interface. Best-effort: a read or
     /// resolution failure logs and is dropped, and the daemon keeps its last-known addresses.
+    ///
+    /// Doubles as the recreation detector: events that can announce a destroyed or recreated
+    /// interface run the reconcile afterwards. A `Link` event on a watched interface, or one
+    /// carrying an index above everything seen (a creation, on platforms whose indexes are
+    /// monotonic), or any unknown-index event where no lifecycle messages exist (macOS), or an
+    /// overflow (the announcement may be among the drops) -- and, for a recreation that reused
+    /// the watched index, a per-capture kernel probe on every matched refresh.
     fn refresh_changed_interfaces(&mut self, reactor: &mut Reactor) {
         let Some(monitor) = self.monitor.as_mut() else {
             return;
         };
-        let mut changed: Vec<u32> = Vec::new();
+        // Coalesce to one (ifindex, saw-a-Link-event) row per interface.
+        let mut changed: Vec<(u32, bool)> = Vec::new();
         let mut overflow = false;
         if let Err(e) = monitor.drain(|event| match event {
             InterfaceEvent::Overflow => overflow = true,
             InterfaceEvent::Address(ifindex) | InterfaceEvent::Link(ifindex) => {
-                if !changed.contains(&ifindex) {
-                    changed.push(ifindex);
+                let is_link = matches!(event, InterfaceEvent::Link(_));
+                match changed.iter_mut().find(|(seen, _)| *seen == ifindex) {
+                    Some((_, link)) => *link |= is_link,
+                    None => changed.push((ifindex, is_link)),
                 }
             }
         }) {
@@ -598,6 +640,13 @@ impl PacketDispatcher {
         if changed.is_empty() && !overflow {
             return; // nothing collected (a spurious wakeup, or a drain error before the first read)
         }
+        // The creation gate compares against the ceiling from BEFORE this batch: the creation's
+        // own Link event would otherwise raise the ceiling past itself and slip through.
+        let prior_ceiling = self.max_seen_ifindex;
+        for (ifindex, _) in &changed {
+            self.max_seen_ifindex = self.max_seen_ifindex.max(*ifindex);
+        }
+        let mut want_reconcile = overflow;
         // The DIAL proxies bind IPv4 only, so collect the interfaces whose v4 address actually moved. A
         // routine v6 or MAC change must not churn a proxy whose v4 (and cached LOCATION) is unchanged.
         let mut v4_moved: Vec<u32> = Vec::new();
@@ -621,15 +670,34 @@ impl PacketDispatcher {
                 }
             }
         } else {
-            for ifindex in &changed {
+            for (ifindex, is_link) in &changed {
                 match self.table.refresh_by_ifindex(*ifindex) {
                     Ok(Some(change)) => {
                         log::debug!("re-resolved interface (ifindex {ifindex}) after a change");
                         if change.v4 {
                             v4_moved.push(*ifindex);
                         }
+                        // A lifecycle event on a watched interface, or a capture whose kernel
+                        // binding died behind this (possibly reused) index: reconcile.
+                        if *is_link || !self.table.probe_by_ifindex(*ifindex) {
+                            want_reconcile = true;
+                        }
                     }
-                    Ok(None) => {} // a change on an interface we don't watch
+                    Ok(None) => {
+                        // An interface we don't watch -- unless it is one of ours, recreated
+                        // under a new index. A Link event above every index seen so far is a
+                        // creation where indexes are monotonic; where they aren't (FreeBSD),
+                        // any Link announcement reconciles; where lifecycle events don't
+                        // exist at all (macOS), any unknown-index event has to.
+                        let creation = if InterfaceMonitor::INDEXES_MONOTONIC {
+                            *is_link && *ifindex > prior_ceiling
+                        } else {
+                            *is_link
+                        };
+                        if creation || !InterfaceMonitor::LIFECYCLE_EVENTS {
+                            want_reconcile = true;
+                        }
+                    }
                     Err(e) => {
                         // Same conservative stance as the overflow branch: a failed re-resolve can't
                         // confirm the bound v4 survived (a notification arrived, so something changed),
@@ -643,12 +711,80 @@ impl PacketDispatcher {
             }
         }
         // Evict proxies whose source or target interface lost the v4 address they bound: their listeners
-        // sit on a vanished address and their cached LOCATION is stale, so they must re-mint, not be reused.
+        // sit on a vanished address and their cached LOCATION is stale, so they must re-mint, not be
+        // reused. Before the reconcile: v4_moved and the table's caches are still in the same
+        // identity space here; the reconcile rewrites the caches and does its own eviction.
         self.dial.evict_on_interface_change(reactor, |cap| {
             self.table
                 .ifindex_of(cap)
                 .is_some_and(|ix| v4_moved.contains(&ix))
         });
+        if want_reconcile {
+            self.reconcile_interfaces(reactor);
+        }
+    }
+
+    /// Detect and repair interfaces whose kernel identity moved out from under the table: the
+    /// recreation recovery. Each stale entry is re-pointed at its name's current interface (or
+    /// parked absent), its captures re-bound in place behind their stable keys, and its DIAL
+    /// proxies evicted -- their mint-time snapshots (listener binds, target address, egress
+    /// pin) died with the old interface, whatever the new one's values. Re-arms the next pass:
+    /// the [`RECONCILE_TICK`] floor when healthy, [`RECONCILE_RETRY`] while an interface is
+    /// absent or a rebuild step failed (the probe keeps re-flagging a half-rebuilt entry).
+    fn reconcile_interfaces(&mut self, reactor: &mut Reactor) {
+        let mut pending = false;
+        for stale in self.table.stale_interfaces() {
+            let name = self
+                .table
+                .interface_name(stale.key)
+                .expect("stale keys come from this table's own scan")
+                .to_owned();
+            let captures = self.table.captures_of(stale.key);
+            if stale.cur == 0 {
+                log::info!(
+                    "interface {name} is gone (was ifindex {}); parking until it returns",
+                    stale.cached
+                );
+            } else {
+                log::info!(
+                    "interface {name}: recreated (ifindex {} -> {}); re-binding",
+                    stale.cached,
+                    stale.cur
+                );
+            }
+            if let Err(e) = self.table.rebind_interface(stale.key, stale.cur) {
+                log::warn!("re-resolving {name} failed: {e}; will retry");
+                pending = true;
+            }
+            if stale.cur != 0 {
+                for capture in &captures {
+                    match self.table.rebind_capture(*capture) {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            log::warn!("capture {capture:?} missing during {name}'s rebuild");
+                        }
+                        Err(e) => {
+                            log::warn!("re-binding a capture on {name} failed: {e}; will retry");
+                            pending = true;
+                        }
+                    }
+                }
+            }
+            // The proxies' snapshots reference the dead interface regardless of what the
+            // replacement resolves to, so the eviction is keyed by capture, not by address
+            // deltas (and not through v4_moved, whose indexes predate the rebuild).
+            self.dial
+                .evict_on_interface_change(reactor, |cap| captures.contains(&cap));
+        }
+        // The fast cadence also covers parked interfaces (quiescent, so not in the stale list):
+        // their return must be picked up promptly even if every event for it is lost.
+        let retry = pending || self.table.any_absent();
+        self.next_reconcile = Instant::now()
+            + if retry {
+                RECONCILE_RETRY
+            } else {
+                RECONCILE_TICK
+            };
     }
 }
 
@@ -675,6 +811,7 @@ impl Handler for PacketDispatcher {
             .filter_map(|(_, reg)| reg.handler.as_ref().and_then(|h| h.next_deadline()))
             .chain(self.dial.next_grace()) // and the soonest DIAL proxy grace, for its eviction sweep
             .chain(self.report.as_ref().map(|r| r.next)) // and the next counter summary, if enabled
+            .chain(Some(self.next_reconcile)) // and the interface reconcile tick
             .min()
     }
 
@@ -718,6 +855,12 @@ impl Handler for PacketDispatcher {
             log_counters(self.table.counter_rows());
             report.next = now + report.interval;
         }
+
+        // The interface reconcile tick (it re-arms itself): the detection floor for
+        // recreations whose events were lost, and the retry driver while one is mid-recovery.
+        if now >= self.next_reconcile {
+            self.reconcile_interfaces(reactor);
+        }
     }
 
     /// A SIGUSR1 diagnostics dump: log the per-interface counter summary on demand. Independent of the
@@ -744,6 +887,65 @@ mod tests {
         pub(crate) fn registration_count(&self) -> usize {
             self.registrations.iter().count()
         }
+    }
+
+    // The reconcile detects a cached identity that moved (corrupted here through the test
+    // seam, as a recreation would move it) and repairs it in place, then re-arms the slow
+    // tick. Unprivileged: resolution only, no captures.
+    #[test]
+    fn reconcile_repairs_a_moved_identity_and_arms_the_slow_tick() -> io::Result<()> {
+        let mut reactor = Reactor::new()?;
+        let mut dispatcher = PacketDispatcher::new();
+        let key = dispatcher.table.find_or_add_interface(LOOPBACK_IFACE)?;
+        let real = crate::interface::if_index(LOOPBACK_IFACE).expect("loopback has an ifindex");
+        dispatcher.table.set_test_ifindex(key, real + 1000);
+        assert!(!dispatcher.table.stale_interfaces().is_empty());
+
+        dispatcher.reconcile_interfaces(&mut reactor);
+
+        assert!(
+            dispatcher.table.stale_interfaces().is_empty(),
+            "the moved identity is repaired"
+        );
+        assert!(
+            dispatcher.next_reconcile > Instant::now() + RECONCILE_RETRY,
+            "a healthy table re-arms the slow tick, not the retry"
+        );
+        Ok(())
+    }
+
+    // A vanished interface parks (identity 0, quiescent thereafter) and keeps the fast retry
+    // cadence armed, so its return is picked up promptly even with every event lost.
+    #[test]
+    fn reconcile_parks_a_vanished_interface_and_keeps_the_fast_retry() -> io::Result<()> {
+        let mut reactor = Reactor::new()?;
+        let mut dispatcher = PacketDispatcher::new();
+        let key = dispatcher.table.find_or_add_interface(LOOPBACK_IFACE)?;
+        dispatcher.table.set_test_name(key, "reflector-gone0");
+
+        dispatcher.reconcile_interfaces(&mut reactor);
+
+        assert!(
+            dispatcher.table.stale_interfaces().is_empty(),
+            "a parked entry is quiescent, not perpetually stale"
+        );
+        assert!(dispatcher.table.any_absent());
+        assert!(
+            dispatcher.next_reconcile <= Instant::now() + RECONCILE_RETRY,
+            "an absent interface keeps the fast retry cadence"
+        );
+        // The interface "returns" (the name resolves again): the next pass rebuilds it.
+        dispatcher.table.set_test_name(key, LOOPBACK_IFACE);
+        dispatcher.reconcile_interfaces(&mut reactor);
+        assert!(
+            !dispatcher.table.any_absent(),
+            "the returned interface is re-pointed"
+        );
+        assert!(
+            dispatcher.next_reconcile > Instant::now() + RECONCILE_RETRY,
+            "recovery re-arms the slow tick"
+        );
+        Ok(())
     }
 
     fn packet(
@@ -1161,11 +1363,12 @@ mod tests {
         let now = Instant::now();
         assert_eq!(
             dispatcher.next_deadline(),
-            None,
-            "no deadline until enabled"
+            Some(dispatcher.next_reconcile),
+            "until enabled, the only standing deadline is the reconcile tick"
         );
 
-        let interval = Duration::from_secs(30);
+        // Shorter than RECONCILE_TICK, so the report deadline is the min() at each assert.
+        let interval = Duration::from_secs(5);
         dispatcher.enable_counter_report(interval, now);
         assert_eq!(dispatcher.next_deadline(), Some(now + interval));
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -398,9 +398,10 @@ impl PacketDispatcher {
         (&mut self.dial, target_iface)
     }
 
-    /// The kernel ifindex of the interface behind `capture`, its stable identity (the address
-    /// resolver caches it at open, and the joiners bake it too). The SSDP/WSD search reflectors read
-    /// it per session for their IPv6 link-local reserved-port binds. `None` if the key is unknown.
+    /// The kernel ifindex of the interface behind `capture`: the table's cached identity,
+    /// re-pointed by the reconcile when the interface is recreated (0 while it is parked
+    /// absent). The SSDP/WSD search reflectors read it per session for their IPv6 link-local
+    /// reserved-port binds. `None` if the key is unknown.
     pub(crate) fn capture_ifindex(&self, capture: CaptureKey) -> Option<u32> {
         self.table.ifindex_of(capture)
     }
@@ -503,14 +504,17 @@ impl PacketDispatcher {
                 Ok(Some(frame)) => frame,
                 Ok(None) => break,
                 Err(e) => {
-                    log::error!("fd {fd}: capture read failed, abandoning batch: {e}");
                     // A dead capture's read error (Linux parks ENETDOWN on the unregistered
-                    // packet socket; a detached BPF descriptor reads ENXIO): pull the
-                    // reconcile forward -- it must not run from here, mid-drain, with this
-                    // capture taken out of its slot. Other read errors are left to the tick;
+                    // packet socket; a detached BPF descriptor reads ENXIO) is the expected
+                    // first sign of an interface destruction: pull the reconcile forward --
+                    // it must not run from here, mid-drain, with this capture taken out of
+                    // its slot. Other read errors are real failures and are left to the tick;
                     // they say nothing about the interface.
                     if matches!(e.raw_os_error(), Some(libc::ENETDOWN | libc::ENXIO)) {
+                        log::info!("fd {fd}: capture lost its interface ({e}); reconciling");
                         self.next_reconcile = Instant::now();
+                    } else {
+                        log::error!("fd {fd}: capture read failed, abandoning batch: {e}");
                     }
                     break;
                 }
@@ -702,10 +706,12 @@ impl PacketDispatcher {
                         // Same conservative stance as the overflow branch: a failed re-resolve can't
                         // confirm the bound v4 survived (a notification arrived, so something changed),
                         // so evict any proxy on it rather than risk a stale, silently-dead listener.
+                        // Reconcile, since it can't confirm the interface survived either.
                         log::warn!(
                             "re-resolving ifindex {ifindex} failed: {e}; evicting its proxies"
                         );
                         v4_moved.push(*ifindex);
+                        want_reconcile = true;
                     }
                 }
             }
@@ -714,11 +720,15 @@ impl PacketDispatcher {
         // sit on a vanished address and their cached LOCATION is stale, so they must re-mint, not be
         // reused. Before the reconcile: v4_moved and the table's caches are still in the same
         // identity space here; the reconcile rewrites the caches and does its own eviction.
-        self.dial.evict_on_interface_change(reactor, |cap| {
-            self.table
-                .ifindex_of(cap)
-                .is_some_and(|ix| v4_moved.contains(&ix))
-        });
+        self.dial.evict_on_interface_change(
+            reactor,
+            |cap| {
+                self.table
+                    .ifindex_of(cap)
+                    .is_some_and(|ix| v4_moved.contains(&ix))
+            },
+            "after its interface's address changed",
+        );
         if want_reconcile {
             self.reconcile_interfaces(reactor);
         }
@@ -740,21 +750,34 @@ impl PacketDispatcher {
                 .expect("stale keys come from this table's own scan")
                 .to_owned();
             let captures = self.table.captures_of(stale.key);
-            if stale.cur == 0 {
-                log::info!(
-                    "interface {name} is gone (was ifindex {}); parking until it returns",
-                    stale.cached
-                );
-            } else {
-                log::info!(
-                    "interface {name}: recreated (ifindex {} -> {}); re-binding",
-                    stale.cached,
-                    stale.cur
-                );
+            let mut failed = false;
+            match (stale.cached, stale.cur) {
+                (was, 0) => {
+                    log::info!(
+                        "interface {name} is gone (was ifindex {was}); parking until it returns"
+                    );
+                }
+                (0, now) => {
+                    log::info!("interface {name}: returned as ifindex {now}; re-binding");
+                }
+                (was, now) => {
+                    log::info!("interface {name}: recreated (ifindex {was} -> {now}); re-binding");
+                }
             }
-            if let Err(e) = self.table.rebind_interface(stale.key, stale.cur) {
-                log::warn!("re-resolving {name} failed: {e}; will retry");
-                pending = true;
+            match self.table.rebind_interface(stale.key, stale.cur) {
+                // Deferred joins are usually "no address yet" and heal on the interface's next
+                // address event, but after a recreation a deaf group is a real outage: warn.
+                Ok(deferred) if deferred > 0 => {
+                    log::warn!(
+                        "{deferred} group membership(s) on {name} not re-joined yet; retrying \
+                         on its next address event"
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!("re-resolving {name} failed: {e}; will retry");
+                    failed = true;
+                }
             }
             if stale.cur != 0 {
                 for capture in &captures {
@@ -765,7 +788,7 @@ impl PacketDispatcher {
                         }
                         Err(e) => {
                             log::warn!("re-binding a capture on {name} failed: {e}; will retry");
-                            pending = true;
+                            failed = true;
                         }
                     }
                 }
@@ -773,8 +796,17 @@ impl PacketDispatcher {
             // The proxies' snapshots reference the dead interface regardless of what the
             // replacement resolves to, so the eviction is keyed by capture, not by address
             // deltas (and not through v4_moved, whose indexes predate the rebuild).
+            let reason = if stale.cur == 0 {
+                "after its interface was removed"
+            } else {
+                "after its interface was recreated"
+            };
             self.dial
-                .evict_on_interface_change(reactor, |cap| captures.contains(&cap));
+                .evict_on_interface_change(reactor, |cap| captures.contains(&cap), reason);
+            if stale.cur != 0 && !failed {
+                log::info!("interface {name}: recovery complete");
+            }
+            pending |= failed;
         }
         // The fast cadence also covers parked interfaces (quiescent, so not in the stale list):
         // their return must be picked up promptly even if every event for it is lost.

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -36,7 +36,7 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
 use crate::capture::Capture;
-use crate::interface::{InterfaceAddresses, InterfaceMonitor};
+use crate::interface::{InterfaceAddresses, InterfaceEvent, InterfaceMonitor};
 use crate::net::LinkType;
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
@@ -571,17 +571,21 @@ impl PacketDispatcher {
     }
 
     /// Drain the interface monitor and re-resolve each interface a notification names,
-    /// coalescing duplicates so one interface re-resolves at most once per wakeup. A `0`
-    /// (the overflow signal) re-resolves every interface. Best-effort: a read or resolution
-    /// failure logs and is dropped, and the daemon keeps its last-known addresses.
+    /// coalescing duplicates so one interface re-resolves at most once per wakeup. An
+    /// [`InterfaceEvent::Overflow`] re-resolves every interface. Best-effort: a read or
+    /// resolution failure logs and is dropped, and the daemon keeps its last-known addresses.
     fn refresh_changed_interfaces(&mut self, reactor: &mut Reactor) {
         let Some(monitor) = self.monitor.as_mut() else {
             return;
         };
         let mut changed: Vec<u32> = Vec::new();
-        if let Err(e) = monitor.drain(|ifindex| {
-            if !changed.contains(&ifindex) {
-                changed.push(ifindex);
+        let mut overflow = false;
+        if let Err(e) = monitor.drain(|event| match event {
+            InterfaceEvent::Overflow => overflow = true,
+            InterfaceEvent::Address(ifindex) | InterfaceEvent::Link(ifindex) => {
+                if !changed.contains(&ifindex) {
+                    changed.push(ifindex);
+                }
             }
         }) {
             // The drain already consumed and collected these notifications before failing, so refresh
@@ -591,14 +595,14 @@ impl PacketDispatcher {
                 "interface monitor read failed mid-drain; refreshing what was collected: {e}"
             );
         }
-        if changed.is_empty() {
+        if changed.is_empty() && !overflow {
             return; // nothing collected (a spurious wakeup, or a drain error before the first read)
         }
         // The DIAL proxies bind IPv4 only, so collect the interfaces whose v4 address actually moved. A
         // routine v6 or MAC change must not churn a proxy whose v4 (and cached LOCATION) is unchanged.
         let mut v4_moved: Vec<u32> = Vec::new();
-        if changed.contains(&0) {
-            // 0 is the overflow signal: notifications were dropped, so re-resolve every interface.
+        if overflow {
+            // Notifications were dropped, so re-resolve every interface.
             log::debug!("interface monitor overflow; re-resolving all interfaces");
             for (ifindex, result) in self.table.refresh_all() {
                 match result {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -205,6 +205,19 @@ pub(crate) trait PacketHandler {
         _reactor: &mut Reactor,
     ) {
     }
+
+    /// One of `captures` was rebound to a recreated interface or had an address moved, so any state
+    /// this handler pinned to it (a reserved port, a response registration) may be stale. The search
+    /// reflectors drop their sessions on that interface; most handlers re-resolve per packet and keep
+    /// nothing, so the default is a no-op. Broadcast to every handler after the dispatcher has already
+    /// repaired the table, so `dispatcher` reads current state.
+    fn on_iface_change(
+        &mut self,
+        _captures: &[CaptureKey],
+        _dispatcher: &mut PacketDispatcher,
+        _reactor: &mut Reactor,
+    ) {
+    }
 }
 
 /// One routing registration: the ingress it applies to, its filter, and the reflector
@@ -654,22 +667,36 @@ impl PacketDispatcher {
         // The DIAL proxies bind IPv4 only, so collect the interfaces whose v4 address actually moved. A
         // routine v6 or MAC change must not churn a proxy whose v4 (and cached LOCATION) is unchanged.
         let mut v4_moved: Vec<u32> = Vec::new();
+        // Interfaces whose addresses actually moved this cycle, for the session notification below:
+        // search reflectors drop sessions whose reserved port was bound to a re-addressed interface.
+        // Only a real address delta (either family) qualifies, not a benign Link / no-op-Address event,
+        // so a healthy session survives a carrier flap or an unrelated interface's churn. (DIAL is
+        // v4-only via v4_moved; sessions can be either family. Recreations are handled by the reconcile,
+        // keyed by capture, so they need no entry here.)
+        let mut touched: Vec<u32> = Vec::new();
         if overflow {
             // Notifications were dropped, so re-resolve every interface.
             log::debug!("interface monitor overflow; re-resolving all interfaces");
             for (ifindex, result) in self.table.refresh_all() {
                 match result {
-                    Ok(change) if change.v4 => v4_moved.push(ifindex),
-                    Ok(_) => {}
+                    Ok(change) => {
+                        if change.v4 {
+                            v4_moved.push(ifindex);
+                        }
+                        if change.v4 || change.v6 {
+                            touched.push(ifindex);
+                        }
+                    }
                     Err(e) => {
                         // The overflow already means notifications were dropped, so this is the one
-                        // chance to catch a move whose event was lost, and we can't confirm the v4
-                        // survived. Treat it as moved so any DIAL proxy on it re-mints rather than
-                        // keeping listeners bound to (and advertising) a possibly-vanished address.
+                        // chance to catch a move whose event was lost, and we can't confirm the address
+                        // survived. Treat it as moved so any DIAL proxy re-mints and any session drops
+                        // rather than keeping a listener bound to a possibly-vanished address.
                         log::warn!(
                             "re-resolving ifindex {ifindex} failed: {e}; evicting its proxies"
                         );
                         v4_moved.push(ifindex);
+                        touched.push(ifindex);
                     }
                 }
             }
@@ -680,6 +707,11 @@ impl PacketDispatcher {
                         log::debug!("re-resolved interface (ifindex {ifindex}) after a change");
                         if change.v4 {
                             v4_moved.push(*ifindex);
+                        }
+                        // Only a real address delta invalidates a session's reserved reply address; a
+                        // bare Link event (carrier / MTU / flag) with no delta must not clear sessions.
+                        if change.v4 || change.v6 {
+                            touched.push(*ifindex);
                         }
                         // A lifecycle event on a watched interface, or a capture whose kernel
                         // binding died behind this (possibly reused) index: reconcile.
@@ -711,26 +743,72 @@ impl PacketDispatcher {
                             "re-resolving ifindex {ifindex} failed: {e}; evicting its proxies"
                         );
                         v4_moved.push(*ifindex);
+                        touched.push(*ifindex);
                         want_reconcile = true;
                     }
                 }
             }
         }
-        // Evict proxies whose source or target interface lost the v4 address they bound: their listeners
-        // sit on a vanished address and their cached LOCATION is stale, so they must re-mint, not be
-        // reused. Before the reconcile: v4_moved and the table's caches are still in the same
-        // identity space here; the reconcile rewrites the caches and does its own eviction.
+        // Evict proxies whose source or target interface lost the v4 address they bound, and drop
+        // search sessions whose reserved port was bound to a re-addressed interface. Both keyed by
+        // capture, materialized before the reconcile rewrites the table's caches so the ifindexes here
+        // still map to the pre-change identities. A recreation under a new index resolves to no capture
+        // here and is handled by the reconcile below.
+        let v4_captures = self.captures_for(&v4_moved);
         self.dial.evict_on_interface_change(
             reactor,
-            |cap| {
-                self.table
-                    .ifindex_of(cap)
-                    .is_some_and(|ix| v4_moved.contains(&ix))
-            },
+            &v4_captures,
             "after its interface's address changed",
         );
+        let touched_captures = self.captures_for(&touched);
+        self.notify_iface_change(&touched_captures, reactor);
         if want_reconcile {
             self.reconcile_interfaces(reactor);
+        }
+    }
+
+    /// The captures on the interfaces currently at `ifindexes`, mapping the refresh path's kernel
+    /// indexes to the stable [`CaptureKey`]s the eviction and session notification are keyed by.
+    fn captures_for(&self, ifindexes: &[u32]) -> Vec<CaptureKey> {
+        ifindexes
+            .iter()
+            .flat_map(|ifindex| self.table.captures_at_ifindex(*ifindex))
+            .collect()
+    }
+
+    /// Broadcast [`PacketHandler::on_iface_change`] to every registered handler for the interfaces
+    /// backing `captures`, taking each handler out for its call so `&mut self` is free. Off the data
+    /// path (only the interface-change / reconcile path, which allocates anyway), so it snapshots the
+    /// live keys into a fresh `Vec` rather than a reused scratch. A handler that unregisters a sibling
+    /// mid-broadcast (a search reflector dropping its sessions' response captures) is fine: the vacated
+    /// slot is skipped.
+    fn notify_iface_change(&mut self, captures: &[CaptureKey], reactor: &mut Reactor) {
+        if captures.is_empty() {
+            return;
+        }
+        let keys: Vec<RegistrationKey> = self
+            .registrations
+            .iter()
+            .map(|(key, _)| RegistrationKey(key))
+            .collect();
+        for key in keys {
+            let Some(mut handler) = self
+                .registrations
+                .get_mut(key.0)
+                .and_then(|reg| reg.handler.take())
+            else {
+                // Expected, not an error: an earlier reflector in this broadcast cleared its sessions
+                // and unregistered their response captures, which are in this snapshot, so they resolve
+                // to None here. Mirrors on_deadline's mid-sweep skip.
+                log::trace!(
+                    "iface-change broadcast: handler for {key:?} gone mid-broadcast, skipped"
+                );
+                continue;
+            };
+            handler.on_iface_change(captures, self, reactor);
+            if let Some(reg) = self.registrations.get_mut(key.0) {
+                reg.handler = Some(handler);
+            }
         }
     }
 
@@ -802,7 +880,11 @@ impl PacketDispatcher {
                 "after its interface was recreated"
             };
             self.dial
-                .evict_on_interface_change(reactor, |cap| captures.contains(&cap), reason);
+                .evict_on_interface_change(reactor, &captures, reason);
+            // Drop search sessions on the interface's captures: their reserved port and response
+            // registration belonged to the interface that was removed or recreated (even one that
+            // returned on the same index, which the reconcile reached via the attached() probe).
+            self.notify_iface_change(&captures, reactor);
             if stale.cur != 0 && !failed {
                 log::info!("interface {name}: recovery complete");
             }

--- a/src/dispatch/dial_context.rs
+++ b/src/dispatch/dial_context.rs
@@ -145,14 +145,16 @@ impl DialContext {
     }
 
     /// Evict every proxy whose source or target capture is on a changed interface (`on_changed`): an
-    /// address move there stranded the proxy's listeners or its device-connect egress, so it must re-mint
-    /// against the current addresses on the next advertisement rather than be reused.
+    /// address move or recreation there stranded the proxy's listeners or its device-connect egress,
+    /// so it must re-mint against the current interface on the next advertisement rather than be
+    /// reused. `reason` names the change in the eviction log (address moved vs recreated).
     pub(crate) fn evict_on_interface_change(
         &mut self,
         reactor: &mut Reactor,
         on_changed: impl Fn(CaptureKey) -> bool,
+        reason: &str,
     ) {
-        self.evict_where(reactor, "after its interface's address changed", |p| {
+        self.evict_where(reactor, reason, |p| {
             on_changed(p.source) || on_changed(p.target)
         });
     }

--- a/src/dispatch/dial_context.rs
+++ b/src/dispatch/dial_context.rs
@@ -144,18 +144,18 @@ impl DialContext {
         self.evict_where(reactor, "past its grace", |p| now >= p.desc_grace);
     }
 
-    /// Evict every proxy whose source or target capture is on a changed interface (`on_changed`): an
-    /// address move or recreation there stranded the proxy's listeners or its device-connect egress,
-    /// so it must re-mint against the current interface on the next advertisement rather than be
-    /// reused. `reason` names the change in the eviction log (address moved vs recreated).
+    /// Evict every proxy whose source or target capture is in `changed`: an address move or recreation
+    /// on that interface stranded the proxy's listeners or its device-connect egress, so it must
+    /// re-mint against the current interface on the next advertisement rather than be reused. `reason`
+    /// names the change in the eviction log (address moved vs recreated).
     pub(crate) fn evict_on_interface_change(
         &mut self,
         reactor: &mut Reactor,
-        on_changed: impl Fn(CaptureKey) -> bool,
+        changed: &[CaptureKey],
         reason: &str,
     ) {
         self.evict_where(reactor, reason, |p| {
-            on_changed(p.source) || on_changed(p.target)
+            changed.contains(&p.source) || changed.contains(&p.target)
         });
     }
 }

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -342,6 +342,22 @@ impl InterfaceTable {
             .collect()
     }
 
+    /// The captures on the interface currently at `ifindex`, or empty if none matches. The reverse
+    /// of [`ifindex_of`](Self::ifindex_of): the refresh path knows the changed index and needs the
+    /// stable capture keys to notify handlers, since the index itself is reusable.
+    pub(super) fn captures_at_ifindex(&self, ifindex: u32) -> Vec<CaptureKey> {
+        match self
+            .entries
+            .iter()
+            .position(|entry| entry.interface.ifindex == ifindex)
+        {
+            Some(index) => self.captures_of(InterfaceKey(
+                u32::try_from(index).expect("interface count fits a u32"),
+            )),
+            None => Vec::new(),
+        }
+    }
+
     /// Re-bind the capture behind `key` to its (recreated) interface, in place -- same fd, same
     /// slot, so every reflector-held key and the reactor's watch stay valid. `Ok(false)` means
     /// no capture sat in the slot (out of range, or taken out mid-drain) -- unreachable when

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -6,7 +6,7 @@ use std::net::IpAddr;
 use std::os::fd::{AsRawFd, RawFd};
 
 use crate::capture::Capture;
-use crate::interface::{AddressChange, Interface, InterfaceAddresses};
+use crate::interface::{AddressChange, Interface, InterfaceAddresses, if_index};
 
 use super::CaptureKey;
 use super::counters::{CaptureCounters, Outcome};
@@ -206,6 +206,97 @@ impl InterfaceTable {
         Ok(Some(change))
     }
 
+    /// Every interface whose kernel identity no longer matches the cached state, paired with the
+    /// index its name currently resolves to (0 = the name resolves to nothing). Two disjoint
+    /// staleness modes: the identity moved (recreation with a new index, deletion, rename-away),
+    /// caught by the name lookup; or a capture's kernel binding died behind an unchanged
+    /// identity (a recreated interface reusing its index, or a half-completed earlier rebuild),
+    /// caught by the [`attached`](crate::capture::Capture::attached) probe. Cost: one name
+    /// lookup per interface plus one probe per capture; the dispatcher gates how often this
+    /// runs. Log-free, like the refresh methods.
+    #[allow(dead_code)] // wired up by the dispatcher's reconcile
+    pub(super) fn stale_interfaces(&self) -> Vec<(InterfaceKey, u32)> {
+        self.entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| {
+                let key = InterfaceKey(u32::try_from(index).expect("interface count fits a u32"));
+                let cur = if_index(&entry.interface.name).unwrap_or(0);
+                let dead_capture = |c: &CaptureEntry| {
+                    c.interface == key && c.capture.as_ref().is_some_and(|cap| !cap.attached(cur))
+                };
+                (cur != entry.interface.ifindex || self.captures.iter().any(dead_capture))
+                    .then_some((key, cur))
+            })
+            .collect()
+    }
+
+    /// Re-point interface `key` at the interface currently bearing its name (kernel index
+    /// `cur`, from [`stale_interfaces`](Self::stale_interfaces)), re-resolve its addresses, and
+    /// re-join its groups on fresh sockets (see [`MulticastJoiner::reset`]) -- the join skipped
+    /// while absent (`cur == 0`): a join on index 0 would let the kernel pick an arbitrary
+    /// interface. The refresh still runs while absent -- no backend errors for a missing
+    /// interface (Linux short-circuits on index 0), and the all-absent result is the point:
+    /// addresses clear, so the egress gate closes and the lost-address logs fire. The ifindex
+    /// is updated first: the Linux resolver keys its dumps by it.
+    /// Captures are re-bound separately ([`rebind_capture`](Self::rebind_capture)), so the
+    /// caller can log and retry them per capture. Log-free.
+    ///
+    /// # Errors
+    /// Propagates a resolution syscall failure; the identity and joiner state are already
+    /// updated, and the probe re-flags the entry if captures never re-bind.
+    #[allow(dead_code)] // wired up by the dispatcher's reconcile
+    pub(super) fn rebind_interface(
+        &mut self,
+        key: InterfaceKey,
+        cur: u32,
+    ) -> io::Result<AddressChange> {
+        // Keys come from this table's own scan, so the index is always in range.
+        let entry = &mut self.entries[key.0 as usize];
+        entry.interface.ifindex = cur;
+        entry.joiner.reset();
+        let change = entry.interface.refresh()?;
+        if cur != 0 {
+            entry.joiner.rejoin(cur);
+        }
+        Ok(change)
+    }
+
+    /// The keys of the captures on `interface`, for a rebuild or eviction pass (the reverse of
+    /// [`interface_of`](Self::interface_of); the table keeps no interface->captures index, so
+    /// this is a linear scan over the few captures).
+    #[allow(dead_code)] // wired up by the dispatcher's reconcile
+    pub(super) fn captures_of(&self, interface: InterfaceKey) -> Vec<CaptureKey> {
+        self.captures
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.interface == interface)
+            .map(|(index, _)| CaptureKey(u32::try_from(index).expect("capture count fits a u32")))
+            .collect()
+    }
+
+    /// Re-bind the capture behind `key` to its (recreated) interface, in place -- same fd, same
+    /// slot, so every reflector-held key and the reactor's watch stay valid. `Ok(false)` means
+    /// no capture sat in the slot (out of range, or taken out mid-drain) -- unreachable when
+    /// `key` came from [`captures_of`](Self::captures_of) in the reconcile context, where no
+    /// drain is in flight, so the caller should log it rather than treat it as success (the
+    /// [`restore`](Self::restore) convention). Log-free; a failed re-bind retries via the
+    /// [`attached`](crate::capture::Capture::attached) probe re-flagging the entry.
+    ///
+    /// # Errors
+    /// Propagates the re-bind syscall failure.
+    #[allow(dead_code)] // wired up by the dispatcher's reconcile
+    pub(super) fn rebind_capture(&mut self, key: CaptureKey) -> io::Result<bool> {
+        match self
+            .captures
+            .get_mut(key.0 as usize)
+            .and_then(|entry| entry.capture.as_mut())
+        {
+            Some(capture) => capture.rebind().map(|()| true),
+            None => Ok(false),
+        }
+    }
+
     /// Re-resolve every interface in place. The response to an overflow signal, where dropped
     /// notifications mean any address could be stale. Returns each interface's ifindex paired with
     /// its refresh outcome (best-effort: a per-interface failure is reported, not fatal), so the
@@ -324,6 +415,64 @@ mod tests {
             "re-resolving every interface succeeds",
         );
         Ok(())
+    }
+
+    // stale_interfaces flags an entry whose cached index no longer matches its name's, and
+    // rebind_interface repairs it. Unprivileged: pure resolution, no captures, so the probe
+    // half of the predicate stays vacuous here (pair tests cover it against real interfaces).
+    #[test]
+    fn stale_interfaces_flags_and_rebind_repairs_a_moved_index() -> io::Result<()> {
+        let mut table = InterfaceTable::new();
+        let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
+        assert!(
+            table.stale_interfaces().is_empty(),
+            "a fresh entry is healthy"
+        );
+        let real = if_index(LOOPBACK_IFACE).expect("loopback has an ifindex");
+        // Simulate a recreation: the kernel identity moved while the cache kept the old index.
+        table.entries[key.0 as usize].interface.ifindex = real + 1000;
+        assert_eq!(table.stale_interfaces(), [(key, real)]);
+        table.rebind_interface(key, real)?;
+        assert!(
+            table.stale_interfaces().is_empty(),
+            "the rebuild repaired the identity"
+        );
+        assert_eq!(table.entries[key.0 as usize].interface.ifindex, real);
+        Ok(())
+    }
+
+    // An entry whose name no longer resolves reports absent (0); rebinding to 0 parks it:
+    // identity 0, addresses cleared (the egress gate closes), no join attempted (a join on
+    // index 0 would let the kernel pick an arbitrary interface).
+    #[test]
+    fn rebind_to_absent_parks_the_entry() -> io::Result<()> {
+        let mut table = InterfaceTable::new();
+        let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
+        table.entries[key.0 as usize].interface.name = "reflector-gone0".into();
+        assert_eq!(table.stale_interfaces(), [(key, 0)]);
+        let change = table.rebind_interface(key, 0)?;
+        assert!(
+            change.v4,
+            "loopback's v4 reads as lost when the entry parks"
+        );
+        assert!(
+            table.stale_interfaces().is_empty(),
+            "a parked entry matches its (absent) identity"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn captures_of_maps_the_reverse_link_and_empty_slots_rebind_as_noops() {
+        let mut table = InterfaceTable::new();
+        let a = table.add_test_capture(); // both link InterfaceKey(0)
+        let b = table.add_test_capture();
+        assert_eq!(table.captures_of(InterfaceKey(0)), [a, b]);
+        assert!(table.captures_of(InterfaceKey(1)).is_empty());
+        // Capture-less slots (drained, or test entries with no fd) and out-of-range keys
+        // report Ok(false) -- a signal for the caller to log, not an error and not a success.
+        assert!(matches!(table.rebind_capture(a), Ok(false)));
+        assert!(matches!(table.rebind_capture(CaptureKey(99)), Ok(false)));
     }
 
     #[test]

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -17,6 +17,17 @@ use super::multicast::MulticastJoiner;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(super) struct InterfaceKey(u32);
 
+/// One stale table entry from [`stale_interfaces`](InterfaceTable::stale_interfaces): its
+/// kernel identity moved, or a capture's binding died behind an unchanged identity.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) struct StaleInterface {
+    pub(super) key: InterfaceKey,
+    /// The identity the table still holds (0 = parked absent).
+    pub(super) cached: u32,
+    /// The index the entry's name resolves to now (0 = the name resolves to nothing).
+    pub(super) cur: u32,
+}
+
 /// One capture, the interface it runs on, and its observability tallies. The `capture` is `Option`
 /// so the drain can take it OUT and restore it; the `interface` link and `counters` stay resident,
 /// so a capture's addresses resolve and its routed outcomes still record mid-drain. `None` marks
@@ -117,10 +128,7 @@ impl InterfaceTable {
 
     /// The kernel ifindex of the interface `capture` runs on. Its stable identity, cached at open.
     pub(super) fn ifindex_of(&self, capture: CaptureKey) -> Option<u32> {
-        let interface = self.interface_of(capture)?;
-        self.entries
-            .get(interface.0 as usize)
-            .map(|entry| entry.interface.ifindex)
+        self.interface_index(self.interface_of(capture)?)
     }
 
     /// The name of the interface `interface` keys, if present.
@@ -128,6 +136,13 @@ impl InterfaceTable {
         self.entries
             .get(interface.0 as usize)
             .map(|entry| entry.interface.name.as_str())
+    }
+
+    /// The index of the interface `interface` keys, if present.
+    pub(super) fn interface_index(&self, interface: InterfaceKey) -> Option<u32> {
+        self.entries
+            .get(interface.0 as usize)
+            .map(|entry| entry.interface.ifindex)
     }
 
     /// The current source addresses behind a capture.
@@ -206,29 +221,62 @@ impl InterfaceTable {
         Ok(Some(change))
     }
 
-    /// Every interface whose kernel identity no longer matches the cached state, paired with the
-    /// index its name currently resolves to (0 = the name resolves to nothing). Two disjoint
+    /// Every interface whose kernel identity no longer matches the cached state. Two disjoint
     /// staleness modes: the identity moved (recreation with a new index, deletion, rename-away),
     /// caught by the name lookup; or a capture's kernel binding died behind an unchanged
     /// identity (a recreated interface reusing its index, or a half-completed earlier rebuild),
-    /// caught by the [`attached`](crate::capture::Capture::attached) probe. Cost: one name
+    /// caught by the [`attached`](crate::capture::Capture::attached) probe. An entry parked
+    /// absent (cached 0, name still resolving to nothing) is quiescent, not stale: its captures
+    /// are known-dead and there is nothing to repair until the name returns. Cost: one name
     /// lookup per interface plus one probe per capture; the dispatcher gates how often this
     /// runs. Log-free, like the refresh methods.
-    #[allow(dead_code)] // wired up by the dispatcher's reconcile
-    pub(super) fn stale_interfaces(&self) -> Vec<(InterfaceKey, u32)> {
+    pub(super) fn stale_interfaces(&self) -> Vec<StaleInterface> {
         self.entries
             .iter()
             .enumerate()
             .filter_map(|(index, entry)| {
                 let key = InterfaceKey(u32::try_from(index).expect("interface count fits a u32"));
+                let cached = entry.interface.ifindex;
                 let cur = if_index(&entry.interface.name).unwrap_or(0);
                 let dead_capture = |c: &CaptureEntry| {
                     c.interface == key && c.capture.as_ref().is_some_and(|cap| !cap.attached(cur))
                 };
-                (cur != entry.interface.ifindex || self.captures.iter().any(dead_capture))
-                    .then_some((key, cur))
+                (cur != cached || (cur != 0 && self.captures.iter().any(dead_capture)))
+                    .then_some(StaleInterface { key, cached, cur })
             })
             .collect()
+    }
+
+    /// Whether every capture on the entry whose cached identity is `ifindex` is still attached
+    /// to its live interface (vacuously true with no matching entry). The cheap staleness
+    /// check for a matched notification -- one kernel probe per capture, no name lookups: it
+    /// catches a recreation that reused the index right when the recreated interface's first
+    /// events arrive, instead of waiting for the reconcile tick.
+    pub(super) fn probe_by_ifindex(&self, ifindex: u32) -> bool {
+        let Some(index) = self
+            .entries
+            .iter()
+            .position(|entry| entry.interface.ifindex == ifindex)
+        else {
+            return true;
+        };
+        let key = InterfaceKey(u32::try_from(index).expect("interface count fits a u32"));
+        self.captures.iter().all(|entry| {
+            entry.interface != key
+                || entry
+                    .capture
+                    .as_ref()
+                    .is_none_or(|capture| capture.attached(ifindex))
+        })
+    }
+
+    /// Whether any interface is parked absent (its name resolved to nothing when it was last
+    /// reconciled). The dispatcher keeps the fast reconcile cadence while one is, so the
+    /// interface's return is picked up promptly even if every event for it is lost.
+    pub(super) fn any_absent(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|entry| entry.interface.ifindex == 0)
     }
 
     /// Re-point interface `key` at the interface currently bearing its name (kernel index
@@ -245,27 +293,21 @@ impl InterfaceTable {
     /// # Errors
     /// Propagates a resolution syscall failure; the identity and joiner state are already
     /// updated, and the probe re-flags the entry if captures never re-bind.
-    #[allow(dead_code)] // wired up by the dispatcher's reconcile
-    pub(super) fn rebind_interface(
-        &mut self,
-        key: InterfaceKey,
-        cur: u32,
-    ) -> io::Result<AddressChange> {
+    pub(super) fn rebind_interface(&mut self, key: InterfaceKey, cur: u32) -> io::Result<()> {
         // Keys come from this table's own scan, so the index is always in range.
         let entry = &mut self.entries[key.0 as usize];
         entry.interface.ifindex = cur;
         entry.joiner.reset();
-        let change = entry.interface.refresh()?;
+        entry.interface.refresh()?; // logs each family's gains and losses
         if cur != 0 {
             entry.joiner.rejoin(cur);
         }
-        Ok(change)
+        Ok(())
     }
 
     /// The keys of the captures on `interface`, for a rebuild or eviction pass (the reverse of
     /// [`interface_of`](Self::interface_of); the table keeps no interface->captures index, so
     /// this is a linear scan over the few captures).
-    #[allow(dead_code)] // wired up by the dispatcher's reconcile
     pub(super) fn captures_of(&self, interface: InterfaceKey) -> Vec<CaptureKey> {
         self.captures
             .iter()
@@ -285,7 +327,6 @@ impl InterfaceTable {
     ///
     /// # Errors
     /// Propagates the re-bind syscall failure.
-    #[allow(dead_code)] // wired up by the dispatcher's reconcile
     pub(super) fn rebind_capture(&mut self, key: CaptureKey) -> io::Result<bool> {
         match self
             .captures
@@ -344,6 +385,22 @@ mod tests {
         /// Push a capture-less entry (no fd) so a routing test can mint a valid [`CaptureKey`] and
         /// exercise the record path without opening a capture; the dangling [`InterfaceKey`] is
         /// never resolved. Reachable from the dispatcher's own tests, hence `pub(in crate::dispatch)`.
+        /// Overwrite an entry's cached identity, standing in for the kernel recreating the
+        /// interface out from under the table. For the dispatcher's reconcile tests.
+        pub(in crate::dispatch) fn set_test_ifindex(
+            &mut self,
+            interface: InterfaceKey,
+            ifindex: u32,
+        ) {
+            self.entries[interface.0 as usize].interface.ifindex = ifindex;
+        }
+
+        /// Rename an entry out from under its kernel interface, standing in for a vanished
+        /// interface (the new name resolves to nothing). For the dispatcher's reconcile tests.
+        pub(in crate::dispatch) fn set_test_name(&mut self, interface: InterfaceKey, name: &str) {
+            self.entries[interface.0 as usize].interface.name = name.to_owned();
+        }
+
         pub(in crate::dispatch) fn add_test_capture(&mut self) -> CaptureKey {
             let key =
                 CaptureKey(u32::try_from(self.captures.len()).expect("capture count fits a u32"));
@@ -431,7 +488,14 @@ mod tests {
         let real = if_index(LOOPBACK_IFACE).expect("loopback has an ifindex");
         // Simulate a recreation: the kernel identity moved while the cache kept the old index.
         table.entries[key.0 as usize].interface.ifindex = real + 1000;
-        assert_eq!(table.stale_interfaces(), [(key, real)]);
+        assert_eq!(
+            table.stale_interfaces(),
+            [StaleInterface {
+                key,
+                cached: real + 1000,
+                cur: real
+            }]
+        );
         table.rebind_interface(key, real)?;
         assert!(
             table.stale_interfaces().is_empty(),
@@ -449,11 +513,19 @@ mod tests {
         let mut table = InterfaceTable::new();
         let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
         table.entries[key.0 as usize].interface.name = "reflector-gone0".into();
-        assert_eq!(table.stale_interfaces(), [(key, 0)]);
-        let change = table.rebind_interface(key, 0)?;
+        let real = if_index(LOOPBACK_IFACE).expect("loopback has an ifindex");
+        assert_eq!(
+            table.stale_interfaces(),
+            [StaleInterface {
+                key,
+                cached: real,
+                cur: 0
+            }]
+        );
+        table.rebind_interface(key, 0)?;
         assert!(
-            change.v4,
-            "loopback's v4 reads as lost when the entry parks"
+            table.entries[key.0 as usize].interface.addrs.v4().is_none(),
+            "a parked entry's addresses clear, closing the egress gate"
         );
         assert!(
             table.stale_interfaces().is_empty(),

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -3,6 +3,7 @@
 
 use std::io;
 use std::net::IpAddr;
+use std::num::NonZeroU32;
 use std::os::fd::{AsRawFd, RawFd};
 
 use crate::capture::Capture;
@@ -79,7 +80,14 @@ impl InterfaceTable {
     pub(super) fn join_on(&mut self, interface: InterfaceKey, group: IpAddr) -> io::Result<()> {
         // Startup-only with a freshly-minted key, so the index is always in range.
         let entry = &mut self.entries[interface.0 as usize];
-        entry.joiner.join(group, entry.interface.ifindex)
+        if let Some(ifindex) = NonZeroU32::new(entry.interface.ifindex) {
+            entry.joiner.join(group, ifindex)
+        } else {
+            // Unreachable at startup (the capture opened, so the interface exists), but the
+            // defensively right behavior: record for the rebuild's replay, never join index 0.
+            entry.joiner.record(group);
+            Ok(())
+        }
     }
 
     /// The key of the interface named `name`, opening and resolving it if absent, so captures on
@@ -126,7 +134,8 @@ impl InterfaceTable {
             .map(|entry| &entry.interface.addrs)
     }
 
-    /// The kernel ifindex of the interface `capture` runs on. Its stable identity, cached at open.
+    /// The kernel ifindex of the interface `capture` runs on: cached at open, re-pointed by the
+    /// reconcile on recreation (0 while parked absent).
     pub(super) fn ifindex_of(&self, capture: CaptureKey) -> Option<u32> {
         self.interface_index(self.interface_of(capture)?)
     }
@@ -216,8 +225,11 @@ impl InterfaceTable {
         };
         let change = entry.interface.refresh()?;
         // Re-resolved addresses may have made a deferred join (a v4 group that had no address)
-        // viable; re-attempt this interface's memberships.
-        entry.joiner.rejoin(entry.interface.ifindex);
+        // viable; re-attempt this interface's memberships. Always present here: the entry was
+        // found by matching a real notification's index.
+        if let Some(ifindex) = NonZeroU32::new(entry.interface.ifindex) {
+            entry.joiner.rejoin(ifindex);
+        }
         Ok(Some(change))
     }
 
@@ -290,19 +302,32 @@ impl InterfaceTable {
     /// Captures are re-bound separately ([`rebind_capture`](Self::rebind_capture)), so the
     /// caller can log and retry them per capture. Log-free.
     ///
+    /// Returns how many group joins were deferred (see [`MulticastJoiner::rejoin`]); the
+    /// deferrals heal on the interface's next address event, but the caller should surface a
+    /// nonzero count -- after a recreation, deaf groups are a real outage.
+    ///
     /// # Errors
-    /// Propagates a resolution syscall failure; the identity and joiner state are already
-    /// updated, and the probe re-flags the entry if captures never re-bind.
-    pub(super) fn rebind_interface(&mut self, key: InterfaceKey, cur: u32) -> io::Result<()> {
+    /// Propagates a resolution syscall failure. The identity is then rolled back so the entry
+    /// stays visibly stale and the retry re-runs the whole rebuild -- committed, it would read
+    /// as healthy to the scan (the captures re-bind fine) while carrying the OLD interface's
+    /// addresses. The joins are replayed before the rollback either way: they need only the
+    /// identity, and a transient resolver error must not leave the interface deaf.
+    pub(super) fn rebind_interface(&mut self, key: InterfaceKey, cur: u32) -> io::Result<usize> {
         // Keys come from this table's own scan, so the index is always in range.
         let entry = &mut self.entries[key.0 as usize];
+        let previous = entry.interface.ifindex;
         entry.interface.ifindex = cur;
         entry.joiner.reset();
-        entry.interface.refresh()?; // logs each family's gains and losses
-        if cur != 0 {
-            entry.joiner.rejoin(cur);
+        let refreshed = entry.interface.refresh(); // logs each family's gains and losses
+        let deferred = match NonZeroU32::new(cur) {
+            // Parked: nothing to join now; the rebuild on the interface's return replays.
+            None => 0,
+            Some(ifindex) => entry.joiner.rejoin(ifindex),
+        };
+        if refreshed.is_err() {
+            entry.interface.ifindex = previous;
         }
-        Ok(())
+        refreshed.map(|_| deferred)
     }
 
     /// The keys of the captures on `interface`, for a rebuild or eviction pass (the reverse of
@@ -350,7 +375,11 @@ impl InterfaceTable {
             .map(|entry| (entry.interface.ifindex, entry.interface.refresh()))
             .collect();
         for entry in &mut self.entries {
-            entry.joiner.rejoin(entry.interface.ifindex);
+            // A parked interface (index 0) has nothing to re-join; the rebuild on its return
+            // replays the recorded groups.
+            if let Some(ifindex) = NonZeroU32::new(entry.interface.ifindex) {
+                entry.joiner.rejoin(ifindex);
+            }
         }
         results
     }
@@ -530,6 +559,30 @@ mod tests {
         assert!(
             table.stale_interfaces().is_empty(),
             "a parked entry matches its (absent) identity"
+        );
+        Ok(())
+    }
+
+    // The overflow response must not touch a parked interface's joiner: a rejoin there would
+    // have targeted index 0, which the kernel resolves to an arbitrary interface. Socket-less
+    // after the park, the joiner must stay socket-less through refresh_all.
+    #[test]
+    fn refresh_all_does_not_rejoin_a_parked_interface() -> io::Result<()> {
+        let mut table = InterfaceTable::new();
+        let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
+        if let Err(e) = table.join_on(key, IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251))) {
+            if join_unsupported(&e) {
+                eprintln!("skip refresh_all_does_not_rejoin: joins unsupported here ({e})");
+                return Ok(());
+            }
+            return Err(e);
+        }
+        table.entries[key.0 as usize].interface.name = "reflector-gone0".into();
+        table.rebind_interface(key, 0)?; // park: joiner reset, no rejoin
+        table.refresh_all();
+        assert!(
+            table.entries[key.0 as usize].joiner.test_socketless(),
+            "a parked interface's joiner stays socket-less through the overflow refresh"
         );
         Ok(())
     }

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -48,6 +48,17 @@ impl MulticastJoiner {
         self.apply(group, ifindex)
     }
 
+    /// Drop the per-family sockets, so the next join starts from fresh ones. For an interface
+    /// that was destroyed: memberships keyed to the dead index are never scrubbed from a
+    /// surviving socket, and on Linux those zombies still count toward
+    /// `igmp_max_memberships` (default 20, unraisable on a locked-down router), so re-joining
+    /// on kept sockets would exhaust the cap after a handful of recreations. Dropping the fds
+    /// releases every membership at once; `desired` survives for the replay.
+    pub(crate) fn reset(&mut self) {
+        self.v4 = None;
+        self.v6 = None;
+    }
+
     /// Re-attempt every recorded membership after the interface re-resolves. A group not joinable
     /// before its address existed succeeds now; an already-held one is a no-op. Best-effort: a
     /// still-unavailable family logs and waits for the next change.
@@ -138,6 +149,31 @@ mod tests {
         let idx = unsafe { libc::if_nametoindex(name.as_ptr()) };
         assert_ne!(idx, 0, "loopback must resolve to an index");
         idx
+    }
+
+    // reset drops the per-family sockets while keeping the desired list, so the next rejoin
+    // replays every group on fresh fds (no zombie memberships from a destroyed interface).
+    #[test]
+    fn reset_keeps_desired_and_rejoin_replays_on_fresh_sockets() {
+        let mut joiner = MulticastJoiner::new();
+        let ifindex = loopback_ifindex();
+        match joiner.join(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251)), ifindex) {
+            Ok(()) => {}
+            Err(e) if join_unsupported(&e) => {
+                eprintln!("skip reset_keeps_desired: MCAST_JOIN_GROUP unsupported here ({e})");
+                return;
+            }
+            Err(e) => panic!("kernel must accept the loopback join: {e}"),
+        }
+        assert!(joiner.v4.is_some());
+        joiner.reset();
+        assert!(joiner.v4.is_none(), "reset drops the family sockets");
+        assert_eq!(joiner.desired.len(), 1, "the desired list survives");
+        joiner.rejoin(ifindex);
+        assert!(
+            joiner.v4.is_some(),
+            "rejoin re-opens a fresh socket and re-joins"
+        );
     }
 
     #[test]

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -7,6 +7,7 @@
 
 use std::io;
 use std::net::IpAddr;
+use std::num::NonZeroU32;
 use std::os::fd::{AsRawFd, OwnedFd};
 
 use libc::c_void;
@@ -34,17 +35,26 @@ impl MulticastJoiner {
         }
     }
 
+    /// Record `group` for a later [`rejoin`](Self::rejoin) without joining now: the
+    /// parked-interface path, where no live index exists to join on. Deduped, like
+    /// [`join`](Self::join)'s own recording.
+    pub(crate) fn record(&mut self, group: IpAddr) {
+        if !self.desired.contains(&group) {
+            self.desired.push(group);
+        }
+    }
+
     /// Join `group` on the interface `ifindex` and record it, so a later interface change
     /// re-attempts it. Idempotent: the kernel keys memberships by `(group, ifindex)`.
+    /// `NonZeroU32` for the same reason as [`rejoin`](Self::rejoin); a parked caller
+    /// [`record`](Self::record)s instead.
     ///
     /// # Errors
     /// The OS error if the socket can't open or the membership can't be added. `EADDRNOTAVAIL` (no
     /// address of that family yet) is deferrable: the group is recorded and [`rejoin`](Self::rejoin)
     /// retries it on the next address-up event.
-    pub(crate) fn join(&mut self, group: IpAddr, ifindex: u32) -> io::Result<()> {
-        if !self.desired.contains(&group) {
-            self.desired.push(group);
-        }
+    pub(crate) fn join(&mut self, group: IpAddr, ifindex: NonZeroU32) -> io::Result<()> {
+        self.record(group);
         self.apply(group, ifindex)
     }
 
@@ -59,19 +69,26 @@ impl MulticastJoiner {
         self.v6 = None;
     }
 
-    /// Re-attempt every recorded membership after the interface re-resolves. A group not joinable
-    /// before its address existed succeeds now; an already-held one is a no-op. Best-effort: a
-    /// still-unavailable family logs and waits for the next change.
-    pub(crate) fn rejoin(&mut self, ifindex: u32) {
+    /// Re-attempt every recorded membership after the interface re-resolves, returning how many
+    /// were deferred. A group not joinable before its address existed succeeds now; an
+    /// already-held one is a no-op. Best-effort: a still-unavailable family logs at debug and
+    /// waits for the next change (routine on the address-up path; the recreation rebuild warns
+    /// on a nonzero count instead). `NonZeroU32` makes the parked case unrepresentable:
+    /// `MCAST_JOIN_GROUP` on index 0 would let the kernel pick an arbitrary interface by route
+    /// lookup and advertise our groups there, so callers skip explicitly while parked.
+    pub(crate) fn rejoin(&mut self, ifindex: NonZeroU32) -> usize {
+        let mut deferred = 0;
         for i in 0..self.desired.len() {
             let group = self.desired[i];
             if let Err(e) = self.apply(group, ifindex) {
                 log::debug!("re-join of {group} on ifindex {ifindex} deferred: {e}");
+                deferred += 1;
             }
         }
+        deferred
     }
 
-    fn apply(&mut self, group: IpAddr, ifindex: u32) -> io::Result<()> {
+    fn apply(&mut self, group: IpAddr, ifindex: NonZeroU32) -> io::Result<()> {
         let (slot, family, level) = match group {
             IpAddr::V4(_) => (&mut self.v4, libc::AF_INET, libc::IPPROTO_IP),
             IpAddr::V6(_) => (&mut self.v6, libc::AF_INET6, libc::IPPROTO_IPV6),
@@ -86,7 +103,7 @@ impl MulticastJoiner {
         // uninitialised, and `setsockopt` reads the whole struct (Valgrind flags them).
         // SAFETY: `group_req` is plain data; all-zero is valid.
         let mut req: GroupReq = unsafe { std::mem::zeroed() };
-        req.gr_interface = ifindex;
+        req.gr_interface = ifindex.get();
         // Interface is selected by `gr_interface`, so the group sockaddr carries no scope id.
         req.gr_group = sockaddr_for(group, 0, 0).0;
         // SAFETY: `req` is a fully-initialised `group_req` (padding zeroed), passed by address + size.
@@ -133,6 +150,14 @@ mod tests {
 
     use super::*;
 
+    impl MulticastJoiner {
+        /// Whether no family socket is open (nothing joined since the last reset). Reachable
+        /// from the interface table's parked-interface tests, hence `pub(in crate::dispatch)`.
+        pub(in crate::dispatch) fn test_socketless(&self) -> bool {
+            self.v4.is_none() && self.v6.is_none()
+        }
+    }
+
     #[test]
     fn already_member_only_for_the_duplicate_join_errno() {
         let of = io::Error::from_raw_os_error;
@@ -142,13 +167,12 @@ mod tests {
         assert!(!already_member(&of(libc::EADDRNOTAVAIL))); // interface transiently down
     }
 
-    fn loopback_ifindex() -> u32 {
+    fn loopback_ifindex() -> NonZeroU32 {
         let name =
             std::ffi::CString::new(crate::interface::LOOPBACK_IFACE).expect("iface has no NUL");
         // SAFETY: `name` is a valid C string.
         let idx = unsafe { libc::if_nametoindex(name.as_ptr()) };
-        assert_ne!(idx, 0, "loopback must resolve to an index");
-        idx
+        NonZeroU32::new(idx).expect("loopback must resolve to an index")
     }
 
     // reset drops the per-family sockets while keeping the desired list, so the next rejoin
@@ -173,6 +197,22 @@ mod tests {
         assert!(
             joiner.v4.is_some(),
             "rejoin re-opens a fresh socket and re-joins"
+        );
+    }
+
+    // The parked-interface path: record keeps the group for the rebuild's replay without
+    // touching the kernel (no index exists to join on; MCAST_JOIN_GROUP on index 0 would let
+    // the kernel pick an arbitrary interface, which the NonZeroU32 signatures now forbid).
+    #[test]
+    fn record_keeps_the_group_for_the_replay_without_joining() {
+        let mut joiner = MulticastJoiner::new();
+        joiner.record(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251)));
+        joiner.record(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251))); // deduped
+        assert!(joiner.v4.is_none(), "no socket opened, no join attempted");
+        assert_eq!(
+            joiner.desired.len(),
+            1,
+            "the group is recorded once for the replay"
         );
     }
 

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -95,28 +95,31 @@ impl InterfacePair {
             return None;
         }
         let pair = Self::create_platform(NEXT_SUBNET.fetch_add(1, Ordering::Relaxed))?;
-        // A freshly-created pair drops frames until both ends finish coming up: the kernel
-        // accepts an injected frame, but the device discards it while the carrier settles, with
-        // no retransmit. A pair we just created as root not coming up is an anomaly, not a
-        // missing precondition -- it must fail the test (the panic unwinds through Drop, so the
-        // interfaces are still torn down), never skip it.
+        pair.settle();
+        Some(pair)
+    }
+
+    /// Wait until both ends are up+running with their address plans resolved. A pair we just
+    /// created as root not coming up is an anomaly, not a missing precondition -- it must fail
+    /// the test (the panic unwinds through Drop, so the interfaces are still torn down), never
+    /// skip it. Needed because a fresh pair drops frames until the carrier settles (with no
+    /// retransmit), and manually-assigned v6 addresses are tentative until DAD completes (the
+    /// resolver filters unusable ones). Tests can then open interfaces and use addresses
+    /// without per-test settling logic.
+    fn settle(&self) {
         let deadline = Instant::now() + WAIT_BUDGET;
-        while !(link_running(&pair.inject) && link_running(&pair.receive))
+        while !(link_running(&self.inject) && link_running(&self.receive))
             && Instant::now() < deadline
         {
             std::thread::sleep(POLL_SLICE);
         }
         assert!(
-            link_running(&pair.inject) && link_running(&pair.receive),
+            link_running(&self.inject) && link_running(&self.receive),
             "{}/{} not up+running after {WAIT_BUDGET:?}",
-            pair.inject,
-            pair.receive
+            self.inject,
+            self.receive
         );
-        // Likewise for the address plan: the manually-assigned v6 addresses are tentative until
-        // DAD completes (the resolver filters unusable ones), so wait until both ends resolve
-        // everything the tests rely on. Tests can then open interfaces and use addresses without
-        // per-test settling logic.
-        let mut inject = Interface::open(&pair.inject).expect("resolve the inject interface");
+        let mut inject = Interface::open(&self.inject).expect("resolve the inject interface");
         assert!(
             wait_for_source(&mut inject, |iface| {
                 iface.addrs.has_v4()
@@ -130,16 +133,27 @@ impl InterfacePair {
                         .is_some_and(|addr| !addr.is_unicast_link_local())
             }),
             "{} never resolved its v4 + link-local + routable v6 plan",
-            pair.inject
+            self.inject
         );
-        let mut receive = Interface::open(&pair.receive).expect("resolve the receive interface");
+        let mut receive = Interface::open(&self.receive).expect("resolve the receive interface");
         assert!(
             wait_for_source(&mut receive, |iface| iface.addrs.has_v4()
                 && iface.addrs.has_v6()),
             "{} never resolved its v4 + link-local plan",
-            pair.receive
+            self.receive
         );
-        Some(pair)
+    }
+
+    /// Destroy and recreate the pair's interfaces under the same names -- fresh kernel
+    /// identities, as an operator's `PPPoE` reconnect or bridge rebuild would produce -- then
+    /// reconfigure and settle. False (with a skip note) if the platform tooling refuses.
+    fn recreate(&self) -> bool {
+        if !(self.relink() && self.configure()) {
+            eprintln!("skip pair test: could not recreate the pair");
+            return false;
+        }
+        self.settle();
+        true
     }
 
     /// Linux: veth names are caller-chosen, so derive them from the pid and a counter -- unique
@@ -159,44 +173,60 @@ impl InterfacePair {
             receive,
             subnet,
         }; // Drop cleans up from here on
-        // Manual link-locals with nodad so both ends are usable immediately, no DAD wait.
-        let configured = run(&format!(
+        if !pair.configure() {
+            eprintln!("skip pair test: could not configure the veth pair");
+            return None;
+        }
+        Some(pair)
+    }
+
+    /// Assign the pair's address plan and bring both ends up. Manual link-locals with nodad so
+    /// both ends are usable immediately, no DAD wait.
+    #[cfg(target_os = "linux")]
+    fn configure(&self) -> bool {
+        run(&format!(
             "ip addr add {}/24 dev {}",
-            pair.inject_v4(),
-            pair.inject
+            self.inject_v4(),
+            self.inject
         )) && run(&format!(
             "ip -6 addr add fe80::1/64 dev {} nodad",
-            pair.inject
+            self.inject
         )) && run(&format!(
             "ip -6 addr add {}/64 dev {} nodad",
-            pair.inject_ula(),
-            pair.inject
+            self.inject_ula(),
+            self.inject
         )) && run(&format!(
             "ip addr add {}/24 dev {}",
-            pair.receive_v4(),
-            pair.receive
+            self.receive_v4(),
+            self.receive
         )) && run(&format!(
             "ip -6 addr add fe80::2/64 dev {} nodad",
-            pair.receive
-        )) && run(&format!("ip link set {} up", pair.inject))
-            && run(&format!("ip link set {} up", pair.receive))
+            self.receive
+        )) && run(&format!("ip link set {} up", self.inject))
+            && run(&format!("ip link set {} up", self.receive))
             // Both ends sit in one stack, so every wire-crossing v4 packet carries a local
             // source address, and Linux's fib_validate_source drops those as martians before
             // socket delivery (tcpdump still sees them below IP). accept_local admits them;
             // the BSDs have no such gate.
             && run(&format!(
                 "echo 1 > /proc/sys/net/ipv4/conf/{}/accept_local",
-                pair.inject
+                self.inject
             ))
             && run(&format!(
                 "echo 1 > /proc/sys/net/ipv4/conf/{}/accept_local",
-                pair.receive
-            ));
-        if !configured {
-            eprintln!("skip pair test: could not configure the veth pair");
-            return None;
-        }
-        Some(pair)
+                self.receive
+            ))
+    }
+
+    /// Destroy the pair and recreate it under the same names (deleting one veth end removes
+    /// both; the names are caller-chosen, so the re-add reuses them).
+    #[cfg(target_os = "linux")]
+    fn relink(&self) -> bool {
+        run(&format!("ip link del {}", self.inject))
+            && run(&format!(
+                "ip link add {} type veth peer name {}",
+                self.inject, self.receive
+            ))
     }
 
     /// macOS: feth units are kernel-assigned (`ifconfig feth create` prints the name), so two
@@ -214,37 +244,53 @@ impl InterfacePair {
             receive,
             subnet,
         }; // Drop cleans up from here on
-        // feth has no automatic IPv6 link-local, so assign one on each end explicitly.
-        let configured = run(&format!("ifconfig {} peer {}", pair.inject, pair.receive))
-            && run(&format!(
-                "ifconfig {} inet {}/24 up",
-                pair.inject,
-                pair.inject_v4()
-            ))
-            && run(&format!(
-                "ifconfig {} inet6 fe80::1 prefixlen 64",
-                pair.inject
-            ))
-            && run(&format!(
-                "ifconfig {} inet6 {} prefixlen 64",
-                pair.inject,
-                pair.inject_ula()
-            ))
-            && run(&format!("ifconfig {} up", pair.receive))
-            && run(&format!(
-                "ifconfig {} inet {}/24",
-                pair.receive,
-                pair.receive_v4()
-            ))
-            && run(&format!(
-                "ifconfig {} inet6 fe80::2 prefixlen 64",
-                pair.receive
-            ));
-        if !configured {
+        if !pair.configure() {
             eprintln!("skip pair test: could not configure the feth pair");
             return None;
         }
         Some(pair)
+    }
+
+    /// Peer the two feths, assign the pair's address plan, and bring both ends up. feth has no
+    /// automatic IPv6 link-local, so assign one on each end explicitly.
+    #[cfg(target_os = "macos")]
+    fn configure(&self) -> bool {
+        run(&format!("ifconfig {} peer {}", self.inject, self.receive))
+            && run(&format!(
+                "ifconfig {} inet {}/24 up",
+                self.inject,
+                self.inject_v4()
+            ))
+            && run(&format!(
+                "ifconfig {} inet6 fe80::1 prefixlen 64",
+                self.inject
+            ))
+            && run(&format!(
+                "ifconfig {} inet6 {} prefixlen 64",
+                self.inject,
+                self.inject_ula()
+            ))
+            && run(&format!("ifconfig {} up", self.receive))
+            && run(&format!(
+                "ifconfig {} inet {}/24",
+                self.receive,
+                self.receive_v4()
+            ))
+            && run(&format!(
+                "ifconfig {} inet6 fe80::2 prefixlen 64",
+                self.receive
+            ))
+    }
+
+    /// Destroy both feths and recreate them under the same names: a specific unit can be
+    /// created by naming it (`ifconfig fethN create`), unlike the first create, which lets
+    /// the kernel pick.
+    #[cfg(target_os = "macos")]
+    fn relink(&self) -> bool {
+        run(&format!("ifconfig {} destroy", self.inject))
+            && run(&format!("ifconfig {} destroy", self.receive))
+            && run(&format!("ifconfig {} create", self.inject))
+            && run(&format!("ifconfig {} create", self.receive))
     }
 
     /// FreeBSD: `ifconfig epair create` mints a connected pair and prints the `a` end; the peer
@@ -263,32 +309,46 @@ impl InterfacePair {
             receive,
             subnet,
         }; // Drop cleans up from here on
-        let configured = run(&format!(
-            "ifconfig {} inet {}/24 up",
-            pair.inject,
-            pair.inject_v4()
-        )) && run(&format!(
-            "ifconfig {} inet6 fe80::1 prefixlen 64",
-            pair.inject
-        )) && run(&format!(
-            "ifconfig {} inet6 {} prefixlen 64",
-            pair.inject,
-            pair.inject_ula()
-        )) && run(&format!("ifconfig {} up", pair.receive))
-            && run(&format!(
-                "ifconfig {} inet {}/24",
-                pair.receive,
-                pair.receive_v4()
-            ))
-            && run(&format!(
-                "ifconfig {} inet6 fe80::2 prefixlen 64",
-                pair.receive
-            ));
-        if !configured {
+        if !pair.configure() {
             eprintln!("skip pair test: could not configure the epair");
             return None;
         }
         Some(pair)
+    }
+
+    /// Assign the pair's address plan and bring both ends up.
+    #[cfg(target_os = "freebsd")]
+    fn configure(&self) -> bool {
+        run(&format!(
+            "ifconfig {} inet {}/24 up",
+            self.inject,
+            self.inject_v4()
+        )) && run(&format!(
+            "ifconfig {} inet6 fe80::1 prefixlen 64",
+            self.inject
+        )) && run(&format!(
+            "ifconfig {} inet6 {} prefixlen 64",
+            self.inject,
+            self.inject_ula()
+        )) && run(&format!("ifconfig {} up", self.receive))
+            && run(&format!(
+                "ifconfig {} inet {}/24",
+                self.receive,
+                self.receive_v4()
+            ))
+            && run(&format!(
+                "ifconfig {} inet6 fe80::2 prefixlen 64",
+                self.receive
+            ))
+    }
+
+    /// Destroy the epair (removing both ends) and recreate it under the same names: the
+    /// cloner accepts a specific unit (`ifconfig epairN create` mints `epairNa`+`epairNb`),
+    /// unlike the first create, which lets the kernel pick.
+    #[cfg(target_os = "freebsd")]
+    fn relink(&self) -> bool {
+        let base = &self.inject[..self.inject.len() - 1]; // "epairNa" -> "epairN"
+        run(&format!("ifconfig {} destroy", self.inject)) && run(&format!("ifconfig {base} create"))
     }
 }
 
@@ -430,6 +490,47 @@ fn pair_injected_broadcast_is_captured_on_the_peer() -> io::Result<()> {
     assert_eq!(captured.payload, payload);
     assert_eq!(captured.dest.port(), INJECT_DST_PORT);
     assert_eq!(captured.source.ip(), IpAddr::V4(pair.inject_v4()));
+    Ok(())
+}
+
+// Interface recreation gives the name a fresh kernel identity, stranding the old capture:
+// attached() flips false, rebind() re-attaches the same fd (Linux: bind(2) re-hooks the packet
+// socket from its unregistered state; BSD: BIOCSETIF re-attaches the detached descriptor), and
+// an injected broadcast proves delivery resumed end to end. This is the kernel-behavior
+// verification the interface hot-swap recovery rests on.
+#[test]
+fn pair_capture_rebinds_after_interface_recreation() -> io::Result<()> {
+    let Some(pair) = InterfacePair::create() else {
+        return Ok(());
+    };
+    let mut peer = Capture::open(&pair.receive)?;
+    let index = if_index(&pair.receive).expect("receive ifindex");
+    assert!(peer.attached(index), "a fresh capture reports attached");
+
+    if !pair.recreate() {
+        return Ok(()); // recreate printed the skip note
+    }
+    let index = if_index(&pair.receive).expect("recreated receive ifindex");
+    assert!(
+        !peer.attached(index),
+        "a capture on the destroyed interface reports detached"
+    );
+
+    peer.rebind()?;
+    assert!(
+        peer.attached(index),
+        "the re-bound capture reports attached"
+    );
+
+    // Delivery is live again: inject on the recreated far end, capture on the re-bound fd.
+    let iface = Interface::open(&pair.inject)?;
+    let injector = Capture::open(&pair.inject)?;
+    let payload = b"pair-rebind";
+    let dst = SocketAddr::from((Ipv4Addr::BROADCAST, INJECT_DST_PORT));
+    inject(&iface, &injector, dst, payload)?;
+    let captured =
+        capture_injected(&mut peer, dst.ip())?.expect("the re-bound capture sees the broadcast");
+    assert_eq!(captured.payload, payload);
     Ok(())
 }
 

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -7,6 +7,7 @@
 
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+use std::num::NonZeroU32;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -731,11 +732,12 @@ fn pair_join_announces_membership_on_the_wire() -> io::Result<()> {
     // (and only those) through the production joiner, so its device accepts the arriving report
     // packets for the observers. Its own joins announce 224.0.0.22/ff02::16 -- never the test
     // groups -- so a test-group match below can only come from the inject side's announcements.
+    let receive_join_ix = NonZeroU32::new(receive_ifindex).expect("receive ifindex is nonzero");
     let mut receive_joiner = MulticastJoiner::new();
-    receive_joiner.join(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 22)), receive_ifindex)?;
+    receive_joiner.join(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 22)), receive_join_ix)?;
     receive_joiner.join(
         IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x16)),
-        receive_ifindex,
+        receive_join_ix,
     )?;
     let igmp = raw_observer(libc::AF_INET, libc::IPPROTO_IGMP)?;
     let mld = raw_observer(libc::AF_INET6, libc::IPPROTO_ICMPV6)?;
@@ -754,7 +756,8 @@ fn pair_join_announces_membership_on_the_wire() -> io::Result<()> {
     }
 
     let mut joiner = MulticastJoiner::new();
-    let inject_ifindex = if_index(&pair.inject).expect("inject ifindex");
+    let inject_ifindex = NonZeroU32::new(if_index(&pair.inject).expect("inject ifindex"))
+        .expect("inject ifindex is nonzero");
     joiner.join(IpAddr::V4(group_v4), inject_ifindex)?;
     joiner.join(IpAddr::V6(group_v6), inject_ifindex)?;
 
@@ -779,7 +782,8 @@ fn pair_joins_multicast_groups_idempotently() -> io::Result<()> {
         return Ok(());
     };
     let mut joiner = MulticastJoiner::new();
-    let inject_ifindex = if_index(&pair.inject).expect("inject ifindex");
+    let inject_ifindex = NonZeroU32::new(if_index(&pair.inject).expect("inject ifindex"))
+        .expect("inject ifindex is nonzero");
     let mdns_v4: IpAddr = "224.0.0.251".parse().expect("mDNS v4 group");
     let mdns_v6: IpAddr = "ff02::fb".parse().expect("mDNS v6 group");
     joiner.join(mdns_v4, inject_ifindex)?;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -127,14 +127,14 @@ impl Ipv6Scope {
     }
 }
 
-/// One configured interface: its name (kept for re-resolution), kernel ifindex (the address
-/// monitor's lookup key), and current source addresses. Built by [`open`](Self::open); the
-/// monitor later refreshes `addrs` in place.
+/// One configured interface: its name (the durable identity, kept for re-resolution), kernel
+/// ifindex (the interface monitor's lookup key), and current source addresses. Built by
+/// [`open`](Self::open); the monitor later refreshes `addrs` in place.
 ///
-/// The `ifindex` is cached at open, not re-derived: if the OS destroys and recreates the interface
-/// (a fresh kernel ifindex, e.g. a `PPPoE` reconnect or a bridge/VLAN rebuild), the monitor no longer
-/// matches its notifications and the capture stays bound to the dead index, so reflection on it is
-/// dead until a restart.
+/// The `ifindex` is a cache of what the name resolves to -- the process's only persistent copy
+/// of an interface index. If the OS destroys and recreates the interface (a fresh kernel
+/// identity, e.g. a `PPPoE` reconnect or a bridge/VLAN rebuild), the dispatcher's reconcile
+/// re-points it (0 while the name resolves to nothing) and re-binds the captures.
 pub(crate) struct Interface {
     pub(crate) name: String,
     pub(crate) ifindex: u32,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -21,7 +21,7 @@ mod interface_monitor;
 #[cfg(target_os = "linux")]
 mod rtnetlink;
 
-pub(crate) use self::interface_monitor::InterfaceMonitor;
+pub(crate) use self::interface_monitor::{InterfaceEvent, InterfaceMonitor};
 
 /// An interface's current source addresses; any may be absent. The fields are private so a sender
 /// reaches a v6 source only through [`v6`](Self::v6), naming the destination's scope: the stored

--- a/src/interface/interface_monitor.rs
+++ b/src/interface/interface_monitor.rs
@@ -58,7 +58,9 @@ impl InterfaceMonitor {
     /// per netns), so a newly-created interface always carries an index above every
     /// previously-seen one. The dispatcher gates unknown-index [`InterfaceEvent::Link`]
     /// events on that; the BSDs reuse indexes (FreeBSD hands out the lowest free, macOS
-    /// recycles the whole ifnet), so no such gate is sound there.
+    /// recycles the whole ifnet), so no such gate is sound there. Two Linux corners slip the
+    /// gate -- a device moved between netns keeps its (possibly low) index when free, and the
+    /// 31-bit wrap -- both backstopped by the reconcile tick.
     pub(crate) const INDEXES_MONOTONIC: bool = backend::INDEXES_MONOTONIC;
 
     /// Whether this backend delivers [`InterfaceEvent::Link`] lifecycle events at all. Where

--- a/src/interface/interface_monitor.rs
+++ b/src/interface/interface_monitor.rs
@@ -1,6 +1,6 @@
-//! Interface address-change monitoring: a routing socket whose readiness means some
-//! interface's addresses (or MAC) changed, so the dispatcher should re-resolve it.
-//! `NETLINK_ROUTE` on Linux, `PF_ROUTE` on the BSDs. One [`InterfaceMonitor`] over a
+//! Interface change monitoring: a routing socket whose readiness means some interface's
+//! addresses (or MAC) changed, or an interface itself came or went, so the dispatcher should
+//! react. `NETLINK_ROUTE` on Linux, `PF_ROUTE` on the BSDs. One [`InterfaceMonitor`] over a
 //! per-platform backend, mirroring the resolver's rtnetlink/getifaddrs split.
 //!
 //! Best-effort: only keeps already-resolved addresses fresh. A failed open (or a read error)
@@ -25,6 +25,23 @@ use self::rtnetlink as backend;
 /// flag on the next recv, so an unbroken run of them means the socket is wedged. Stop rather
 /// than spin the single-threaded loop forever; a level-triggered wait re-fires to try later.
 const MAX_CONSECUTIVE_OVERFLOWS: u32 = 16;
+
+/// What one routing-socket notification reported. The kind drives the dispatcher's trigger
+/// policy; the monitor itself attaches no meaning beyond the message-type mapping.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum InterfaceEvent {
+    /// An address-level change on the interface with this kernel index (also BSD `RTM_IFINFO`
+    /// link-state/MAC updates: a flap refreshes addresses, it doesn't signal a lifecycle change).
+    Address(u32),
+    /// A link lifecycle event on the interface with this kernel index: Linux
+    /// `RTM_{NEW,DEL}LINK` (creation, deletion, or any link change -- netlink doesn't
+    /// distinguish), FreeBSD `RTM_IFANNOUNCE` (arrival/departure). macOS has no lifecycle
+    /// message, so this variant is never constructed there.
+    #[cfg_attr(target_os = "macos", allow(dead_code))]
+    Link(u32),
+    /// The socket overflowed and notifications were dropped: every interface may be stale.
+    Overflow,
+}
 
 /// A routing-socket monitor for interface address and link changes. The dispatcher watches
 /// its fd and calls [`drain`](Self::drain) on readiness.
@@ -54,15 +71,15 @@ impl InterfaceMonitor {
         self.sock.as_raw_fd()
     }
 
-    /// Drain every queued notification, calling `on_change(ifindex)` per affected interface.
-    /// After an overflow it calls `on_change(0)`, meaning "re-resolve everything" (kernel
-    /// indices are >= 1, so 0 is an unambiguous signal). Reads to `EAGAIN` so a level-triggered
+    /// Drain every queued notification, calling `on_change(event)` per affected interface;
+    /// the per-interface events carry the kernel index. After an overflow it reports
+    /// [`InterfaceEvent::Overflow`] once per burst. Reads to `EAGAIN` so a level-triggered
     /// wait won't immediately re-fire.
     ///
     /// # Errors
     /// The first non-recoverable recv failure. Recoverable: `EAGAIN`/`EWOULDBLOCK` end the
-    /// drain, `ENOBUFS` reports the overflow signal and continues (bailing if it never clears).
-    pub(crate) fn drain(&mut self, mut on_change: impl FnMut(u32)) -> io::Result<()> {
+    /// drain, `ENOBUFS` reports the overflow and continues (bailing if it never clears).
+    pub(crate) fn drain(&mut self, mut on_change: impl FnMut(InterfaceEvent)) -> io::Result<()> {
         let mut overflows = 0u32;
         loop {
             // SAFETY: an all-zero sockaddr_storage is a valid, inert source-address out-param.
@@ -93,7 +110,7 @@ impl InterfaceMonitor {
                     log::warn!(
                         "interface monitor overflowed; notifications were dropped, re-resolving every interface"
                     );
-                    on_change(0);
+                    on_change(InterfaceEvent::Overflow);
                 } else if overflows >= MAX_CONSECUTIVE_OVERFLOWS {
                     log::warn!(
                         "interface monitor overflow did not clear after {overflows} reads; ending the drain"

--- a/src/interface/interface_monitor.rs
+++ b/src/interface/interface_monitor.rs
@@ -54,6 +54,18 @@ pub(crate) struct InterfaceMonitor {
 }
 
 impl InterfaceMonitor {
+    /// Whether this platform allocates interface indexes monotonically (Linux: 31-bit cyclic
+    /// per netns), so a newly-created interface always carries an index above every
+    /// previously-seen one. The dispatcher gates unknown-index [`InterfaceEvent::Link`]
+    /// events on that; the BSDs reuse indexes (FreeBSD hands out the lowest free, macOS
+    /// recycles the whole ifnet), so no such gate is sound there.
+    pub(crate) const INDEXES_MONOTONIC: bool = backend::INDEXES_MONOTONIC;
+
+    /// Whether this backend delivers [`InterfaceEvent::Link`] lifecycle events at all. Where
+    /// it does not (macOS: no `RTM_IFANNOUNCE`), an unknown-index address event is the only
+    /// signal a recreated interface ever sends, and must stand in as the recreation trigger.
+    pub(crate) const LIFECYCLE_EVENTS: bool = backend::LIFECYCLE_EVENTS;
+
     /// Open and subscribe a routing socket, non-blocking and close-on-exec.
     ///
     /// # Errors

--- a/src/interface/interface_monitor/route.rs
+++ b/src/interface/interface_monitor/route.rs
@@ -16,6 +16,15 @@ use super::InterfaceEvent;
 /// backend's 8 KiB suffices.
 pub(super) const READ_BUF: usize = 2048;
 
+/// See [`InterfaceMonitor::INDEXES_MONOTONIC`](super::InterfaceMonitor::INDEXES_MONOTONIC):
+/// the BSDs reuse indexes (FreeBSD hands out the lowest free one; macOS recycles the whole
+/// ifnet for stable-uniqueid drivers), so index ordering carries no creation signal.
+pub(super) const INDEXES_MONOTONIC: bool = false;
+
+/// See [`InterfaceMonitor::LIFECYCLE_EVENTS`](super::InterfaceMonitor::LIFECYCLE_EVENTS):
+/// FreeBSD announces arrival/departure via `RTM_IFANNOUNCE`; macOS has no lifecycle message.
+pub(super) const LIFECYCLE_EVENTS: bool = cfg!(target_os = "freebsd");
+
 /// Requested `SO_RCVBUF` for the route socket, whose default receive queue is only ~8 KiB. Enlarge it so
 /// a burst of routing messages is far less likely to overflow it and drop changes. Best-effort and
 /// kernel-clamped; FreeBSD's `SO_RERROR` still recovers from an overflow, and macOS (no `SO_RERROR`)

--- a/src/interface/interface_monitor/route.rs
+++ b/src/interface/interface_monitor/route.rs
@@ -9,6 +9,8 @@ use std::os::fd::{AsRawFd, OwnedFd};
 
 use libc::c_int;
 
+use super::InterfaceEvent;
+
 /// Holds one routing message: a fixed header plus a few small sockaddrs (the `RTAX_*` slots),
 /// a few hundred bytes. No rtnetlink-style attribute lists, so smaller than the `rtnetlink`
 /// backend's 8 KiB suffices.
@@ -25,6 +27,14 @@ const RECV_BUFFER: c_int = 256 * 1024;
 const INDEX_OFFSET: usize = 12;
 const _: () = assert!(std::mem::offset_of!(libc::ifa_msghdr, ifam_index) == INDEX_OFFSET);
 const _: () = assert!(std::mem::offset_of!(libc::if_msghdr, ifm_index) == INDEX_OFFSET);
+
+/// `ifan_index` (in `if_announcemsghdr`) sits earlier than the shared offset above: the announce
+/// header has no `ifam_addrs`/`ifm_data` before it. FreeBSD only; macOS has no `RTM_IFANNOUNCE`.
+#[cfg(target_os = "freebsd")]
+const ANNOUNCE_INDEX_OFFSET: usize = 4;
+#[cfg(target_os = "freebsd")]
+const _: () =
+    assert!(std::mem::offset_of!(libc::if_announcemsghdr, ifan_index) == ANNOUNCE_INDEX_OFFSET);
 
 /// Open a `PF_ROUTE` socket, non-blocking + close-on-exec.
 pub(super) fn open() -> io::Result<OwnedFd> {
@@ -63,10 +73,12 @@ pub(super) fn open() -> io::Result<OwnedFd> {
     Ok(sock)
 }
 
-/// Walk every routing message in `buf`; report the interface index of each `RTM_NEWADDR` /
-/// `RTM_DELADDR` (address change) and `RTM_IFINFO` (link/MAC change). Every routing message
-/// begins with `u16 msglen; u8 version; u8 type`.
-pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
+/// Walk every routing message in `buf`; report the interface index and event kind of each
+/// `RTM_NEWADDR` / `RTM_DELADDR` (address change) and `RTM_IFINFO` (link-state/MAC change --
+/// [`InterfaceEvent::Address`] too: a flap refreshes addresses, it isn't a lifecycle event),
+/// plus, on FreeBSD, `RTM_IFANNOUNCE` (interface arrival/departure, [`InterfaceEvent::Link`]).
+/// Every routing message begins with `u16 msglen; u8 version; u8 type`.
+pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(InterfaceEvent)) {
     let mut offset = 0;
     while offset + 4 <= buf.len() {
         let msglen = usize::from(u16::from_ne_bytes([buf[offset], buf[offset + 1]]));
@@ -81,18 +93,32 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
             );
             break;
         }
-        if matches!(
-            msg_type,
-            libc::RTM_NEWADDR | libc::RTM_DELADDR | libc::RTM_IFINFO
-        ) && msglen >= INDEX_OFFSET + 2
+        // Each subscribed type's index sits at its own fixed offset in the message header;
+        // `event` is the matching variant constructor.
+        let hit = match msg_type {
+            libc::RTM_NEWADDR | libc::RTM_DELADDR | libc::RTM_IFINFO => Some((
+                INDEX_OFFSET,
+                InterfaceEvent::Address as fn(u32) -> InterfaceEvent,
+            )),
+            #[cfg(target_os = "freebsd")]
+            libc::RTM_IFANNOUNCE => Some((
+                ANNOUNCE_INDEX_OFFSET,
+                InterfaceEvent::Link as fn(u32) -> InterfaceEvent,
+            )),
+            _ => None,
+        };
+        if let Some((index_offset, event)) = hit
+            && msglen >= index_offset + 2
         {
             let index =
-                u16::from_ne_bytes([buf[offset + INDEX_OFFSET], buf[offset + INDEX_OFFSET + 1]]);
-            // 0 names no interface (kernel indices are >= 1) and is the parent's "re-resolve
-            // everything" overflow signal, so a stray 0 must never be forwarded.
-            if index != 0 {
-                log::trace!("interface monitor: change for ifindex {index}");
-                on_change(u32::from(index));
+                u16::from_ne_bytes([buf[offset + index_offset], buf[offset + index_offset + 1]]);
+            if index == 0 {
+                // Kernel indices are >= 1, so a 0 is a malformed message; never forward it.
+                log::warn!("interface monitor: dropping a change with no valid interface index");
+            } else {
+                let event = event(u32::from(index));
+                log::trace!("interface monitor: {event:?}");
+                on_change(event);
             }
         }
         offset += msglen;
@@ -128,8 +154,26 @@ mod tests {
         let mut buf = message(libc::RTM_NEWADDR, 7, 20);
         buf.extend(message(libc::RTM_IFINFO, 9, 24));
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
-        assert_eq!(seen, [7, 9]);
+        for_each_change(&buf, &mut |e| seen.push(e));
+        // RTM_IFINFO is a flap/MAC change, not a lifecycle event, so both report Address.
+        assert_eq!(
+            seen,
+            [InterfaceEvent::Address(7), InterfaceEvent::Address(9)]
+        );
+    }
+
+    /// FreeBSD announces interface arrival/departure; the walk maps both to a Link event,
+    /// reading `ifan_index` at its own (earlier) offset.
+    #[cfg(target_os = "freebsd")]
+    #[test]
+    fn announce_messages_report_a_link_event() {
+        let mut m = vec![0u8; 24];
+        m[0..2].copy_from_slice(&24u16.to_ne_bytes());
+        m[3] = u8::try_from(libc::RTM_IFANNOUNCE).expect("RTM_IFANNOUNCE fits u8");
+        m[ANNOUNCE_INDEX_OFFSET..ANNOUNCE_INDEX_OFFSET + 2].copy_from_slice(&7u16.to_ne_bytes());
+        let mut seen = Vec::new();
+        for_each_change(&m, &mut |e| seen.push(e));
+        assert_eq!(seen, [InterfaceEvent::Link(7)]);
     }
 
     #[test]
@@ -137,7 +181,7 @@ mod tests {
         // RTM_ADD (a route was added) is neither an address nor a link change.
         let buf = message(libc::RTM_ADD, 5, 20);
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 
@@ -149,7 +193,7 @@ mod tests {
         buf[0..2].copy_from_slice(&u16::try_from(INDEX_OFFSET).unwrap().to_ne_bytes());
         buf[3] = u8::try_from(libc::RTM_NEWADDR).unwrap();
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 
@@ -159,7 +203,7 @@ mod tests {
         // must not be reported (which would trigger a spurious re-resolve of everything).
         let buf = message(libc::RTM_NEWADDR, 0, 20);
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 
@@ -168,7 +212,7 @@ mod tests {
         let mut buf = message(libc::RTM_NEWADDR, 7, 20);
         buf[0..2].copy_from_slice(&9999u16.to_ne_bytes()); // msglen past the datagram
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 }

--- a/src/interface/interface_monitor/rtnetlink.rs
+++ b/src/interface/interface_monitor/rtnetlink.rs
@@ -8,6 +8,7 @@ use std::os::fd::{AsRawFd, OwnedFd};
 use libc::socklen_t;
 
 use super::super::rtnetlink::read_at;
+use super::InterfaceEvent;
 use crate::libcex::{IfAddrMsg, NETLINK_ROUTE, NlMsgHdr, SockAddrNl, nl_align};
 
 /// Holds one notification. Multicast delivers one message per datagram, never a coalesced
@@ -51,9 +52,10 @@ pub(super) fn open() -> io::Result<OwnedFd> {
     Ok(sock)
 }
 
-/// Walk every netlink message in one datagram; report the interface index of each
-/// `RTM_{NEW,DEL}ADDR` (from its `ifaddrmsg`) and `RTM_{NEW,DEL}LINK` (from its `ifinfomsg`).
-pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
+/// Walk every netlink message in one datagram; report the interface index and event kind of
+/// each `RTM_{NEW,DEL}ADDR` ([`InterfaceEvent::Address`], from its `ifaddrmsg`) and
+/// `RTM_{NEW,DEL}LINK` ([`InterfaceEvent::Link`], from its `ifinfomsg`).
+pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(InterfaceEvent)) {
     let mut offset = 0;
     while let Some(hdr) = read_at::<NlMsgHdr>(buf, offset) {
         let len = hdr.len as usize;
@@ -75,15 +77,18 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(u32)) {
         match hdr.msg_type {
             libc::RTM_NEWADDR | libc::RTM_DELADDR => {
                 if let Some(body) = read_at::<IfAddrMsg>(&buf[..end], body_at) {
-                    report(body.index, on_change);
+                    report(body.index, InterfaceEvent::Address, on_change);
                 }
             }
             libc::RTM_NEWLINK | libc::RTM_DELLINK => {
-                // `ifi_index` is i32 but always a positive kernel index.
-                if let Some(body) = read_at::<libc::ifinfomsg>(&buf[..end], body_at)
-                    && let Ok(index) = u32::try_from(body.ifi_index)
-                {
-                    report(index, on_change);
+                if let Some(body) = read_at::<libc::ifinfomsg>(&buf[..end], body_at) {
+                    // `ifi_index` is i32 but always a positive kernel index; a negative one is
+                    // as malformed as 0, so fold it in for report's drop-and-warn.
+                    report(
+                        u32::try_from(body.ifi_index).unwrap_or(0),
+                        InterfaceEvent::Link,
+                        on_change,
+                    );
                 }
             }
             _ => {}
@@ -104,14 +109,22 @@ pub(super) fn sender_ok(src: &libc::sockaddr_storage, len: socklen_t) -> bool {
     nl.pid == 0
 }
 
-/// Forward a change for `index`, unless `index` is 0. Zero names no interface (kernel
-/// indices are >= 1) and is the parent's "re-resolve everything" overflow signal, so a stray
-/// 0 must never be forwarded.
-fn report(index: u32, on_change: &mut impl FnMut(u32)) {
-    if index != 0 {
-        log::trace!("interface monitor: change for ifindex {index}");
-        on_change(index);
+/// Forward an `event(index)` change; `event` is a variant constructor
+/// ([`InterfaceEvent::Address`] or [`InterfaceEvent::Link`]). Kernel indices are >= 1, so a 0
+/// (including a folded-in negative `ifi_index`) is a malformed message: dropped with a warn
+/// rather than forwarded as nonsense.
+fn report(
+    index: u32,
+    event: fn(u32) -> InterfaceEvent,
+    on_change: &mut impl FnMut(InterfaceEvent),
+) {
+    if index == 0 {
+        log::warn!("interface monitor: dropping a change with no valid interface index");
+        return;
     }
+    let event = event(index);
+    log::trace!("interface monitor: {event:?}");
+    on_change(event);
 }
 
 #[cfg(test)]
@@ -174,8 +187,8 @@ mod tests {
         let mut buf = message(libc::RTM_NEWADDR, &ifaddrmsg(7));
         buf.extend(message(libc::RTM_DELLINK, &ifinfomsg(9)));
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
-        assert_eq!(seen, [7, 9]);
+        for_each_change(&buf, &mut |e| seen.push(e));
+        assert_eq!(seen, [InterfaceEvent::Address(7), InterfaceEvent::Link(9)]);
     }
 
     #[test]
@@ -183,7 +196,7 @@ mod tests {
         // NLMSG_DONE (3) and any non-addr/link type carry no interface index for us.
         let buf = message(3, &ifaddrmsg(5));
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 
@@ -192,7 +205,7 @@ mod tests {
         // A truncated ifaddrmsg (claimed type, body shorter than ifaddrmsg) yields nothing.
         let buf = message(libc::RTM_NEWADDR, &[0u8; 2]);
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 
@@ -202,7 +215,7 @@ mod tests {
         // must not be reported (which would trigger a spurious re-resolve of everything).
         let buf = message(libc::RTM_NEWADDR, &ifaddrmsg(0));
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 
@@ -211,7 +224,7 @@ mod tests {
         let mut buf = message(libc::RTM_NEWADDR, &ifaddrmsg(7));
         buf[0..4].copy_from_slice(&9999u32.to_ne_bytes()); // len past the datagram
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
+        for_each_change(&buf, &mut |e| seen.push(e));
         assert!(seen.is_empty());
     }
 
@@ -225,7 +238,7 @@ mod tests {
         buf.extend(message(libc::RTM_NEWADDR, &ifaddrmsg(9)));
         buf[second..second + 4].copy_from_slice(&u32::MAX.to_ne_bytes());
         let mut seen = Vec::new();
-        for_each_change(&buf, &mut |i| seen.push(i));
-        assert_eq!(seen, [7]);
+        for_each_change(&buf, &mut |e| seen.push(e));
+        assert_eq!(seen, [InterfaceEvent::Address(7)]);
     }
 }

--- a/src/interface/interface_monitor/rtnetlink.rs
+++ b/src/interface/interface_monitor/rtnetlink.rs
@@ -16,6 +16,14 @@ use crate::libcex::{IfAddrMsg, NETLINK_ROUTE, NlMsgHdr, SockAddrNl, nl_align};
 /// (stats, `IFLA_AF_SPEC`, VF info) at ~1 KB; addresses are far smaller. 8 KiB is roomy.
 pub(super) const READ_BUF: usize = 8192;
 
+/// See [`InterfaceMonitor::INDEXES_MONOTONIC`](super::InterfaceMonitor::INDEXES_MONOTONIC):
+/// Linux allocates indexes cyclically over a 31-bit space, never reusing until wrap.
+pub(super) const INDEXES_MONOTONIC: bool = true;
+
+/// See [`InterfaceMonitor::LIFECYCLE_EVENTS`](super::InterfaceMonitor::LIFECYCLE_EVENTS):
+/// `RTM_{NEW,DEL}LINK` are subscribed and forwarded.
+pub(super) const LIFECYCLE_EVENTS: bool = true;
+
 /// Subscribe v4/v6 address adds+removes and link (MAC/state) changes. A MAC change arrives
 /// as `RTM_NEWLINK`, not an address event, so `RTMGRP_LINK` is needed to catch it.
 const SUBSCRIBED_GROUPS: u32 =

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -9,7 +9,7 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 use libc::{c_int, c_void};
 
-use crate::sys::{IoStatus, open_socket, sockaddr_for, socklen_of, would_block};
+use crate::sys::{IoStatus, open_socket, so_error, sockaddr_for, socklen_of, would_block};
 
 /// Listen backlog. A DIAL listener fields a few short-lived client fetches, so this is ample.
 const LISTEN_BACKLOG: c_int = 16;
@@ -276,26 +276,6 @@ fn connect_v4(fd: RawFd, dst: SocketAddrV4) -> io::Result<bool> {
         return Ok(true);
     }
     Err(err)
-}
-
-/// Read the socket's pending error (`SO_ERROR`) after a non-blocking connect's writable edge.
-fn so_error(fd: RawFd) -> io::Result<c_int> {
-    let mut err: c_int = 0;
-    let mut len = socklen_of::<c_int>();
-    // SAFETY: `&err`/`&len` are a valid (value, length) out-pair of `c_int` size for `fd`.
-    let rc = unsafe {
-        libc::getsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_ERROR,
-            (&raw mut err).cast::<c_void>(),
-            &raw mut len,
-        )
-    };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(err)
 }
 
 /// Constrain `fd`'s egress to the interface named `iface` so a route lookup can't leak the connect

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -293,7 +293,7 @@ mod tests {
         let handler = ctx.handler_keys()[0];
 
         // A change on an unrelated interface leaves the proxy alone.
-        ctx.evict_on_interface_change(&mut reactor, |c| c == CaptureKey::from_u64(99), "test");
+        ctx.evict_on_interface_change(&mut reactor, &[CaptureKey::from_u64(99)], "test");
         assert_eq!(
             ctx.proxy_count(),
             1,
@@ -302,14 +302,14 @@ mod tests {
         assert!(reactor.is_registered(handler));
 
         // A change on its source interface evicts and unregisters it.
-        ctx.evict_on_interface_change(&mut reactor, |c| c == advert_source(), "test");
+        ctx.evict_on_interface_change(&mut reactor, &[advert_source()], "test");
         assert_eq!(ctx.proxy_count(), 0, "a source interface change evicts it");
         assert!(!reactor.is_registered(handler), "and unregisters it");
 
         // A re-mint is evicted just the same by a change on its target interface.
         rewrite_advert(&mut ctx, &mut reactor, DIAL_ADVERT).expect("re-minted");
         let handler = ctx.handler_keys()[0];
-        ctx.evict_on_interface_change(&mut reactor, |c| c == advert_target(), "test");
+        ctx.evict_on_interface_change(&mut reactor, &[advert_target()], "test");
         assert_eq!(
             ctx.proxy_count(),
             0,
@@ -328,7 +328,7 @@ mod tests {
             .unregister(ctx.handler_keys()[0])
             .expect("unregister the proxy");
         // An interface change matching no live proxy still prunes the now-stale entry.
-        ctx.evict_on_interface_change(&mut reactor, |_| false, "test");
+        ctx.evict_on_interface_change(&mut reactor, &[], "test");
         assert_eq!(ctx.proxy_count(), 0, "the already-evicted entry is pruned");
     }
 

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -293,7 +293,7 @@ mod tests {
         let handler = ctx.handler_keys()[0];
 
         // A change on an unrelated interface leaves the proxy alone.
-        ctx.evict_on_interface_change(&mut reactor, |c| c == CaptureKey::from_u64(99));
+        ctx.evict_on_interface_change(&mut reactor, |c| c == CaptureKey::from_u64(99), "test");
         assert_eq!(
             ctx.proxy_count(),
             1,
@@ -302,14 +302,14 @@ mod tests {
         assert!(reactor.is_registered(handler));
 
         // A change on its source interface evicts and unregisters it.
-        ctx.evict_on_interface_change(&mut reactor, |c| c == advert_source());
+        ctx.evict_on_interface_change(&mut reactor, |c| c == advert_source(), "test");
         assert_eq!(ctx.proxy_count(), 0, "a source interface change evicts it");
         assert!(!reactor.is_registered(handler), "and unregisters it");
 
         // A re-mint is evicted just the same by a change on its target interface.
         rewrite_advert(&mut ctx, &mut reactor, DIAL_ADVERT).expect("re-minted");
         let handler = ctx.handler_keys()[0];
-        ctx.evict_on_interface_change(&mut reactor, |c| c == advert_target());
+        ctx.evict_on_interface_change(&mut reactor, |c| c == advert_target(), "test");
         assert_eq!(
             ctx.proxy_count(),
             0,
@@ -328,7 +328,7 @@ mod tests {
             .unregister(ctx.handler_keys()[0])
             .expect("unregister the proxy");
         // An interface change matching no live proxy still prunes the now-stale entry.
-        ctx.evict_on_interface_change(&mut reactor, |_| false);
+        ctx.evict_on_interface_change(&mut reactor, |_| false, "test");
         assert_eq!(ctx.proxy_count(), 0, "the already-evicted entry is pruned");
     }
 

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -396,26 +396,25 @@ impl PacketHandler for SearchReflector {
         });
     }
 
-    /// A capture this reflector uses was rebound to a recreated interface, or its address moved. Every
-    /// session's reserved port and response registration were bound to that interface's old identity,
-    /// so drop them all (their ports free with the reservations); the next search re-opens fresh
-    /// against the current one. Both captures share every session, so a change on either clears all.
+    /// The target interface was rebound (recreated) or its reply address moved, so every session's
+    /// reserved port and response registration -- both bound to the target -- are stale; drop them all
+    /// (their ports free with the reservations) and let the next search re-open fresh. A SOURCE change
+    /// is deliberately ignored: the reply leg holds only the source's `CaptureKey` (stable across a
+    /// rebind) and re-resolves the source address at send time, so a session outlives it untouched.
     fn on_iface_change(
         &mut self,
         captures: &[CaptureKey],
         dispatcher: &mut PacketDispatcher,
         _reactor: &mut Reactor,
     ) {
-        if self.sessions.is_empty()
-            || !(captures.contains(&self.source) || captures.contains(&self.target))
-        {
+        if self.sessions.is_empty() || !captures.contains(&self.target) {
             return;
         }
         for session in self.sessions.drain(..) {
             dispatcher.unregister(session.response_key);
         }
         log::debug!(
-            "{}: cleared all sessions after an interface they use changed",
+            "{}: cleared all sessions after the target interface changed",
             self.name
         );
     }
@@ -681,10 +680,11 @@ mod tests {
         );
     }
 
-    // The source capture clears sessions too: its egress leg belongs to every session, so a change
-    // on either the source or the target invalidates them.
+    // A SOURCE capture change leaves sessions intact: the reservation and response registration live
+    // on the target, and the reply leg only holds the source's (stable) CaptureKey and re-resolves the
+    // source address at send time, so a source recreation does not orphan anything.
     #[test]
-    fn on_iface_change_on_the_source_capture_clears_sessions() {
+    fn on_iface_change_leaves_sessions_on_a_source_capture_change() {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new().unwrap();
         let mut reflector = test_reflector();
@@ -695,13 +695,15 @@ mod tests {
             "239.255.255.250:1900",
             Instant::now() + Duration::from_secs(5),
         );
+        assert_eq!(dispatcher.registration_count(), 1);
         let source = reflector.source;
         reflector.on_iface_change(&[source], &mut dispatcher, &mut reactor);
-        assert!(
-            reflector.sessions.is_empty(),
-            "a change on the source capture clears the session"
+        assert_eq!(
+            reflector.sessions.len(),
+            1,
+            "a source capture change leaves the session (its reply leg re-resolves)"
         );
-        assert_eq!(dispatcher.registration_count(), 0);
+        assert_eq!(dispatcher.registration_count(), 1);
     }
 
     #[test]

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -39,15 +39,6 @@ struct Session {
     /// The multicast group searched; part of the dedup key, since its scope picks the reserved reply
     /// address — a different group is a new session, not a retransmit.
     dest: SocketAddr,
-    /// The target address the reservation was minted against. A retransmit re-checks it: if the
-    /// target's pick moved (an interface recreation or address change), the reservation is bound
-    /// to a vanished address and the session must re-mint, not be reused.
-    our_addr: IpAddr,
-    /// The target ifindex the reservation's scope was bound with. A link-local `our_addr` can
-    /// survive a recreate unchanged while its zone (this index) moves, so the retransmit re-check
-    /// compares it too -- a zoneless address match alone would reuse a reservation bound to the
-    /// dead zone.
-    our_ifindex: u32,
     expiry: Instant,
     reservation: PortReservation,
     response_key: RegistrationKey,
@@ -254,8 +245,6 @@ impl SearchReflector {
         Ok(Session {
             searcher: packet.source,
             dest: packet.dest,
-            our_addr,
-            our_ifindex: target_ifindex,
             expiry,
             reservation,
             response_key,
@@ -314,59 +303,40 @@ impl PacketHandler for SearchReflector {
 
         // A retransmit from a known searcher to the same group reuses its session: refresh the window
         // and re-reflect from the same reserved port. A new searcher, or the same searcher to a
-        // different group (a different reply scope), opens a fresh session. The reuse is conditional
-        // on the session's reply binding -- the address, and the target ifindex its (link-local)
-        // zone was bound with -- still matching the target's current pick: an interface recreation
-        // or address change orphans the reservation (bound to a vanished address or zone), and an
-        // unbroken retransmit stream would otherwise keep the dead session alive forever. A
-        // transiently address-less target (`None`) keeps the session -- the same address usually
-        // returns, and the re-reflect below fails harmlessly until it does.
+        // different group (a different reply scope), opens a fresh session. No staleness check here:
+        // an interface recreation or address change orphans a session's reservation, but the dispatcher
+        // drops such sessions eagerly via [`on_iface_change`](SearchReflector::on_iface_change), so a
+        // reused session is always bound to the interface's current identity.
         if let Some(index) = session_for(&self.sessions, packet.source, packet.dest) {
-            let current = reply_source(dispatcher, self.target, packet.dest.ip());
-            let current_ifindex = dispatcher.capture_ifindex(self.target).unwrap_or(0);
-            let moved = matches!(current, Some(addr)
-                if addr != self.sessions[index].our_addr
-                    || current_ifindex != self.sessions[index].our_ifindex);
-            if moved {
-                let session = self.sessions.swap_remove(index);
-                dispatcher.unregister(session.response_key);
-                log::debug!(
-                    "{}: re-minting the session for {} (its reply binding moved)",
-                    self.name,
-                    packet.source
-                );
-                // Fall through to open a fresh session against the current address.
-            } else {
-                let session = &mut self.sessions[index];
-                let port = session.reservation.port();
-                return match dispatcher.send_udp_group(
-                    self.target,
-                    packet.dest,
-                    port,
-                    self.ttl,
-                    packet.payload,
-                ) {
-                    Ok(()) => {
-                        session.expiry = expiry;
-                        log::debug!(
-                            "re-reflected {} search from {} to {} on reserved port {port}",
-                            self.name,
-                            packet.source,
-                            packet.dest
-                        );
-                        Outcome::Reflected(message_type)
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "{}: cannot reflect search from {} to {}: {e}",
-                            self.name,
-                            packet.source,
-                            packet.dest
-                        );
-                        Outcome::Dropped(message_type)
-                    }
-                };
-            }
+            let session = &mut self.sessions[index];
+            let port = session.reservation.port();
+            return match dispatcher.send_udp_group(
+                self.target,
+                packet.dest,
+                port,
+                self.ttl,
+                packet.payload,
+            ) {
+                Ok(()) => {
+                    session.expiry = expiry;
+                    log::debug!(
+                        "re-reflected {} search from {} to {} on reserved port {port}",
+                        self.name,
+                        packet.source,
+                        packet.dest
+                    );
+                    Outcome::Reflected(message_type)
+                }
+                Err(e) => {
+                    log::warn!(
+                        "{}: cannot reflect search from {} to {}: {e}",
+                        self.name,
+                        packet.source,
+                        packet.dest
+                    );
+                    Outcome::Dropped(message_type)
+                }
+            };
         }
 
         let session = match self.make_session(packet, dispatcher, expiry, message_type) {
@@ -425,11 +395,34 @@ impl PacketHandler for SearchReflector {
             }
         });
     }
+
+    /// A capture this reflector uses was rebound to a recreated interface, or its address moved. Every
+    /// session's reserved port and response registration were bound to that interface's old identity,
+    /// so drop them all (their ports free with the reservations); the next search re-opens fresh
+    /// against the current one. Both captures share every session, so a change on either clears all.
+    fn on_iface_change(
+        &mut self,
+        captures: &[CaptureKey],
+        dispatcher: &mut PacketDispatcher,
+        _reactor: &mut Reactor,
+    ) {
+        if self.sessions.is_empty()
+            || !(captures.contains(&self.source) || captures.contains(&self.target))
+        {
+            return;
+        }
+        for session in self.sessions.drain(..) {
+            dispatcher.unregister(session.response_key);
+        }
+        log::debug!(
+            "{}: cleared all sessions after an interface they use changed",
+            self.name
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io;
     use std::net::Ipv4Addr;
 
     use super::*;
@@ -494,8 +487,6 @@ mod tests {
         reflector.sessions.push(Session {
             searcher,
             dest,
-            our_addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            our_ifindex: 0,
             expiry,
             reservation,
             response_key,
@@ -641,132 +632,76 @@ mod tests {
         assert!(session_for(&reflector.sessions, searcher, site_local).is_none());
     }
 
-    // A retransmit only reuses a session whose mint-time reply address is still the target's
-    // current pick: an interface recreation or address change orphans the reservation (bound to
-    // the vanished address), so the session is torn down and a fresh one minted. A real loopback
-    // target lets the fresh mint succeed.
+    // on_iface_change drops every session on a capture the reflector uses: a recreation or address
+    // change orphaned each session's reservation and response registration, so they must go (their
+    // ports free with the reservations) and the next search re-opens fresh. A change on a capture the
+    // reflector does not use leaves them.
     #[test]
-    fn a_retransmit_re_mints_a_session_whose_reply_address_moved() -> io::Result<()> {
-        let Some(target_cap) = open_loopback_or_skip() else {
-            return Ok(());
-        };
+    fn on_iface_change_clears_sessions_on_a_used_capture() {
         let mut dispatcher = PacketDispatcher::new();
-        let target = dispatcher
-            .add_capture(target_cap)
-            .expect("add the loopback capture");
-        let mut reactor = Reactor::new()?;
-        let mut reflector = SearchReflector::new(
-            CaptureKey::from_u64(999), // synthetic source: no reply comes back in this test
-            target,
-            None,
-            "TEST",
-            MessageType::SsdpResponse,
-            TEST_TTL,
-            always_reflect,
-            fixed_window,
-            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+        let mut reactor = Reactor::new().unwrap();
+        let mut reflector = test_reflector();
+        let expiry = Instant::now() + Duration::from_secs(5);
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.1:5",
+            "239.255.255.250:1900",
+            expiry,
         );
         push_session(
             &mut reflector,
             &mut dispatcher,
-            "10.0.0.7:50000",
+            "10.0.0.2:5",
             "239.255.255.250:1900",
-            Instant::now() + Duration::from_secs(5),
+            expiry,
         );
-        // The session was minted against an address the target no longer holds.
-        reflector.sessions[0].our_addr = IpAddr::V4(Ipv4Addr::new(10, 9, 9, 9));
-        assert_eq!(dispatcher.registration_count(), 1);
+        assert_eq!(dispatcher.registration_count(), 2);
 
-        let packet = Packet {
-            source: "10.0.0.7:50000".parse().unwrap(),
-            dest: "239.255.255.250:1900".parse().unwrap(),
-            ttl: TEST_TTL,
-            dst_mac: None,
-            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
-            payload: b"a search",
-        };
-        reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
-
+        // A capture the reflector does not use: the sessions stand.
+        reflector.on_iface_change(&[CaptureKey::from_u64(42)], &mut dispatcher, &mut reactor);
         assert_eq!(
             reflector.sessions.len(),
-            1,
-            "one fresh session replaces the orphaned one"
+            2,
+            "a change on an unused capture leaves the sessions"
         );
-        assert_eq!(
-            reflector.sessions[0].our_addr,
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-            "the fresh session is minted against the target's current address"
+        assert_eq!(dispatcher.registration_count(), 2);
+
+        // The target capture, shared by every session: all cleared, their response captures gone.
+        let target = reflector.target;
+        reflector.on_iface_change(&[target], &mut dispatcher, &mut reactor);
+        assert!(
+            reflector.sessions.is_empty(),
+            "a change on the target capture clears every session"
         );
         assert_eq!(
             dispatcher.registration_count(),
-            1,
-            "the orphaned response capture was unregistered, the fresh one registered"
+            0,
+            "each cleared session's response capture is unregistered"
         );
-        Ok(())
     }
 
-    // A retransmit also re-mints when the target's reply address is unchanged but its ifindex
-    // moved: a recreate can keep a link-local address while its zone (the ifindex the reservation
-    // was bound with) changes, orphaning the reservation. Exercised with a stale ifindex on a
-    // loopback target whose address still matches the current pick, so only the zone clause fires.
+    // The source capture clears sessions too: its egress leg belongs to every session, so a change
+    // on either the source or the target invalidates them.
     #[test]
-    fn a_retransmit_re_mints_a_session_whose_target_ifindex_moved() -> io::Result<()> {
-        let Some(target_cap) = open_loopback_or_skip() else {
-            return Ok(());
-        };
+    fn on_iface_change_on_the_source_capture_clears_sessions() {
         let mut dispatcher = PacketDispatcher::new();
-        let target = dispatcher
-            .add_capture(target_cap)
-            .expect("add the loopback capture");
-        let mut reactor = Reactor::new()?;
-        let mut reflector = SearchReflector::new(
-            CaptureKey::from_u64(999), // synthetic source: no reply comes back in this test
-            target,
-            None,
-            "TEST",
-            MessageType::SsdpResponse,
-            TEST_TTL,
-            always_reflect,
-            fixed_window,
-            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
-        );
+        let mut reactor = Reactor::new().unwrap();
+        let mut reflector = test_reflector();
         push_session(
             &mut reflector,
             &mut dispatcher,
-            "10.0.0.7:50000",
+            "10.0.0.1:5",
             "239.255.255.250:1900",
             Instant::now() + Duration::from_secs(5),
         );
-        // Address still matches the target's current pick, but the reservation was bound under a
-        // since-vanished ifindex, so the zone clause of the re-mint gate must fire.
-        reflector.sessions[0].our_ifindex = 9999;
-        assert_eq!(dispatcher.registration_count(), 1);
-
-        let packet = Packet {
-            source: "10.0.0.7:50000".parse().unwrap(),
-            dest: "239.255.255.250:1900".parse().unwrap(),
-            ttl: TEST_TTL,
-            dst_mac: None,
-            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
-            payload: b"a search",
-        };
-        reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
-
-        assert_eq!(
-            reflector.sessions.len(),
-            1,
-            "one fresh session replaces the stale-zone one"
+        let source = reflector.source;
+        reflector.on_iface_change(&[source], &mut dispatcher, &mut reactor);
+        assert!(
+            reflector.sessions.is_empty(),
+            "a change on the source capture clears the session"
         );
-        assert_ne!(
-            reflector.sessions[0].our_ifindex, 9999,
-            "the fresh session is minted against the target's current ifindex"
-        );
-        assert_eq!(
-            dispatcher.registration_count(),
-            1,
-            "the orphaned response capture was unregistered, the fresh one registered"
-        );
-        Ok(())
+        assert_eq!(dispatcher.registration_count(), 0);
     }
 
     #[test]

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -39,6 +39,15 @@ struct Session {
     /// The multicast group searched; part of the dedup key, since its scope picks the reserved reply
     /// address — a different group is a new session, not a retransmit.
     dest: SocketAddr,
+    /// The target address the reservation was minted against. A retransmit re-checks it: if the
+    /// target's pick moved (an interface recreation or address change), the reservation is bound
+    /// to a vanished address and the session must re-mint, not be reused.
+    our_addr: IpAddr,
+    /// The target ifindex the reservation's scope was bound with. A link-local `our_addr` can
+    /// survive a recreate unchanged while its zone (this index) moves, so the retransmit re-check
+    /// compares it too -- a zoneless address match alone would reuse a reservation bound to the
+    /// dead zone.
+    our_ifindex: u32,
     expiry: Instant,
     reservation: PortReservation,
     response_key: RegistrationKey,
@@ -200,20 +209,7 @@ impl SearchReflector {
             );
             return Err(Outcome::Dropped(message_type));
         };
-        // The replies come to the address the reflected search is sourced from, at the reserved port,
-        // so this must be the same scope-matched pick `build_udp` makes for `packet.dest`, or the
-        // device replies to a source the response capture below isn't watching.
-        let our_addr = match packet.dest.ip() {
-            IpAddr::V4(_) => dispatcher
-                .egress_addrs(self.target)
-                .and_then(InterfaceAddresses::v4)
-                .map(IpAddr::V4),
-            IpAddr::V6(dst6) => dispatcher
-                .egress_addrs(self.target)
-                .and_then(|a| a.v6(Ipv6Scope::of(dst6)))
-                .map(IpAddr::V6),
-        };
-        let Some(our_addr) = our_addr else {
+        let Some(our_addr) = reply_source(dispatcher, self.target, packet.dest.ip()) else {
             log::warn!(
                 "{}: cannot reflect search from {}: target has no source address for {} yet",
                 self.name,
@@ -258,6 +254,8 @@ impl SearchReflector {
         Ok(Session {
             searcher: packet.source,
             dest: packet.dest,
+            our_addr,
+            our_ifindex: target_ifindex,
             expiry,
             reservation,
             response_key,
@@ -265,19 +263,30 @@ impl SearchReflector {
     }
 }
 
-/// The live session a search belongs to: same searcher *and* same group. The group is part of the key
-/// because its scope picks the reserved reply address, so a search to a different group is a new session,
-/// not a retransmit. A free fn over `&mut [Session]`, not a `&mut self` method: a `&mut self` return
-/// would lock all of `self`, but the caller reads other fields (`target`, `ttl`) while holding the
-/// session.
-fn session_for(
-    sessions: &mut [Session],
-    source: SocketAddr,
-    dest: SocketAddr,
-) -> Option<&mut Session> {
+/// The target-side source address replies to `dest` come back to: the same scope-matched pick
+/// `build_udp` makes for the reflected search, so the reserved port and its response capture
+/// watch the address the device actually answers.
+fn reply_source(dispatcher: &PacketDispatcher, target: CaptureKey, dest: IpAddr) -> Option<IpAddr> {
+    match dest {
+        IpAddr::V4(_) => dispatcher
+            .egress_addrs(target)
+            .and_then(InterfaceAddresses::v4)
+            .map(IpAddr::V4),
+        IpAddr::V6(dst6) => dispatcher
+            .egress_addrs(target)
+            .and_then(|a| a.v6(Ipv6Scope::of(dst6)))
+            .map(IpAddr::V6),
+    }
+}
+
+/// The index of the live session a search belongs to: same searcher *and* same group. The group is
+/// part of the key because its scope picks the reserved reply address, so a search to a different
+/// group is a new session, not a retransmit. An index, not a `&mut Session`: the caller decides
+/// between reusing the session and evicting it, and a borrow would lock `self.sessions` for both.
+fn session_for(sessions: &[Session], source: SocketAddr, dest: SocketAddr) -> Option<usize> {
     sessions
-        .iter_mut()
-        .find(|s| s.searcher == source && s.dest == dest)
+        .iter()
+        .position(|s| s.searcher == source && s.dest == dest)
 }
 
 impl PacketHandler for SearchReflector {
@@ -303,38 +312,61 @@ impl PacketHandler for SearchReflector {
         };
         let expiry = Instant::now() + (self.window)(packet.payload);
 
-        // A retransmit from a known searcher to the same group reuses its session: refresh the window and
-        // re-reflect from the same reserved port. A new searcher, or the same searcher to a different
-        // group (a different reply scope), opens a fresh session.
-        if let Some(session) = session_for(&mut self.sessions, packet.source, packet.dest) {
-            let port = session.reservation.port();
-            return match dispatcher.send_udp_group(
-                self.target,
-                packet.dest,
-                port,
-                self.ttl,
-                packet.payload,
-            ) {
-                Ok(()) => {
-                    session.expiry = expiry;
-                    log::debug!(
-                        "re-reflected {} search from {} to {} on reserved port {port}",
-                        self.name,
-                        packet.source,
-                        packet.dest
-                    );
-                    Outcome::Reflected(message_type)
-                }
-                Err(e) => {
-                    log::warn!(
-                        "{}: cannot reflect search from {} to {}: {e}",
-                        self.name,
-                        packet.source,
-                        packet.dest
-                    );
-                    Outcome::Dropped(message_type)
-                }
-            };
+        // A retransmit from a known searcher to the same group reuses its session: refresh the window
+        // and re-reflect from the same reserved port. A new searcher, or the same searcher to a
+        // different group (a different reply scope), opens a fresh session. The reuse is conditional
+        // on the session's reply binding -- the address, and the target ifindex its (link-local)
+        // zone was bound with -- still matching the target's current pick: an interface recreation
+        // or address change orphans the reservation (bound to a vanished address or zone), and an
+        // unbroken retransmit stream would otherwise keep the dead session alive forever. A
+        // transiently address-less target (`None`) keeps the session -- the same address usually
+        // returns, and the re-reflect below fails harmlessly until it does.
+        if let Some(index) = session_for(&self.sessions, packet.source, packet.dest) {
+            let current = reply_source(dispatcher, self.target, packet.dest.ip());
+            let current_ifindex = dispatcher.capture_ifindex(self.target).unwrap_or(0);
+            let moved = matches!(current, Some(addr)
+                if addr != self.sessions[index].our_addr
+                    || current_ifindex != self.sessions[index].our_ifindex);
+            if moved {
+                let session = self.sessions.swap_remove(index);
+                dispatcher.unregister(session.response_key);
+                log::debug!(
+                    "{}: re-minting the session for {} (its reply binding moved)",
+                    self.name,
+                    packet.source
+                );
+                // Fall through to open a fresh session against the current address.
+            } else {
+                let session = &mut self.sessions[index];
+                let port = session.reservation.port();
+                return match dispatcher.send_udp_group(
+                    self.target,
+                    packet.dest,
+                    port,
+                    self.ttl,
+                    packet.payload,
+                ) {
+                    Ok(()) => {
+                        session.expiry = expiry;
+                        log::debug!(
+                            "re-reflected {} search from {} to {} on reserved port {port}",
+                            self.name,
+                            packet.source,
+                            packet.dest
+                        );
+                        Outcome::Reflected(message_type)
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "{}: cannot reflect search from {} to {}: {e}",
+                            self.name,
+                            packet.source,
+                            packet.dest
+                        );
+                        Outcome::Dropped(message_type)
+                    }
+                };
+            }
         }
 
         let session = match self.make_session(packet, dispatcher, expiry, message_type) {
@@ -397,6 +429,7 @@ impl PacketHandler for SearchReflector {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use std::net::Ipv4Addr;
 
     use super::*;
@@ -461,6 +494,8 @@ mod tests {
         reflector.sessions.push(Session {
             searcher,
             dest,
+            our_addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            our_ifindex: 0,
             expiry,
             reservation,
             response_key,
@@ -602,8 +637,136 @@ mod tests {
         let searcher: SocketAddr = "[fe80::1]:50000".parse().unwrap();
         let link_local: SocketAddr = "[ff02::c]:1900".parse().unwrap();
         let site_local: SocketAddr = "[ff05::c]:1900".parse().unwrap();
-        assert!(session_for(&mut reflector.sessions, searcher, link_local).is_some());
-        assert!(session_for(&mut reflector.sessions, searcher, site_local).is_none());
+        assert!(session_for(&reflector.sessions, searcher, link_local).is_some());
+        assert!(session_for(&reflector.sessions, searcher, site_local).is_none());
+    }
+
+    // A retransmit only reuses a session whose mint-time reply address is still the target's
+    // current pick: an interface recreation or address change orphans the reservation (bound to
+    // the vanished address), so the session is torn down and a fresh one minted. A real loopback
+    // target lets the fresh mint succeed.
+    #[test]
+    fn a_retransmit_re_mints_a_session_whose_reply_address_moved() -> io::Result<()> {
+        let Some(target_cap) = open_loopback_or_skip() else {
+            return Ok(());
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let target = dispatcher
+            .add_capture(target_cap)
+            .expect("add the loopback capture");
+        let mut reactor = Reactor::new()?;
+        let mut reflector = SearchReflector::new(
+            CaptureKey::from_u64(999), // synthetic source: no reply comes back in this test
+            target,
+            None,
+            "TEST",
+            MessageType::SsdpResponse,
+            TEST_TTL,
+            always_reflect,
+            fixed_window,
+            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+        );
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.7:50000",
+            "239.255.255.250:1900",
+            Instant::now() + Duration::from_secs(5),
+        );
+        // The session was minted against an address the target no longer holds.
+        reflector.sessions[0].our_addr = IpAddr::V4(Ipv4Addr::new(10, 9, 9, 9));
+        assert_eq!(dispatcher.registration_count(), 1);
+
+        let packet = Packet {
+            source: "10.0.0.7:50000".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
+            payload: b"a search",
+        };
+        reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
+
+        assert_eq!(
+            reflector.sessions.len(),
+            1,
+            "one fresh session replaces the orphaned one"
+        );
+        assert_eq!(
+            reflector.sessions[0].our_addr,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            "the fresh session is minted against the target's current address"
+        );
+        assert_eq!(
+            dispatcher.registration_count(),
+            1,
+            "the orphaned response capture was unregistered, the fresh one registered"
+        );
+        Ok(())
+    }
+
+    // A retransmit also re-mints when the target's reply address is unchanged but its ifindex
+    // moved: a recreate can keep a link-local address while its zone (the ifindex the reservation
+    // was bound with) changes, orphaning the reservation. Exercised with a stale ifindex on a
+    // loopback target whose address still matches the current pick, so only the zone clause fires.
+    #[test]
+    fn a_retransmit_re_mints_a_session_whose_target_ifindex_moved() -> io::Result<()> {
+        let Some(target_cap) = open_loopback_or_skip() else {
+            return Ok(());
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let target = dispatcher
+            .add_capture(target_cap)
+            .expect("add the loopback capture");
+        let mut reactor = Reactor::new()?;
+        let mut reflector = SearchReflector::new(
+            CaptureKey::from_u64(999), // synthetic source: no reply comes back in this test
+            target,
+            None,
+            "TEST",
+            MessageType::SsdpResponse,
+            TEST_TTL,
+            always_reflect,
+            fixed_window,
+            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+        );
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.7:50000",
+            "239.255.255.250:1900",
+            Instant::now() + Duration::from_secs(5),
+        );
+        // Address still matches the target's current pick, but the reservation was bound under a
+        // since-vanished ifindex, so the zone clause of the re-mint gate must fire.
+        reflector.sessions[0].our_ifindex = 9999;
+        assert_eq!(dispatcher.registration_count(), 1);
+
+        let packet = Packet {
+            source: "10.0.0.7:50000".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
+            payload: b"a search",
+        };
+        reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
+
+        assert_eq!(
+            reflector.sessions.len(),
+            1,
+            "one fresh session replaces the stale-zone one"
+        );
+        assert_ne!(
+            reflector.sessions[0].our_ifindex, 9999,
+            "the fresh session is minted against the target's current ifindex"
+        );
+        assert_eq!(
+            dispatcher.registration_count(),
+            1,
+            "the orphaned response capture was unregistered, the fresh one registered"
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -8,7 +8,7 @@ use std::net::{IpAddr, Ipv6Addr};
 use std::os::fd::AsRawFd;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 
-use libc::{c_int, socklen_t};
+use libc::{c_int, c_void, socklen_t};
 
 /// Take ownership of a raw fd returned by a fd-returning syscall: a negative value is the
 /// POSIX error sentinel; a non-negative one is a fresh fd we own.
@@ -65,6 +65,28 @@ pub(crate) fn would_block(err: &io::Error) -> bool {
 /// `size_of::<T>()` as a `socklen_t`, for `setsockopt`/`bind` length arguments.
 pub(crate) fn socklen_of<T>() -> socklen_t {
     socklen_t::try_from(size_of::<T>()).expect("option/address size fits socklen_t")
+}
+
+/// Read (and thereby clear) the socket's pending error (`SO_ERROR`): a non-blocking connect's
+/// outcome after its writable edge, or an asynchronous error the kernel parked on the socket
+/// (e.g. `ENETDOWN` on a packet socket whose interface died).
+pub(crate) fn so_error(fd: RawFd) -> io::Result<c_int> {
+    let mut err: c_int = 0;
+    let mut len = socklen_of::<c_int>();
+    // SAFETY: `&err`/`&len` are a valid (value, length) out-pair of `c_int` size for `fd`.
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_ERROR,
+            (&raw mut err).cast::<c_void>(),
+            &raw mut len,
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(err)
 }
 
 /// Best-effort: request a larger `SO_RCVBUF` so a burst can't overflow the kernel receive queue as


### PR DESCRIPTION
When the OS destroys and recreates a watched interface (PPPoE reconnect, bridge/VLAN rebuild), it comes back with a new kernel ifindex the cached one no longer matches, and the AF_PACKET/BPF capture stays bound to the dead index -- reflection on it was dead until a restart. The daemon now recovers on its own.

## What

- The interface monitor reports typed events (`Address`/`Link`/`Overflow`) carrying the ifindex. Detection is tiered per OS: Linux gates unknown-index `Link` events on a monotonic-index high-water mark, FreeBSD uses `RTM_IFANNOUNCE`, macOS (no lifecycle messages) falls back to the periodic reconcile.
- On detection the dispatcher re-binds the capture in place (same fd, so the installed filter persists), re-resolves addresses, re-joins multicast groups on the new index, and evicts DIAL proxies (they re-mint on the next advertisement). A search session whose target reply binding moved re-mints on the next retransmit.
- While the interface is absent its reflection parks (sends drop quietly, as on an address loss) and resumes when the name returns; a 30s/1s reconcile tick backstops any lost notification.

## Testing

- `cargo test --lib` (host + Linux), clippy/fmt/doc clean; pair tests under `CAP_NET_RAW` exercise a real veth destroy/recreate.
- e2e (Docker, 48 cases): `mdns_interface_recreate` (four phases, two behind a decoy that forces a different index), `dial_interface_recreate` (target then source recreate, proxy eviction + re-mint), `ssdp_search_interface_recreate` (search-session re-mint across a recreate).
- Daemon log timeline audited end to end: parking -> returned-as-ifindex -> address gains -> recovery complete; no re-join on index 0.
