### PR TITLE
feat: count per-interface recoveries in the observability counters

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -887,6 +887,9 @@ impl PacketDispatcher {
             // returned on the same index, which the reconcile reached via the attached() probe).
             self.notify_iface_change(&captures, reactor);
             if stale.cur != 0 && !failed {
+                for capture in &captures {
+                    self.table.record_recovery(*capture);
+                }
                 log::info!("interface {name}: recovery complete");
             }
             pending |= failed;
@@ -1059,6 +1062,29 @@ mod tests {
         assert!(
             dispatcher.next_reconcile > Instant::now() + RECONCILE_RETRY,
             "recovery re-arms the slow tick"
+        );
+        Ok(())
+    }
+
+    // A completed recovery bumps the recoveries tally on each of the interface's capture rows.
+    // Unprivileged: the moved identity is faked through the test seam and the capture row is a
+    // capture-less test entry (rebind_capture reports it missing, which does not fail the recovery).
+    #[test]
+    fn reconcile_counts_a_recovery_on_the_interface_captures() -> io::Result<()> {
+        let mut reactor = Reactor::new()?;
+        let mut dispatcher = PacketDispatcher::new();
+        let key = dispatcher.table.find_or_add_interface(LOOPBACK_IFACE)?;
+        let capture = dispatcher.table.add_test_capture(); // links the first interface
+        assert_eq!(dispatcher.table.recoveries_of(capture), 0);
+        let real = crate::interface::if_index(LOOPBACK_IFACE).expect("loopback has an ifindex");
+        dispatcher.table.set_test_ifindex(key, real + 1000); // as a recreation would move it
+
+        dispatcher.reconcile_interfaces(&mut reactor);
+
+        assert_eq!(
+            dispatcher.table.recoveries_of(capture),
+            1,
+            "the completed recovery is counted on the interface's capture row"
         );
         Ok(())
     }

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -172,12 +172,14 @@ impl TypeCounters {
     }
 }
 
-/// Every tally for one interface (capture): one [`TypeCounters`] per [`MessageType`], plus a
-/// type-less `filtered` count for junk.
+/// Every tally for one interface (capture): one [`TypeCounters`] per [`MessageType`], a type-less
+/// `filtered` count for junk, and a `recoveries` count of completed interface rebuilds (a recreated
+/// or returned interface whose captures re-bound).
 #[derive(Clone, Default)]
 pub(crate) struct CaptureCounters {
     types: [TypeCounters; MESSAGE_TYPE_COUNT],
     filtered: u64,
+    recoveries: u64,
 }
 
 impl CaptureCounters {
@@ -192,19 +194,31 @@ impl CaptureCounters {
         }
     }
 
-    /// This row's non-zero tallies as one line, e.g. `mDNS query reflected=42 skipped=10; SSDP
-    /// search reflected=5 dropped=1; filtered=2`. `None` when nothing has been counted, so an
-    /// idle interface produces no report line.
+    /// Tally one completed recovery of the interface behind this row: its kernel identity was
+    /// recreated (or it returned from absent) and its captures re-bound. A lifecycle event, not a
+    /// per-packet outcome, so it leads the report line.
+    pub(crate) fn record_recovery(&mut self) {
+        self.recoveries += 1;
+    }
+
+    /// This row's non-zero tallies as one line, e.g. `recoveries=1; mDNS query reflected=42
+    /// skipped=10; SSDP search reflected=5 dropped=1; filtered=2`. `None` when nothing has been
+    /// counted, so an idle interface produces no report line.
     fn format_nonzero(&self) -> Option<String> {
-        let mut parts: Vec<String> = MessageType::ALL
-            .iter()
-            .zip(&self.types)
-            .filter_map(|(ty, counts)| {
-                counts
-                    .format_nonzero()
-                    .map(|fields| format!("{ty} {fields}"))
-            })
-            .collect();
+        let mut parts: Vec<String> = Vec::new();
+        if self.recoveries > 0 {
+            parts.push(format!("recoveries={}", self.recoveries));
+        }
+        parts.extend(
+            MessageType::ALL
+                .iter()
+                .zip(&self.types)
+                .filter_map(|(ty, counts)| {
+                    counts
+                        .format_nonzero()
+                        .map(|fields| format!("{ty} {fields}"))
+                }),
+        );
         if self.filtered > 0 {
             parts.push(format!("filtered={}", self.filtered));
         }
@@ -236,6 +250,11 @@ mod tests {
         }
         fn filtered(&self) -> u64 {
             self.filtered
+        }
+        /// This row's recovery tally. Read from the dispatcher's reconcile test through the
+        /// interface table, hence `pub(crate)`.
+        pub(crate) fn recoveries(&self) -> u64 {
+            self.recoveries
         }
     }
 
