### PR TITLE
ci: run the unit suite under Miri on every supported target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,103 @@ jobs:
           triple='${{ matrix.target.triple }}'
           sudo python3 e2e/run.py --backend native --binary "target/${triple:+$triple/}release/reflector"
 
+  # The unit suite under Miri, for every shipped target. Valgrind (below) watches the machine: it catches
+  # an access that is actually invalid, but it is blind to UB that performs no invalid access at all -- an
+  # unaligned read the hardware tolerates, or a raw pointer used after a &mut reborrow invalidated its
+  # provenance. Both are UB the optimizer is entitled to act on, and both live in our unsafe: read_unaligned
+  # casts into netlink/BPF byte buffers, StreamBuffer's MaybeUninit tail. Miri interprets the abstract
+  # machine and checks the alignment/aliasing/provenance rules instead, so it covers exactly the class
+  # memcheck cannot. The two lanes are complements, not duplicates.
+  #
+  # Miri cannot call foreign functions, so a test needing a real socket, capture device, poll backend,
+  # interface or signal handler is gated with cfg_attr(miri, ignore = "what it needs"). Everything else
+  # runs UNFILTERED, deliberately: a new test is covered by Miri by default, and one that reaches the
+  # kernel fails loudly until it is gated. A name-filtered allowlist would instead go quietly stale.
+  #
+  # Miri interprets rather than executes, so --target needs no toolchain, emulator or VM for that OS: this
+  # one ubuntu runner covers the BSD-only cfg code and the 32-bit ARM layouts (where an alignment bug in
+  # the parsers would actually surface) as well as its own. It needs no privileges either -- Miri's geteuid
+  # is a constant, so the root-gated tests always take their skip branch.
+  #
+  # Toolchain: the latest nightly that actually ships Miri, resolved per run rather than pinned. Floating is
+  # deliberate -- new Miri releases tighten the checks (Tree Borrows) and add shims, and a pin would freeze
+  # us at whatever the lane was born with. Not every nightly ships the component though (it is gated on
+  # Miri's own tests passing), so plain `nightly` hard-fails on a day Miri did not build, which would red
+  # every PR for a reason that has nothing to do with this repo. rust-lang's components-history serves the
+  # most recent date that DID ship it, so float on that.
+  #
+  # The cost of floating, stated plainly: a Miri or rustc regression can red this lane on an unrelated PR.
+  # That is the accepted trade for picking up new checks the day they land. When Miri gains a shim for
+  # something we gate on (kqueue, say), the gate does NOT lift itself -- the cfg_attr has to be deleted by
+  # hand; the lane just makes that possible.
+  miri:
+    name: Miri (${{ matrix.target }})
+    needs: gate
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+          - armv7-unknown-linux-musleabihf
+          - armv5te-unknown-linux-musleabi
+          - x86_64-unknown-freebsd
+          - aarch64-unknown-freebsd
+          - aarch64-apple-darwin
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Resolve the newest nightly that ships Miri
+        run: |
+          date=$(curl -fsSL https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+          # The endpoint serves a bare date. Anything else (an error page, an outage) must fail here
+          # rather than turn into a confusing rustup error two steps later.
+          case "$date" in
+            20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+            *) echo "::error::expected a nightly date, got: $date"; exit 1 ;;
+          esac
+          echo "MIRI_TOOLCHAIN=nightly-$date" >> "$GITHUB_ENV"
+      - name: Cache cargo build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          # ~/.cache/miri holds the per-target sysroot Miri builds from rust-src; without it every run
+          # recompiles std for the target. The toolchain is in the key because a new nightly needs a new
+          # sysroot; the second restore-key still reuses the previous day's registry and target dir.
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ~/.cache/miri
+            target
+          key: cargo-miri-${{ matrix.target }}-${{ env.MIRI_TOOLCHAIN }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-miri-${{ matrix.target }}-${{ env.MIRI_TOOLCHAIN }}-
+            cargo-miri-${{ matrix.target }}-
+      - name: Install the Miri toolchain
+        run: rustup toolchain install "$MIRI_TOOLCHAIN" --profile minimal --component miri,rust-src
+      - name: Show toolchain
+        run: rustc "+$MIRI_TOOLCHAIN" -V && cargo "+$MIRI_TOOLCHAIN" miri -V
+      # Both aliasing models. They are different rulesets, not a strictness ordering: Stacked Borrows is
+      # today's default, Tree Borrows is the successor, and each accepts things the other rejects. Code
+      # sound under both stays sound whichever one rustc settles on -- worth having for unsafe that holds
+      # raw pointers into buffers it also hands out as &mut (StreamBuffer's tail, the parsers).
+      # -Zmiri-strict-provenance rejects int-to-pointer casts that launder provenance away, which is a real
+      # hazard in FFI glue: it is what keeps kqueue's udata round-trip on ptr::without_provenance_mut.
+      # The two runs share the sysroot, so the second only re-interprets the suite.
+      - name: cargo miri test (stacked borrows)
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
+        run: cargo "+$MIRI_TOOLCHAIN" miri test --locked --target ${{ matrix.target }} --lib
+      - name: cargo miri test (tree borrows)
+        env:
+          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-strict-provenance
+        run: cargo "+$MIRI_TOOLCHAIN" miri test --locked --target ${{ matrix.target }} --lib
+
   # The unit suite under Valgrind memcheck. The valgrind-e2e job below only ever sees the daemon's
   # datapath; the unit suite is where the unsafe surface actually executes -- the netlink walk
   # arithmetic, sockaddr conversions, StreamBuffer's unsafe commit, MaybeUninit buffers, the
@@ -578,7 +675,7 @@ jobs:
   success:
     name: Success
     if: ${{ !cancelled() }}
-    needs: [gate, fmt, lint, test, freebsd, docker-e2e, native-e2e, freebsd-native-e2e, valgrind-test, valgrind-e2e]
+    needs: [gate, fmt, lint, test, freebsd, docker-e2e, native-e2e, freebsd-native-e2e, miri, valgrind-test, valgrind-e2e]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -351,6 +351,7 @@ mod tests {
     // looped frame off `lo`. Validates the open/filter/bind/recv path and that lo
     // is Ethernet-framed. PACKET_IGNORE_OUTGOING drops the TX copy; we see the RX one.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn captures_a_known_frame_on_lo() -> io::Result<()> {
         const PROBE: &[u8] = b"reflector-afpacket-capture-probe";
         let Some(mut capture) = open_or_skip("lo", "afpacket_capture")? else {
@@ -393,6 +394,7 @@ mod tests {
     // delivers a raw-injected loopback frame to a socket is kernel-specific, and not
     // what send() is for: on a real interface it reaches other hosts, not us.)
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn send_loops_back_on_lo() -> io::Result<()> {
         const PROBE: &[u8] = b"reflector-afpacket-send-probe";
         let Some(mut capture) = open_or_skip("lo", "afpacket_send")? else {

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -468,6 +468,7 @@ mod tests {
     // Traffic to 127.0.0.1 / ::1 is deterministic, no env var needed. Dynamically
     // skips when BPF (or IPv6 loopback) is unavailable; fails on real errors.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn loopback_capture_decodes_known_frames() -> io::Result<()> {
         let Some(mut capture) = open_or_skip("lo0", "loopback_capture")? else {
             return Ok(());
@@ -506,6 +507,7 @@ mod tests {
     // means FreeBSD behaves like macOS: loopback send isn't observable this way.
     #[cfg(target_os = "freebsd")]
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn loopback_send_reaches_a_local_socket() -> io::Result<()> {
         use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, UdpSocket};
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -590,6 +590,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "opens a real file")]
     fn read_config_file_tolerates_a_non_utf8_path() {
         use std::os::unix::ffi::OsStrExt;
         // An invalid-UTF-8 path byte must not panic; a missing file yields ReadFile (rendered lossily).

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1011,6 +1011,7 @@ mod tests {
     // seam, as a recreation would move it) and repairs it in place, then re-arms the slow
     // tick. Unprivileged: resolution only, no captures.
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn reconcile_repairs_a_moved_identity_and_arms_the_slow_tick() -> io::Result<()> {
         let mut reactor = Reactor::new()?;
         let mut dispatcher = PacketDispatcher::new();
@@ -1035,6 +1036,7 @@ mod tests {
     // A vanished interface parks (identity 0, quiescent thereafter) and keeps the fast retry
     // cadence armed, so its return is picked up promptly even with every event lost.
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn reconcile_parks_a_vanished_interface_and_keeps_the_fast_retry() -> io::Result<()> {
         let mut reactor = Reactor::new()?;
         let mut dispatcher = PacketDispatcher::new();
@@ -1070,6 +1072,7 @@ mod tests {
     // Unprivileged: the moved identity is faked through the test seam and the capture row is a
     // capture-less test entry (rebind_capture reports it missing, which does not fail the recovery).
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn reconcile_counts_a_recovery_on_the_interface_captures() -> io::Result<()> {
         let mut reactor = Reactor::new()?;
         let mut dispatcher = PacketDispatcher::new();
@@ -1296,6 +1299,7 @@ mod tests {
     // UDP probe off the ingress key, routes it through the matching Echo reflector,
     // which re-emits on the *egress* key. Skips without capture access (no CAP_NET_RAW).
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn routes_a_captured_packet_to_a_matching_reflector() -> io::Result<()> {
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_ingress")? else {
             return Ok(());
@@ -1375,6 +1379,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn unregister_stops_routing_to_a_handler() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
@@ -1427,6 +1432,7 @@ mod tests {
     // a reflect and its mirror skip (both matching) tally a single reflect, and a handler whose filter
     // misses doesn't contribute at all.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn route_folds_matched_outcomes_and_records_once() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
@@ -1469,6 +1475,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn route_folds_fan_out_reflects_and_records_once() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
@@ -1498,6 +1505,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn counter_report_fires_on_its_interval() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
@@ -1539,6 +1547,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn reports_the_soonest_deadline_and_sweeps_only_the_due_one() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
@@ -1604,6 +1613,7 @@ mod tests {
     // call isn't in the snapshot and doesn't receive the in-flight frame. True whether it appends
     // or reuses a freed slot (a key snapshot, unlike the old length bound, doesn't depend on index).
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn a_mid_route_registration_is_not_fed_the_in_flight_frame() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
@@ -1659,6 +1669,7 @@ mod tests {
     // second and panics `route`'s `expect`; with it, the outer loop handles both
     // (calls == 2). Skips without capture access (no CAP_NET_RAW).
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn reentrant_drain_on_the_same_ingress_hits_the_guard() -> io::Result<()> {
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_reentrant")? else {
             return Ok(());
@@ -1708,6 +1719,7 @@ mod tests {
     // capture, drains it, and routes to the Echo, which re-emits on the egress key.
     // Exercises the per-fd `on_readable`. Skips without capture access (no CAP_NET_RAW).
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn reactor_drives_the_dispatcher_to_route_a_packet() -> io::Result<()> {
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_reactor_in")? else {
             return Ok(());
@@ -1759,6 +1771,7 @@ mod tests {
     // and `send_udp_group` must each be a safe no-op (log-drop / `None` / `Ok`), never a panic:
     // the new behavior the capture-gated e2e tests above skip without `CAP_NET_RAW`.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn unknown_capture_key_is_a_safe_no_op() -> io::Result<()> {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new()?;
@@ -1807,6 +1820,7 @@ mod tests {
     // are checked from inside the reflector's call, when the ingress entry's capture is
     // `None`. Skips without capture access (no CAP_NET_RAW).
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn ingress_resolves_and_drops_while_taken_out() -> io::Result<()> {
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_mid_drain")? else {
             return Ok(());
@@ -1855,6 +1869,7 @@ mod tests {
     // distinct from any capture key. Best-effort: the watch appears only if the socket opened
     // (some sandboxes deny it), so an empty watch list means skip.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn monitor_fd_is_watched_under_the_sentinel_tag() {
         let dispatcher = PacketDispatcher::new();
         let watches = dispatcher.capture_watches();
@@ -1872,6 +1887,7 @@ mod tests {
 
     // A join_group on an unknown capture is logged and skipped, not an error or a panic.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn join_group_ignores_an_unknown_capture() {
         let mut dispatcher = PacketDispatcher::new();
         let group = IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251));

--- a/src/dispatch/dial_context.rs
+++ b/src/dispatch/dial_context.rs
@@ -202,6 +202,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn next_grace_reports_the_soonest_or_none_when_empty() {
         let mut reactor = Reactor::new().unwrap();
         let mut ctx = DialContext::new();
@@ -230,6 +231,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn lookup_finds_a_live_proxy_and_prunes_an_evicted_one() {
         let mut reactor = Reactor::new().unwrap();
         let mut ctx = DialContext::new();

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -488,6 +488,7 @@ mod tests {
     // the changed fields (`None` for an unwatched index). Resolution is unprivileged (no capture
     // needed), so this exercises the monitor's refresh path without CAP_NET_RAW.
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn refresh_by_ifindex_targets_the_matching_interface() -> io::Result<()> {
         let mut table = InterfaceTable::new();
         table.find_or_add_interface(LOOPBACK_IFACE)?;
@@ -510,6 +511,7 @@ mod tests {
     // the recorded memberships idempotently. Unprivileged: loopback accepts the join and resolving
     // the interface needs no CAP_NET_RAW.
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn join_on_records_a_membership_and_refresh_re_attempts_it() -> io::Result<()> {
         let mut table = InterfaceTable::new();
         let iface = table.find_or_add_interface(LOOPBACK_IFACE)?;
@@ -540,6 +542,7 @@ mod tests {
     // rebind_interface repairs it. Unprivileged: pure resolution, no captures, so the probe
     // half of the predicate stays vacuous here (pair tests cover it against real interfaces).
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn stale_interfaces_flags_and_rebind_repairs_a_moved_index() -> io::Result<()> {
         let mut table = InterfaceTable::new();
         let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
@@ -571,6 +574,7 @@ mod tests {
     // identity 0, addresses cleared (the egress gate closes), no join attempted (a join on
     // index 0 would let the kernel pick an arbitrary interface).
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn rebind_to_absent_parks_the_entry() -> io::Result<()> {
         let mut table = InterfaceTable::new();
         let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
@@ -600,6 +604,7 @@ mod tests {
     // have targeted index 0, which the kernel resolves to an arbitrary interface. Socket-less
     // after the park, the joiner must stay socket-less through refresh_all.
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn refresh_all_does_not_rejoin_a_parked_interface() -> io::Result<()> {
         let mut table = InterfaceTable::new();
         let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
@@ -634,6 +639,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn find_or_add_interface_dedups_by_name() -> io::Result<()> {
         let mut table = InterfaceTable::new();
         let first = table.find_or_add_interface(LOOPBACK_IFACE)?;

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -193,6 +193,7 @@ mod tests {
     // reset drops the per-family sockets while keeping the desired list, so the next rejoin
     // replays every group on fresh fds (no zombie memberships from a destroyed interface).
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn reset_keeps_desired_and_rejoin_replays_on_fresh_sockets() {
         let mut joiner = MulticastJoiner::new();
         let ifindex = loopback_ifindex();
@@ -237,6 +238,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn kernel_accepts_a_join_on_loopback() {
         // Exercises the full MCAST_JOIN_GROUP FFI against the kernel (per-OS const, group_req layout,
         // by-index selection; by-index doesn't require the interface's IFF_MULTICAST flag). QEMU

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -316,6 +316,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn resolves_loopback_v4() {
         // Every host's loopback has 127.0.0.1; resolution needs no privileges, so this
         // exercises the full backend (the v4 path, and on Linux the rtnetlink round-trip).
@@ -324,6 +325,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn refresh_reports_which_source_fields_changed() {
         let mut iface = Interface::open(LOOPBACK_IFACE).unwrap();
         // Re-resolving an interface whose addresses are already current reports nothing moved.
@@ -347,6 +349,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn unknown_interface_has_no_addresses() {
         let addrs = Interface::open("nonexistent-xyz-999").unwrap().addrs;
         assert_eq!(addrs, InterfaceAddresses::default());

--- a/src/interface/interface_monitor.rs
+++ b/src/interface/interface_monitor.rs
@@ -160,6 +160,7 @@ mod tests {
     // or erroring. Best-effort: some sandboxes deny the routing socket, where the monitor
     // degrades to no live updates, so there's nothing to drain and we skip.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real routing socket")]
     fn opens_and_drains_without_blocking() {
         let mut monitor = match InterfaceMonitor::open() {
             Ok(monitor) => monitor,

--- a/src/memory_report.rs
+++ b/src/memory_report.rs
@@ -98,6 +98,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "reads the process resource usage from the kernel")]
     fn peak_rss_is_nonzero_for_the_running_process() {
         // A live process has a non-zero high-water RSS; this also exercises the getrusage path.
         assert!(peak_rss_kib() > 0);
@@ -105,11 +106,13 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    #[cfg_attr(miri, ignore = "reads /proc/self/status")]
     fn current_rss_reads_proc_self_status() {
         assert!(current_rss_kib().is_some_and(|rss| rss > 0));
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn reporter_schedules_the_next_report_an_interval_out() {
         let interval = Duration::from_secs(30);
         let now = Instant::now();
@@ -121,6 +124,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn dump_only_reporter_keeps_no_deadline() {
         let mut reporter = MemoryReporter::new(None, Instant::now());
         assert_eq!(reporter.next_deadline(), None);

--- a/src/net/port_reservation.rs
+++ b/src/net/port_reservation.rs
@@ -118,6 +118,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn reserves_a_nonzero_port_on_loopback() {
         let r = PortReservation::create(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)
             .expect("bind an ephemeral port on loopback");
@@ -128,6 +129,7 @@ mod tests {
     // rejects the pairing (Linux never reads it, macOS zeroes it), so this has teeth on the
     // FreeBSD lane and pins the contract elsewhere.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn routable_v6_reservation_ignores_the_ifindex() {
         let r = PortReservation::create(IpAddr::V6(Ipv6Addr::LOCALHOST), u32::MAX)
             .expect("bind an ephemeral port on v6 loopback without a zone id");
@@ -135,6 +137,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn two_reservations_get_distinct_ports() {
         let a = PortReservation::create(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
         let b = PortReservation::create(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -372,6 +372,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn loopback_listen_connect_accept_stream() {
         let listener = TcpSocket::listen(Ipv4Addr::LOCALHOST).expect("listen on loopback");
         let server_addr = listener.local_addr();
@@ -397,6 +398,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn loopback_send_vectored_concatenates_the_slices() {
         let listener = TcpSocket::listen(Ipv4Addr::LOCALHOST).expect("listen on loopback");
         let mut client = TcpSocket::connect(listener.local_addr(), Ipv4Addr::LOCALHOST, None)
@@ -419,6 +421,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn shutdown_write_half_closes_keeping_the_read_half() {
         let listener = TcpSocket::listen(Ipv4Addr::LOCALHOST).expect("listen on loopback");
         let mut client =

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -670,6 +670,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn dispatch_calls_on_readable() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -685,6 +686,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn handler_can_unregister_itself() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -714,6 +716,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn handler_can_register_during_dispatch() {
         // The classic mid-dispatch hazard: registering a new handler while dispatching.
         // Nothing borrows the arenas during the call, so it is simply allowed.
@@ -743,6 +746,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn handler_can_unregister_another() {
         let mut reactor = Reactor::new().unwrap();
         let (victim_fd, _pv) = pair();
@@ -777,6 +781,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn write_interest_gates_on_writable() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -798,6 +803,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn read_handler_disarming_write_skips_the_write_phase() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -830,6 +836,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn read_handler_unregistering_itself_skips_the_write_phase() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -861,6 +868,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn dispatching_a_stale_reg_is_a_noop() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -872,6 +880,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn poll_once_dispatches_a_ready_fd() {
         let mut reactor = Reactor::new().unwrap();
         let (a, peer) = pair();
@@ -894,6 +903,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn run_loop_stops_when_a_handler_requests_shutdown() {
         let mut reactor = Reactor::new().unwrap();
         let (a, peer) = pair();
@@ -917,6 +927,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn dispatch_control_reaches_every_handler() {
         let mut reactor = Reactor::new().unwrap();
         let count = Rc::new(Cell::new(0u32));
@@ -931,6 +942,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn run_loop_broadcasts_a_pending_dump() {
         let mut reactor = Reactor::new().unwrap();
         let (a, peer) = pair();
@@ -953,6 +965,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn unwatch_removes_one_fd_and_leaves_the_handler() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _pa) = pair();
@@ -985,6 +998,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn watch_hands_back_the_ready_event() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -1004,6 +1018,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn register_hands_the_handler_its_own_key() {
         // A handler that records the key it is adopted with, so we can check it matches `register`'s.
         struct KeyRecorder(Rc<Cell<Option<HandlerKey>>>);
@@ -1024,6 +1039,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn watch_on_a_stale_handler_errors() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _pa) = pair();
@@ -1035,6 +1051,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn watch_rejects_a_duplicate_fd() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _pa) = pair();
@@ -1047,6 +1064,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn watch_failure_errors_and_leaves_the_handler_usable() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _pa) = pair();
@@ -1065,6 +1083,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn setting_interest_on_a_stale_reg_is_a_benign_false() {
         let mut reactor = Reactor::new().unwrap();
         let (a, _peer) = pair();
@@ -1104,6 +1123,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn next_deadline_reports_the_soonest_across_handlers() {
         let mut reactor = Reactor::new().unwrap();
         let base = Instant::now();
@@ -1114,6 +1134,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn dispatch_deadlines_fires_only_the_handlers_that_are_due() {
         let mut reactor = Reactor::new().unwrap();
         let base = Instant::now();
@@ -1133,6 +1154,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn run_loop_wakes_at_a_deadline_and_runs_the_timer() {
         let mut reactor = Reactor::new().unwrap();
         let fired = Rc::new(Cell::new(false));

--- a/src/reactor/poll.rs
+++ b/src/reactor/poll.rs
@@ -43,6 +43,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn reports_readable_with_the_registered_key() {
         let (a, b) = UnixStream::pair().unwrap();
         let mut poller = Poller::new(CAPACITY).unwrap();
@@ -61,6 +62,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn write_interest_toggles() {
         let (a, _b) = UnixStream::pair().unwrap();
         let mut poller = Poller::new(CAPACITY).unwrap();
@@ -85,6 +87,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn read_interest_toggles() {
         let (a, b) = UnixStream::pair().unwrap();
         let mut poller = Poller::new(CAPACITY).unwrap();
@@ -109,6 +112,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn disarming_unarmed_write_is_ok() {
         let (a, _b) = UnixStream::pair().unwrap();
         let poller = Poller::new(CAPACITY).unwrap();
@@ -121,6 +125,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn remove_clears_interest() {
         let (a, b) = UnixStream::pair().unwrap();
         let mut poller = Poller::new(CAPACITY).unwrap();
@@ -131,6 +136,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn remove_unregistered_is_benign() {
         let (a, _b) = UnixStream::pair().unwrap();
         let poller = Poller::new(CAPACITY).unwrap();
@@ -139,6 +145,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn reports_each_ready_fd() {
         let (a1, b1) = UnixStream::pair().unwrap();
         let (a2, b2) = UnixStream::pair().unwrap();
@@ -159,6 +166,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn level_triggered_refires_until_drained() {
         // Level-triggered (no edge/one-shot mode): a readable fd re-fires every wait until drained, so a
         // handler may read once and trust the next wait for the rest.

--- a/src/reactor/poll/kqueue.rs
+++ b/src/reactor/poll/kqueue.rs
@@ -206,6 +206,7 @@ mod tests {
     // The shared `Poller` contract tests live in the parent `poll` module; only the
     // kqueue-specific re-add behavior is tested here.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn re_add_is_idempotent() {
         let (a, _b) = UnixStream::pair().unwrap();
         let poller = Poller::new(CAPACITY).unwrap();

--- a/src/reactor/signal.rs
+++ b/src/reactor/signal.rs
@@ -219,6 +219,7 @@ mod tests {
     static SIGNAL_STATE: Mutex<()> = Mutex::new(());
 
     #[test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore = "reads real fd flags")]
     fn self_pipe_is_cloexec_and_nonblocking() {
         let (read, write) = self_pipe().unwrap();
 
@@ -243,6 +244,7 @@ mod tests {
     // Installs process-global signal handlers, so it is serialized with the other install test via
     // `SIGNAL_STATE`.
     #[test]
+    #[cfg_attr(miri, ignore = "installs a real signal handler")]
     fn installed_handler_flags_shutdown_and_dump() {
         let _serialized = SIGNAL_STATE
             .lock()
@@ -277,6 +279,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "installs a real signal handler")]
     fn install_clears_a_stale_signal_flag() {
         let _serialized = SIGNAL_STATE
             .lock()

--- a/src/reflector/dial/connection.rs
+++ b/src/reflector/dial/connection.rs
@@ -619,6 +619,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn forward_dir_frames_a_request_and_rewrites_host() {
         let (peer_in, from) = connected_pair(); // peer_in -> from (the client side)
         let (to, peer_out) = connected_pair(); // to -> peer_out (the device side)
@@ -649,6 +650,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn forward_dir_rewrites_application_url_to_the_rest_listener_and_learns_it() {
         let (peer_in, from) = connected_pair();
         let (to, peer_out) = connected_pair();
@@ -687,6 +689,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn forward_dir_rewrites_a_location_redirect_to_the_desc_listener() {
         let (peer_in, from) = connected_pair();
         let (to, peer_out) = connected_pair();
@@ -717,6 +720,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn forward_reports_source_eof_when_the_peer_closes_its_write() {
         let (peer_in, from) = connected_pair();
         let (to, _peer_out) = connected_pair();
@@ -812,6 +816,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn close_if_complete_closes_only_when_both_flows_are_done() {
         let (_reactor, mut conn, _client_peer, _device_peer) = watched_connection();
         // Both Open: keep.
@@ -829,6 +834,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn forward_eof_finishes_the_flow_and_fins_the_destination() {
         let (mut reactor, mut conn, client_peer, device_peer) = watched_connection();
         // The client sends a full request, then closes its write half (a FIN after the bytes).
@@ -853,6 +859,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn half_close_holds_in_source_closed_until_the_backlog_drains() {
         let (mut reactor, mut conn, _client_peer, device_peer) = watched_connection();
         // A backlog still owed to the device at the moment the client half-closes.
@@ -885,6 +892,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn source_hangup_with_no_backlog_tears_down() {
         let (mut reactor, mut conn, _client_peer, _device_peer) = watched_connection();
         // A readable edge once the flow is past Open is a hangup on the disarmed source. With nothing
@@ -904,6 +912,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn source_hangup_still_drains_the_forward_backlog() {
         let (mut reactor, mut conn, _client_peer, device_peer) = watched_connection();
         // The client half-closed with a request still buffered toward the (live) device...
@@ -945,6 +954,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn both_peers_hangup_closes_without_panic() {
         let (mut reactor, mut conn, _client_peer, _device_peer) = watched_connection();
         // Both directions still owe a backlog to their (about-to-vanish) peers.

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -354,6 +354,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn accept_rest_proxies_to_the_learned_rest_endpoint() {
         let mut reactor = Reactor::new().expect("reactor");
         let (mut proxy, rest_addr) = watched_proxy(&mut reactor);
@@ -386,6 +387,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn accept_rest_drops_a_client_before_the_rest_endpoint_is_learned() {
         let mut reactor = Reactor::new().expect("reactor");
         let (mut proxy, rest_addr) = watched_proxy(&mut reactor); // rest_endpoint stays None

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -211,6 +211,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn rewrite_location_mints_a_proxy_and_rewrites_to_its_desc_listener() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -233,6 +234,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn rewrite_location_reuses_a_live_proxy_for_the_same_device() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -243,6 +245,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn rewrite_location_refreshes_the_grace_on_every_advertisement() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -265,6 +268,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn rewrite_location_remints_after_the_proxy_is_evicted() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -286,6 +290,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn an_interface_change_evicts_a_proxy_by_source_or_target() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -319,6 +324,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn evict_on_interface_change_prunes_an_already_evicted_entry() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -333,6 +339,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
     fn rewrite_location_forwards_non_dial_and_unrewritable_messages_unchanged() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -348,6 +355,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn dial_context_sweep_evicts_a_proxy_past_its_grace() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();
@@ -367,6 +375,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn rewrite_location_clamps_an_oversized_max_age() {
         let mut reactor = Reactor::new().expect("reactor");
         let mut ctx = DialContext::new();

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -493,6 +493,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn next_deadline_is_the_soonest_session_expiry() {
         let mut dispatcher = PacketDispatcher::new();
         let mut reflector = test_reflector();
@@ -523,6 +524,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn on_deadline_evicts_expired_sessions_and_unregisters_their_captures() {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new().unwrap();
@@ -567,6 +569,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn a_retransmit_reuses_its_session_and_refreshes_the_window() {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new().unwrap();
@@ -610,6 +613,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn a_session_is_keyed_by_searcher_and_group() {
         // The dedup key is (searcher, group). One live session for a searcher's link-local search: a
         // retransmit (same searcher, same group) finds it, but the same searcher's site-local search does
@@ -636,6 +640,7 @@ mod tests {
     // ports free with the reservations) and the next search re-opens fresh. A change on a capture the
     // reflector does not use leaves them.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn on_iface_change_clears_sessions_on_a_used_capture() {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new().unwrap();
@@ -684,6 +689,7 @@ mod tests {
     // on the target, and the reply leg only holds the source's (stable) CaptureKey and re-resolves the
     // source address at send time, so a source recreation does not orphan anything.
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn on_iface_change_leaves_sessions_on_a_source_capture_change() {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new().unwrap();
@@ -707,6 +713,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn make_session_drops_a_search_with_no_source_mac() {
         // No source MAC means no L2 address to reply to, so make_session drops the search rather than
         // open a session it could never answer.
@@ -733,6 +740,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn make_session_drops_at_the_session_cap() {
         // At MAX_SESSIONS in flight a new searcher is dropped; no live session is evicted early.
         let mut dispatcher = PacketDispatcher::new();
@@ -781,6 +789,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn a_failed_reflect_rolls_back_the_session_registration() {
         // make_session registers the response capture before reflecting; if the reflect then fails, that
         // registration must be rolled back, not leaked. A real loopback target lets make_session succeed;


### PR DESCRIPTION
Adds a Miri lane for the unit suite, on all nine supported targets.

Miri interprets Rust's abstract machine, so it catches UB that Valgrind fundamentally cannot: UB that
performs no invalid memory access. An unaligned read the hardware tolerates, or a raw pointer used
after a `&mut` reborrow invalidated its provenance, are both UB the optimizer may act on, and both
sit squarely in this crate's unsafe (the `read_unaligned` casts into netlink/BPF byte buffers,
`StreamBuffer`'s `MaybeUninit` tail). Memcheck sees nothing wrong with either. The two lanes
complement each other rather than overlap.

**No bugs found.** The pure-Rust unsafe is already clean: across the nine targets and both aliasing
models, zero UB, zero leaks. The lane is regression defense, not a fix. Concretely, it is what stops
someone "simplifying" `read_unaligned` to `read`, or `ptr::without_provenance_mut` to an `as` cast:
both compile, pass every test, and are UB.

### Gating

Miri cannot call foreign functions, so any test needing a real socket, capture device, poll backend,
interface or signal handler cannot run. Those are gated with `#[cfg_attr(miri, ignore = "...")]` and
**everything else runs unfiltered** -- deliberately, so a new test is covered by default and one that
reaches the kernel fails loudly until it is gated. A name-filtered allowlist would go quietly stale.

The reason names the capability the test needs, not the syscall it hits: 48 of the gated tests bottom
out in a different call per target (resolving an interface is rtnetlink on Linux, getifaddrs on BSD),
so naming one would be false on the others.

Reactor tests are gated only off Linux: Miri shims epoll but not kqueue, so they still run there,
where they also exercise our `epoll_event` FFI layout.

### The lane

One ubuntu runner covers every target: Miri interprets, so `--target` needs no toolchain, emulator or
VM for that OS. The BSD-only `cfg` code and the 32-bit ARM layouts are checked from x86_64 Linux. No
privileges needed (Miri's `geteuid` is a constant, so the root-gated tests take their skip branch).

Both aliasing models run (Stacked Borrows and Tree Borrows are different rulesets, and Tree Borrows is
the successor), plus `-Zmiri-strict-provenance`.

The toolchain floats on the newest nightly that ships Miri, rather than a pin that would freeze the
lane where it was born. Not every nightly builds the component, so plain `nightly` would red the lane
on an unrelated day; rust-lang's components-history gives the newest date that did ship it.

### Testing

- `cargo test --lib` unchanged: 431 passed, 0 ignored -- the gates are inert without `cfg(miri)`.
- fmt, clippy, actionlint clean.
- Miri: zero UB and zero leaks everywhere it has been run. The gate list was derived from actual runs
  on all nine targets (not static analysis), and where re-verified the skip count matches the measured
  blocked count exactly (80 on Linux, 105 on macOS/FreeBSD), so nothing is over- or under-gated.
- The authoritative check is this PR's own CI: nine targets x two aliasing models.
