### PR TITLE
test: cover interface-recreate recovery on an interface pair

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -845,10 +845,11 @@ impl PacketDispatcher {
             match self.table.rebind_interface(stale.key, stale.cur) {
                 // Deferred joins are usually "no address yet" and heal on the interface's next
                 // address event, but after a recreation a deaf group is a real outage: warn.
-                Ok(deferred) if deferred > 0 => {
+                Ok(counts) if counts.deferred > 0 => {
                     log::warn!(
-                        "{deferred} group membership(s) on {name} not re-joined yet; retrying \
-                         on its next address event"
+                        "{} group membership(s) on {name} not re-joined yet; retrying \
+                         on its next address event",
+                        counts.deferred
                     );
                 }
                 Ok(_) => {}

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -11,7 +11,7 @@ use crate::interface::{AddressChange, Interface, InterfaceAddresses, if_index};
 
 use super::CaptureKey;
 use super::counters::{CaptureCounters, Outcome};
-use super::multicast::MulticastJoiner;
+use super::multicast::{MulticastJoiner, RejoinCounts};
 
 /// A `Copy` handle into the interface table's interface entries. An insert-only index like
 /// [`CaptureKey`], but a distinct newtype so the two can't be confused.
@@ -302,9 +302,10 @@ impl InterfaceTable {
     /// Captures are re-bound separately ([`rebind_capture`](Self::rebind_capture)), so the
     /// caller can log and retry them per capture. Log-free.
     ///
-    /// Returns how many group joins were deferred (see [`MulticastJoiner::rejoin`]); the
-    /// deferrals heal on the interface's next address event, but the caller should surface a
-    /// nonzero count -- after a recreation, deaf groups are a real outage.
+    /// Returns the [`RejoinCounts`] split of joined vs deferred (see
+    /// [`MulticastJoiner::rejoin`]); the deferrals heal on the interface's next address event, but
+    /// the caller should surface a nonzero deferred count -- after a recreation, deaf groups are a
+    /// real outage.
     ///
     /// # Errors
     /// Propagates a resolution syscall failure. The identity is then rolled back so the entry
@@ -312,22 +313,26 @@ impl InterfaceTable {
     /// as healthy to the scan (the captures re-bind fine) while carrying the OLD interface's
     /// addresses. The joins are replayed before the rollback either way: they need only the
     /// identity, and a transient resolver error must not leave the interface deaf.
-    pub(super) fn rebind_interface(&mut self, key: InterfaceKey, cur: u32) -> io::Result<usize> {
+    pub(super) fn rebind_interface(
+        &mut self,
+        key: InterfaceKey,
+        cur: u32,
+    ) -> io::Result<RejoinCounts> {
         // Keys come from this table's own scan, so the index is always in range.
         let entry = &mut self.entries[key.0 as usize];
         let previous = entry.interface.ifindex;
         entry.interface.ifindex = cur;
         entry.joiner.reset();
         let refreshed = entry.interface.refresh(); // logs each family's gains and losses
-        let deferred = match NonZeroU32::new(cur) {
+        let counts = match NonZeroU32::new(cur) {
             // Parked: nothing to join now; the rebuild on the interface's return replays.
-            None => 0,
+            None => RejoinCounts::default(),
             Some(ifindex) => entry.joiner.rejoin(ifindex),
         };
         if refreshed.is_err() {
             entry.interface.ifindex = previous;
         }
-        refreshed.map(|_| deferred)
+        refreshed.map(|_| counts)
     }
 
     /// The keys of the captures on `interface`, for a rebuild or eviction pass (the reverse of

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -15,6 +15,17 @@ use libc::c_void;
 use crate::libcex::{GroupReq, MCAST_JOIN_GROUP};
 use crate::sys::{open_socket, sockaddr_for, socklen_of};
 
+/// How a [`rejoin`](MulticastJoiner::rejoin) replay landed: `joined` groups are members after the
+/// call (freshly re-joined, or already member), `deferred` groups could not join yet and wait for
+/// the next address event. The two sum to the desired-group count. `joined` (not "rejoined": the
+/// parked-return replay is a first join) is the signal a caller uses to tell a real replay from a
+/// vacuous one over an empty desired list.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+pub(crate) struct RejoinCounts {
+    pub(crate) joined: usize,
+    pub(crate) deferred: usize,
+}
+
 /// One capture interface's multicast memberships: one unbound `SOCK_DGRAM` fd per family, opened on
 /// that family's first join. The joiner holds no ifindex of its own -- the caller passes the
 /// interface's current one per call, so the table's [`Interface`](crate::interface::Interface) stays
@@ -69,23 +80,27 @@ impl MulticastJoiner {
         self.v6 = None;
     }
 
-    /// Re-attempt every recorded membership after the interface re-resolves, returning how many
-    /// were deferred. A group not joinable before its address existed succeeds now; an
-    /// already-held one is a no-op. Best-effort: a still-unavailable family logs at debug and
-    /// waits for the next change (routine on the address-up path; the recreation rebuild warns
-    /// on a nonzero count instead). `NonZeroU32` makes the parked case unrepresentable:
-    /// `MCAST_JOIN_GROUP` on index 0 would let the kernel pick an arbitrary interface by route
-    /// lookup and advertise our groups there, so callers skip explicitly while parked.
-    pub(crate) fn rejoin(&mut self, ifindex: NonZeroU32) -> usize {
-        let mut deferred = 0;
+    /// Re-attempt every recorded membership after the interface re-resolves, returning the
+    /// [`RejoinCounts`] split of joined vs deferred. A group not joinable before its address
+    /// existed succeeds now; an already-held one is a no-op that still counts as joined.
+    /// Best-effort: a still-unavailable family logs at debug and waits for the next change
+    /// (routine on the address-up path; the recreation rebuild warns on a nonzero deferred count
+    /// instead). `NonZeroU32` makes the parked case unrepresentable: `MCAST_JOIN_GROUP` on index 0
+    /// would let the kernel pick an arbitrary interface by route lookup and advertise our groups
+    /// there, so callers skip explicitly while parked.
+    pub(crate) fn rejoin(&mut self, ifindex: NonZeroU32) -> RejoinCounts {
+        let mut counts = RejoinCounts::default();
         for i in 0..self.desired.len() {
             let group = self.desired[i];
-            if let Err(e) = self.apply(group, ifindex) {
-                log::debug!("re-join of {group} on ifindex {ifindex} deferred: {e}");
-                deferred += 1;
+            match self.apply(group, ifindex) {
+                Ok(()) => counts.joined += 1,
+                Err(e) => {
+                    log::debug!("re-join of {group} on ifindex {ifindex} deferred: {e}");
+                    counts.deferred += 1;
+                }
             }
         }
-        deferred
+        counts
     }
 
     fn apply(&mut self, group: IpAddr, ifindex: NonZeroU32) -> io::Result<()> {
@@ -193,7 +208,12 @@ mod tests {
         joiner.reset();
         assert!(joiner.v4.is_none(), "reset drops the family sockets");
         assert_eq!(joiner.desired.len(), 1, "the desired list survives");
-        joiner.rejoin(ifindex);
+        let counts = joiner.rejoin(ifindex);
+        assert_eq!(
+            (counts.joined, counts.deferred),
+            (1, 0),
+            "rejoin replays the one recorded group, none deferred"
+        );
         assert!(
             joiner.v4.is_some(),
             "rejoin re-opens a fresh socket and re-joins"

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -10,6 +10,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::num::NonZeroU32;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::process::Command;
+use std::sync::{Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use crate::capture::Capture;
@@ -49,6 +50,12 @@ fn run_capture(command: &str) -> Option<String> {
     let name = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     (!name.is_empty()).then_some(name)
 }
+
+/// Serializes the pair tests' interface create/destroy. They run in parallel and the feth/epair
+/// fixtures take kernel-assigned names, so one test's destroy frees a name a parallel test's
+/// create-by-name (in [`recreate`](InterfacePair::recreate)) then collides with. One creator at a
+/// time keeps the naming deterministic. Poison is ignored: a panicking test must not wedge the rest.
+static PAIR_LOCK: Mutex<()> = Mutex::new(());
 
 /// A connected virtual-interface pair for the test's lifetime. `create` returns `None` (with a
 /// skip note) without root or when the platform tooling refuses; `Drop` destroys only interfaces
@@ -96,6 +103,9 @@ impl InterfacePair {
             eprintln!("skip pair test: interface creation requires root");
             return None;
         }
+        // Held through create + settle so no parallel pair test creates an interface concurrently
+        // (see PAIR_LOCK); released when this returns, before the test body runs.
+        let _serialize = PAIR_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         let pair = Self::create_platform(NEXT_SUBNET.fetch_add(1, Ordering::Relaxed))?;
         pair.settle();
         Some(pair)
@@ -152,6 +162,9 @@ impl InterfacePair {
     /// and brought up once already, so the tooling and privileges are known good; a relink or
     /// reconfigure that fails now is an anomaly to surface, not a precondition to skip on.
     fn recreate(&self) {
+        // Serialize against every other pair test's create/recreate (see PAIR_LOCK): the destroy
+        // here frees a kernel-assigned name that a concurrent create-by-name would otherwise grab.
+        let _serialize = PAIR_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         assert!(
             self.relink() && self.configure(),
             "recreating {}/{} failed after a successful create",

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use crate::capture::Capture;
-use crate::interface::{Interface, Ipv6Scope, if_index};
+use crate::interface::{Interface, InterfaceAddresses, Ipv6Scope, if_index};
 use crate::net::packet::Packet;
 use crate::sys::socklen_of;
 #[cfg(target_os = "linux")]
@@ -23,6 +23,7 @@ use crate::{
 };
 
 use super::datagram::{build_udp, ethernet_dst};
+use super::interface_table::InterfaceTable;
 use super::multicast::MulticastJoiner;
 
 const INJECT_SRC_PORT: u16 = 40000;
@@ -145,16 +146,19 @@ impl InterfacePair {
         );
     }
 
-    /// Destroy and recreate the pair's interfaces under the same names -- fresh kernel
-    /// identities, as an operator's `PPPoE` reconnect or bridge rebuild would produce -- then
-    /// reconfigure and settle. False (with a skip note) if the platform tooling refuses.
-    fn recreate(&self) -> bool {
-        if !(self.relink() && self.configure()) {
-            eprintln!("skip pair test: could not recreate the pair");
-            return false;
-        }
+    /// Destroy and recreate the pair's interfaces under the same names -- fresh kernel identities,
+    /// as an operator's `PPPoE` reconnect or bridge rebuild would produce -- then reconfigure and
+    /// settle. Panics on failure, like [`settle`](Self::settle): the pair was created, configured,
+    /// and brought up once already, so the tooling and privileges are known good; a relink or
+    /// reconfigure that fails now is an anomaly to surface, not a precondition to skip on.
+    fn recreate(&self) {
+        assert!(
+            self.relink() && self.configure(),
+            "recreating {}/{} failed after a successful create",
+            self.inject,
+            self.receive
+        );
         self.settle();
-        true
     }
 
     /// Linux: veth names are caller-chosen, so derive them from the pid and a counter -- unique
@@ -450,14 +454,14 @@ fn capture_injected(peer: &mut Capture, dest: IpAddr) -> io::Result<Option<Captu
 /// Build a datagram with the production builder (the egress's own addresses and MAC, per-scope
 /// v6 source) and inject it through the production send path.
 fn inject(
-    iface: &Interface,
+    addrs: &InterfaceAddresses,
     injector: &Capture,
     dst: SocketAddr,
     payload: &[u8],
 ) -> io::Result<()> {
     let mut scratch = [0u8; 2048];
     let n = build_udp(
-        &iface.addrs,
+        addrs,
         injector.link_type(),
         dst,
         ethernet_dst(dst.ip()).expect("broadcast/multicast destination"),
@@ -485,7 +489,7 @@ fn pair_injected_broadcast_is_captured_on_the_peer() -> io::Result<()> {
 
     let payload = b"pair-broadcast";
     let dst = SocketAddr::from((Ipv4Addr::BROADCAST, INJECT_DST_PORT));
-    inject(&iface, &injector, dst, payload)?;
+    inject(&iface.addrs, &injector, dst, payload)?;
 
     let captured = capture_injected(&mut peer, dst.ip())?.expect("peer captured the broadcast");
     assert_eq!(captured.payload, payload);
@@ -508,9 +512,7 @@ fn pair_capture_rebinds_after_interface_recreation() -> io::Result<()> {
     let index = if_index(&pair.receive).expect("receive ifindex");
     assert!(peer.attached(index), "a fresh capture reports attached");
 
-    if !pair.recreate() {
-        return Ok(()); // recreate printed the skip note
-    }
+    pair.recreate();
     let index = if_index(&pair.receive).expect("recreated receive ifindex");
     assert!(
         !peer.attached(index),
@@ -528,9 +530,121 @@ fn pair_capture_rebinds_after_interface_recreation() -> io::Result<()> {
     let injector = Capture::open(&pair.inject)?;
     let payload = b"pair-rebind";
     let dst = SocketAddr::from((Ipv4Addr::BROADCAST, INJECT_DST_PORT));
-    inject(&iface, &injector, dst, payload)?;
+    inject(&iface.addrs, &injector, dst, payload)?;
     let captured =
         capture_injected(&mut peer, dst.ip())?.expect("the re-bound capture sees the broadcast");
+    assert_eq!(captured.payload, payload);
+    Ok(())
+}
+
+// The interface table's own recovery, end to end against a real recreation, driving BOTH ends of
+// the pair at once -- the path the periodic reconcile follows (the only detection macOS has, its
+// recreated ifnet keeping the index). Both interfaces sit in the table with a capture each, and a
+// baseline injection proves delivery works first. After the pair is destroyed and recreated under
+// its names, stale_interfaces flags BOTH entries through the captures' attached() probe -- the half
+// the unprivileged unit test leaves vacuous, and the only half that fires when the index is reused.
+// rebind_interface re-points each entry and replays its recorded joins on a fresh socket (none
+// deferred), rebind_capture re-attaches each fd in place, and a second injection -- sent on the
+// re-bound injector, observed on the re-bound receiver -- proves delivery resumed through the very
+// captures that were stranded.
+#[test]
+fn pair_interface_table_recovers_after_interface_recreation() -> io::Result<()> {
+    let Some(pair) = InterfacePair::create() else {
+        return Ok(());
+    };
+    let mut table = InterfaceTable::new();
+    let inject_key = table.find_or_add_interface(&pair.inject)?;
+    let injector = table.add_capture(Capture::open(&pair.inject)?, inject_key);
+    let receive_key = table.find_or_add_interface(&pair.receive)?;
+    let receiver = table.add_capture(Capture::open(&pair.receive)?, receive_key);
+    // Record memberships on the receive side so its rebuild has groups to replay on the fresh socket.
+    table.join_on(receive_key, IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251)))?;
+    table.join_on(
+        receive_key,
+        IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb)),
+    )?;
+    assert!(
+        table.stale_interfaces().is_empty(),
+        "a freshly-built table is healthy"
+    );
+
+    // Baseline: delivery works through both captures before any recreation. The frame's source
+    // addresses come from the table's own resolved copy of the inject interface -- no second open.
+    let payload = b"pair-table-recover";
+    let dst = SocketAddr::from((Ipv4Addr::BROADCAST, INJECT_DST_PORT));
+    inject(
+        table
+            .egress_addrs(injector)
+            .expect("the inject interface's addresses"),
+        table
+            .capture(injector)
+            .expect("the injector capture is present"),
+        dst,
+        payload,
+    )?;
+    let mut receiver_cap = table
+        .take(receiver)
+        .expect("the receiver capture is present");
+    assert!(
+        capture_injected(&mut receiver_cap, dst.ip())?.is_some(),
+        "delivery works before the recreation"
+    );
+    assert!(
+        table.restore(receiver, receiver_cap),
+        "restore the receiver for the recovery"
+    );
+
+    pair.recreate();
+
+    // Both interfaces are stranded. On a reused index only the attached() probe catches it; either
+    // way both entries are flagged.
+    let stale = table.stale_interfaces();
+    assert_eq!(
+        stale.len(),
+        2,
+        "both recreated interfaces are flagged stale"
+    );
+
+    // Drive the production recovery for each: re-point + replay its joins on a fresh socket (only
+    // the receive side recorded any), then re-attach its capture fd in place.
+    for s in &stale {
+        let counts = table.rebind_interface(s.key, s.cur)?;
+        let expected_joined = if s.key == receive_key { 2 } else { 0 };
+        assert_eq!(
+            (counts.joined, counts.deferred),
+            (expected_joined, 0),
+            "the interface re-joined its recorded groups on the fresh socket, none deferred"
+        );
+        for capture in table.captures_of(s.key) {
+            assert!(
+                table.rebind_capture(capture)?,
+                "the capture re-bound in place"
+            );
+        }
+    }
+    assert!(
+        table.stale_interfaces().is_empty(),
+        "the rebuild cleared all staleness"
+    );
+
+    // Delivery resumes through the very captures that were stranded: sent on the re-bound injector
+    // (with the interface's re-resolved addresses, straight from the table), observed on the
+    // re-bound receiver.
+    inject(
+        table
+            .egress_addrs(injector)
+            .expect("the re-bound inject interface's addresses"),
+        table
+            .capture(injector)
+            .expect("the re-bound injector is present"),
+        dst,
+        payload,
+    )?;
+    let mut receiver_cap = table
+        .take(receiver)
+        .expect("the re-bound receiver is present");
+    let captured = capture_injected(&mut receiver_cap, dst.ip())?
+        .expect("delivery resumed after recovery, through both re-bound captures");
     assert_eq!(captured.payload, payload);
     Ok(())
 }
@@ -557,7 +671,7 @@ fn pair_injected_v6_multicast_reaches_a_joined_udp_socket() -> io::Result<()> {
 
     let payload = b"pair-v6-multicast";
     inject(
-        &iface,
+        &iface.addrs,
         &injector,
         SocketAddr::from((all_nodes, port)),
         payload,
@@ -584,7 +698,7 @@ fn pair_sources_v6_multicast_by_destination_scope() -> io::Result<()> {
 
     let site_group = Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0x0c);
     inject(
-        &iface,
+        &iface.addrs,
         &injector,
         SocketAddr::from((site_group, INJECT_DST_PORT)),
         payload,
@@ -599,7 +713,7 @@ fn pair_sources_v6_multicast_by_destination_scope() -> io::Result<()> {
 
     let link_group = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x0c);
     inject(
-        &iface,
+        &iface.addrs,
         &injector,
         SocketAddr::from((link_group, INJECT_DST_PORT)),
         payload,


### PR DESCRIPTION
Adds a root-gated interface-pair test driving the production interface-recreation recovery end to end: both ends of the pair recovered in one reconcile pass, with a baseline injection proving delivery before the recreation and delivery resuming through the re-bound captures after. This exercises the `attached()`-probe half of `stale_interfaces` that the unprivileged unit test leaves vacuous, and is the only recovery path macOS has (its recreated ifnet keeps the index).

`MulticastJoiner::rejoin` now returns `RejoinCounts { joined, deferred }` (was just the deferred count), so the test asserts the recorded groups actually re-joined rather than the vacuous "none deferred" an empty desired list would also satisfy. `recreate()` asserts on failure like `settle()` instead of skipping.

Testing: fmt, clippy --all-targets, cargo doc, cargo test --lib on host and Linux (Docker). All 7 pair tests executed and passed on real veth as root in a privileged Linux container; the macOS and FreeBSD pair lanes run under CI.