### PR TITLE
fix: let docker_test.sh actually run the root-gated pair tests

### DIFF
--- a/docker_test.sh
+++ b/docker_test.sh
@@ -1,29 +1,49 @@
 #!/usr/bin/env bash
-# Run cargo on Linux inside Docker, so cfg(linux)-only code — the epoll poll
-# backend now, the AF_PACKET capture path later — actually compiles and runs from
-# the macOS dev host. Everything after the script name is forwarded to `cargo`;
-# with no args it runs the test suite.
+# Run cargo on Linux inside Docker, so cfg(linux)-only code (the epoll backend, the AF_PACKET
+# capture path) actually compiles and runs from the macOS dev host. Everything after the script
+# name is forwarded to `cargo`; with no args it runs the test suite.
 #
 #   ./docker_test.sh                                       # cargo test
-#   ./docker_test.sh test epoll                            # filter to epoll tests
+#   ./docker_test.sh test pair_                            # the root-gated interface-pair tests
 #   ./docker_test.sh clippy --all-targets -- -D warnings   # Linux clippy/lints
 #
-# Named volumes hold the Linux target dir (so the macOS ./target is untouched),
-# the crate registry, and the rustup home -- the last so the pinned toolchain's
-# rustfmt/clippy components (absent from rust:slim) download once, not every run.
-# The capture layer will later need raw-socket privileges -- add `--cap-add=NET_RAW`
-# here when those tests land.
+# Named volumes hold the Linux target dir (so the macOS ./target is untouched), the crate
+# registry, and the rustup home -- the last so the pinned toolchain's rustfmt/clippy components
+# (absent from rust:slim) download once, not every run.
+#
+# The root-gated tests (interface pairs, captures) need more than a stock `docker run`:
+#   NET_ADMIN   create and destroy the veth pair
+#   NET_RAW     open AF_PACKET captures, join multicast groups
+#   --sysctl    the pair needs accept_local (both ends share one stack, so wire-crossing v4
+#               packets carry a local source that fib_validate_source would drop as martian).
+#               It is ORCONF (conf/all OR conf/<iface>), so presetting `all` here covers the
+#               veths the fixture creates later. Do NOT reach for `systempaths=unconfined` to
+#               make /proc/sys writable instead: that also unmasks /proc/sysrq-trigger (a write
+#               there panics the HOST) and /proc/kcore (the live kernel memory image).
+# rust:slim also ships no `ip`, and without it the veth fixture skips every pair test instead of
+# failing, so the image adds iproute2. The layer is cached, so later runs pay nothing for it.
 set -euo pipefail
 cd "$(dirname "$0")"
 
 [ "$#" -eq 0 ] && set -- test
 
+IMAGE=reflector-devtest
+docker build -q -t "$IMAGE" - >/dev/null <<'DOCKERFILE'
+FROM rust:slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+DOCKERFILE
+
 exec docker run --rm \
+    --cap-add=NET_ADMIN \
+    --cap-add=NET_RAW \
+    --sysctl net.ipv4.conf.all.accept_local=1 \
     -v "$PWD":/reflector \
     -v reflector-linux-target:/linux-target \
     -v reflector-cargo-registry:/usr/local/cargo/registry \
     -v reflector-rustup:/usr/local/rustup \
     -e CARGO_TARGET_DIR=/linux-target \
     -w /reflector \
-    rust:slim \
+    "$IMAGE" \
     cargo "$@"

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -225,15 +225,28 @@ impl InterfacePair {
             // Both ends sit in one stack, so every wire-crossing v4 packet carries a local
             // source address, and Linux's fib_validate_source drops those as martians before
             // socket delivery (tcpdump still sees them below IP). accept_local admits them;
-            // the BSDs have no such gate.
-            && run(&format!(
-                "echo 1 > /proc/sys/net/ipv4/conf/{}/accept_local",
-                self.inject
-            ))
-            && run(&format!(
-                "echo 1 > /proc/sys/net/ipv4/conf/{}/accept_local",
-                self.receive
-            ))
+            // the BSDs have no such gate. It is an ORCONF sysctl (conf/all OR conf/<iface>), so
+            // a preset conf/all already covers every interface, including ones created later:
+            // skip the per-interface write then, since it needs a writable /proc/sys, which
+            // docker mounts read-only (docker_test.sh presets `all` via --sysctl instead of
+            // unmasking /proc).
+            && (Self::accept_local_preset()
+                || (run(&format!(
+                    "echo 1 > /proc/sys/net/ipv4/conf/{}/accept_local",
+                    self.inject
+                )) && run(&format!(
+                    "echo 1 > /proc/sys/net/ipv4/conf/{}/accept_local",
+                    self.receive
+                ))))
+    }
+
+    /// Whether `net.ipv4.conf.all.accept_local` is already 1. Reading /proc/sys works even where
+    /// writing it doesn't, so this lets a caller preset the ORCONF `all` knob out of band (the
+    /// docker dev container does, via `--sysctl`) and keep /proc/sys read-only.
+    #[cfg(target_os = "linux")]
+    fn accept_local_preset() -> bool {
+        std::fs::read_to_string("/proc/sys/net/ipv4/conf/all/accept_local")
+            .is_ok_and(|value| value.trim() == "1")
     }
 
     /// Destroy the pair and recreate it under the same names (deleting one veth end removes


### PR DESCRIPTION
`./docker_test.sh test pair_` was documented but dead: the script granted the capture layer no privileges (its header still said to add `NET_RAW` "when those tests land"), and `rust:slim` ships no `ip`, so the veth fixture *skipped* every pair test instead of running it.

- Grant `NET_ADMIN` (create the veth pair) and `NET_RAW` (AF_PACKET captures, multicast joins), and add `iproute2` in a cached image layer.
- `accept_local` is the last piece: docker mounts `/proc/sys` read-only, so the fixture's per-interface write is refused. It is an ORCONF sysctl (`conf/all` OR `conf/<iface>`), so the script presets `all` via `--sysctl` and the fixture skips the now-redundant per-interface write when it sees it. **A native run is unchanged** — `conf/all` is 0 there, so the per-interface writes run and must still succeed.
- Deliberately **not** `systempaths=unconfined`: that would make `/proc/sys` writable but also unmasks `/proc/sysrq-trigger` (a write there panics the host) and `/proc/kcore` (the live kernel memory image). The container keeps every docker `/proc` protection.

Testing: `./docker_test.sh test pair_` now runs them (7 passed, 0 skipped) and `./docker_test.sh clippy --all-targets -- -D warnings` is clean. Verified the native path is unaffected by running the suite with a writable `/proc/sys` and `conf/all=0` (a stock Linux box): the per-interface write path runs, 7 passed.