@@ -283,6 +302,22 @@ mod tests {
         assert_eq!(c.typed(MessageType::SsdpSearch), (0, 0, 1, 1));
         assert_eq!(c.typed(MessageType::WakeOnLan), (0, 0, 0, 0));
         assert_eq!(c.filtered(), 1);
+    }
+
+    #[test]
+    fn record_recovery_counts_and_leads_the_summary() {
+        let mut c = CaptureCounters::default();
+        assert_eq!(c.recoveries(), 0);
+        c.record_recovery();
+        c.record_recovery();
+        assert_eq!(c.recoveries(), 2);
+        // A recovered but otherwise-idle interface still reports, recoveries leading.
+        assert_eq!(c.format_nonzero().as_deref(), Some("recoveries=2"));
+        c.record(Outcome::Reflected(MessageType::MdnsQuery));
+        assert_eq!(
+            c.format_nonzero().as_deref(),
+            Some("recoveries=2; mDNS query reflected=1"),
+        );
     }
 
     #[test]

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -196,6 +196,13 @@ impl InterfaceTable {
         self.captures[capture.0 as usize].counters.record(outcome);
     }
 
+    /// Tally a completed recovery on a capture's row (see [`CaptureCounters::record_recovery`]).
+    /// Indexed directly, like [`record`](Self::record): the keys come from
+    /// [`captures_of`](Self::captures_of) in the reconcile, so the row always exists.
+    pub(super) fn record_recovery(&mut self, capture: CaptureKey) {
+        self.captures[capture.0 as usize].counters.record_recovery();
+    }
+
     /// Each capture's `(interface name, counter row)` for the periodic report. The table owns the
     /// capture→interface-name mapping and stays log-free (the dispatcher does the logging).
     pub(super) fn counter_rows(&self) -> impl Iterator<Item = (&str, &CaptureCounters)> {
@@ -469,6 +476,11 @@ mod tests {
             ty: MessageType,
         ) -> (u64, u64, u64, u64) {
             self.captures[capture.0 as usize].counters.typed(ty)
+        }
+
+        /// The recovery tally recorded on `capture`'s row, for the dispatcher's reconcile test.
+        pub(in crate::dispatch) fn recoveries_of(&self, capture: CaptureKey) -> u64 {
+            self.captures[capture.0 as usize].counters.recoveries()
         }
     }
 


### PR DESCRIPTION
Adds a `recoveries` counter to each interface's counter row, incremented per capture at the reconcile's "recovery complete" point (a recreated or returned interface whose captures re-bound). It leads the periodic/SIGUSR1 counter summary line (`counters eth0: recoveries=1; ...`), so a recovered-but-idle interface, which otherwise stays silent, now produces a report line.

Follow-up to the interface hot-swap recovery: gives operators a per-interface tally of how often the daemon has re-bound an interface.

Testing: fmt, clippy --all-targets, cargo doc, cargo test --lib on host and Linux (Docker). Unit test for the counter increment + summary formatting, and a reconcile test asserting the tally bumps once per completed recovery.