### PR TITLE
Rename the project to netflector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,9 +383,9 @@ jobs:
         run: ci/freebsd-vm.sh run 'pkg install -y python3 && python3 --version'
       - name: Run the e2e suite in the VM
         run: |
-          ci/freebsd-vm.sh run 'mkdir -p /root/reflector'
-          ci/freebsd-vm.sh push e2e target/${{ matrix.arch.triple }}/release/reflector /root/reflector/
-          ci/freebsd-vm.sh run 'cd /root/reflector && python3 e2e/run.py --backend native --binary ./reflector'
+          ci/freebsd-vm.sh run 'mkdir -p /root/netflector'
+          ci/freebsd-vm.sh push e2e target/${{ matrix.arch.triple }}/release/netflector /root/netflector/
+          ci/freebsd-vm.sh run 'cd /root/netflector && python3 e2e/run.py --backend native --binary ./netflector'
       - name: VM console log
         if: failure()
         run: ci/freebsd-vm.sh console
@@ -412,16 +412,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-      - name: Build reflector image
+      - name: Build netflector image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
-          tags: reflector:e2e
+          tags: netflector:e2e
           load: true
           cache-from: type=gha,scope=${{ matrix.arch.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch.name }}
       - name: Run e2e
-        run: python3 e2e/run.py --skip-build --image reflector:e2e
+        run: python3 e2e/run.py --skip-build --image netflector:e2e
 
   # The same e2e suite without Docker: netns + veth segments and plain processes. The glibc lanes
   # run a release binary built directly on the runner -- the from-source configuration. The 64-bit
@@ -429,7 +429,7 @@ jobs:
   # toolchain, built and run natively. The 32-bit ARM lanes run that shipped configuration too,
   # lld-cross-linked like the Dockerfile's cross layers, with the daemon executing under qemu-user
   # via binfmt_misc: the harness, probes, and every kernel primitive (netns, veth, AF_PACKET,
-  # netlink) are native; only the reflector is emulated. That puts real 32-bit pointer-width
+  # netlink) are native; only netflector is emulated. That puts real 32-bit pointer-width
   # traffic through the whole capture -> classify -> re-emit path, which the QEMU unit-test lanes
   # can't (unit-only) and the docker-e2e lanes can't (64-bit images).
   native-e2e:
@@ -495,7 +495,7 @@ jobs:
       - name: Run e2e natively
         run: |
           triple='${{ matrix.target.triple }}'
-          sudo python3 e2e/run.py --backend native --binary "target/${triple:+$triple/}release/reflector"
+          sudo python3 e2e/run.py --backend native --binary "target/${triple:+$triple/}release/netflector"
 
   # The FreeBSD port pins every byte it builds from: the release tarball and all 20 crates, each with a
   # SHA256 in distinfo. If Cargo.lock moves and those are not regenerated, the port either fails to build
@@ -738,7 +738,7 @@ jobs:
           export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,indirect --track-fds=yes --num-callers=30 --error-exitcode=1'
           sudo -E "$(command -v cargo)" test --locked
 
-  # The e2e suite with the reflector under Valgrind memcheck (the runtime-valgrind image: a glibc release
+  # The e2e suite with netflector under Valgrind memcheck (the runtime-valgrind image: a glibc release
   # binary with debug symbols). run.py --valgrind SIGTERMs the daemon per case so Valgrind runs its leak
   # analysis at a clean exit; --error-exitcode=1 fails on any leak, leaked fd, or memcheck error.
   # --skip-build reuses the image built here.
@@ -758,7 +758,7 @@ jobs:
         with:
           context: .
           target: runtime-valgrind
-          tags: reflector:e2e-valgrind
+          tags: netflector:e2e-valgrind
           load: true
           cache-from: type=gha,scope=valgrind
           cache-to: type=gha,mode=max,scope=valgrind

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,12 +164,12 @@ jobs:
       - name: Stage binary
         run: |
           mkdir -p dist
-          cp "target/${{ matrix.target }}/release/reflector" "dist/reflector-${{ github.ref_name }}-${{ matrix.variant }}"
+          cp "target/${{ matrix.target }}/release/netflector" "dist/netflector-${{ github.ref_name }}-${{ matrix.variant }}"
 
       - name: Verify static linking (Linux)
         if: runner.os == 'Linux'
         run: |
-          bin="dist/reflector-${{ github.ref_name }}-${{ matrix.variant }}"
+          bin="dist/netflector-${{ github.ref_name }}-${{ matrix.variant }}"
           file "$bin"
           # The static binary has no shared-library deps (the invariant that matters), but PIE-ness
           # varies -- musl x86_64 is static-pie, the ARM targets and FreeBSD are plain static -- so
@@ -180,15 +180,14 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: reflector-${{ matrix.variant }}
-          path: dist/reflector-${{ github.ref_name }}-${{ matrix.variant }}
+          name: netflector-${{ matrix.variant }}
+          path: dist/netflector-${{ github.ref_name }}-${{ matrix.variant }}
           if-no-files-found: error
 
   # Each image arch builds on its own runner and pushes by digest; the manifest job stitches the
-  # digests into one multi-arch tag (the same shape the C++ reflector releases with). Native
-  # runners for amd64/arm64 mean those layers link with rustc's default toolchain -- the
-  # Dockerfile writes its lld config only for cross builds, i.e. the arm32 pair, which have no
-  # native runner and cross-compile on the amd64 host (no QEMU).
+  # digests into one multi-arch tag. Native runners for amd64/arm64 mean those layers link with
+  # rustc's default toolchain -- the Dockerfile writes its lld config only for cross builds, i.e.
+  # the arm32 pair, which have no native runner and cross-compile on the amd64 host (no QEMU).
   image:
     name: Image (${{ matrix.arch }})
     needs: verify-ci
@@ -235,7 +234,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/reflector,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
@@ -284,7 +283,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/reflector
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -293,7 +292,7 @@ jobs:
       - name: Create and push the manifest list
         working-directory: /tmp/digests
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/reflector
+          IMAGE: ghcr.io/${{ github.repository }}
           METADATA: ${{ steps.meta.outputs.json }}
         run: |
           mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA")
@@ -304,7 +303,7 @@ jobs:
 
       - name: Inspect
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/reflector
+          IMAGE: ghcr.io/${{ github.repository }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
@@ -320,19 +319,19 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
-          pattern: reflector-*
+          pattern: netflector-*
           merge-multiple: true
 
       - name: Checksums
         run: |
           cd dist
-          sha256sum reflector-* | tee SHA256SUMS
+          sha256sum netflector-* | tee SHA256SUMS
 
       - name: Create release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: |
-            dist/reflector-*
+            dist/netflector-*
             dist/SHA256SUMS
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# reflector
+# netflector
 
 ## Hard invariants
 
@@ -8,7 +8,7 @@
 - Must cross-compile to linux/arm/v7, linux/arm/v5, and static FreeBSD (amd64/arm64).
 - Error `Display` text is user-facing (printed to stderr) — keep it clear. Test
   structured error variants (`matches!`), not Display substrings.
-- lib/bin split: logic in the `reflector` library (`src/lib.rs`); thin binary (`src/main.rs`).
+- lib/bin split: logic in the `netflector` library (`src/lib.rs`); thin binary (`src/main.rs`).
 
 ## Build / test
 
@@ -26,7 +26,7 @@
   cargo, e.g. `./docker_test.sh clippy --all-targets -- -D warnings`). Check both
   host and Linux when touching `cfg(target_os)` code.
 - `cargo run` — no path arg: config from env only; with a path arg: TOML merged
-  with `REFLECTOR_*` env.
+  with `NETFLECTOR_*` env.
 - Test-only seams (`cfg(test)` accessor methods, consts) go in an `impl` block
   inside `mod tests`, never as `#[cfg(test)]` members of a production `impl`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## Hard invariants
 
-- Single-threaded event loop — no threads, no locks. Single-thread reactor
-  (`mio` or hand-rolled), never a multi-thread async runtime.
+- Single-threaded event loop: no threads, no locks. Hand-rolled epoll/kqueue
+  reactor, never a multi-thread async runtime.
 - Footprint-sensitive (embedded ARM, MikroTik). Mind data-path allocations.
-- Must cross-compile to linux/arm/v7, linux/arm/v5, and static FreeBSD (amd64/arm64).
-- Error `Display` text is user-facing (printed to stderr) — keep it clear. Test
+- Must cross-compile to linux/arm/v7, linux/arm/v5, and static FreeBSD
+  (amd64/arm64); macOS arm64 is a shipped target too, not dev-host-only.
+- Error `Display` text is user-facing (printed to stderr): keep it clear. Test
   structured error variants (`matches!`), not Display substrings.
 - lib/bin split: logic in the `netflector` library (`src/lib.rs`); thin binary (`src/main.rs`).
 
@@ -14,18 +15,18 @@
 
 - Keep `cargo clippy --all-targets -- -D warnings` clean.
 - Keep `cargo fmt --check` clean (run `cargo fmt` to fix).
-- Keep `cargo doc --no-deps --document-private-items` clean — `[lints.rustdoc]`
+- Keep `cargo doc --no-deps --document-private-items` clean. `[lints.rustdoc]`
   denies broken/private intra-doc links, but only `cargo doc` runs that check
-  (clippy/build don't). It's a separate gate step; run it on Linux too
+  (clippy/build don't); run it on Linux too
   (`./docker_test.sh doc --no-deps --document-private-items`) for `cfg` items.
 - Gate shared-logic changes (errno classifier, parser, struct layout) with the full
   `cargo test --lib`, not a name-filtered subset that can skip the integration test
   exercising the real syscall path.
-- Platform `cfg` code (the epoll backend now, AF_PACKET capture later) isn't built
-  on the macOS dev host — verify it on Linux with `./docker_test.sh` (forwards to
-  cargo, e.g. `./docker_test.sh clippy --all-targets -- -D warnings`). Check both
-  host and Linux when touching `cfg(target_os)` code.
-- `cargo run` — no path arg: config from env only; with a path arg: TOML merged
+- Platform `cfg` code (the epoll backend, AF_PACKET capture) isn't built on the
+  macOS dev host: verify it on Linux with `./docker_test.sh` (forwards to cargo,
+  e.g. `./docker_test.sh clippy --all-targets -- -D warnings`). Check both host
+  and Linux when touching `cfg(target_os)` code.
+- `cargo run` with no path arg: config from env only; with a path arg: TOML merged
   with `NETFLECTOR_*` env.
 - Test-only seams (`cfg(test)` accessor methods, consts) go in an `impl` block
   inside `mod tests`, never as `#[cfg(test)]` members of a production `impl`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "netflector"
+version = "0.13.0"
+dependencies = [
+ "libc",
+ "log",
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,17 +63,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "reflector"
-version = "0.13.0"
-dependencies = [
- "libc",
- "log",
- "serde",
- "thiserror",
- "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "reflector"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflector"
-version = "0.12.2"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.93"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "reflector"
+name = "netflector"
 version = "0.13.0"
 edition = "2024"
 rust-version = "1.93"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# Build the reflector as a fully static musl binary and ship it on scratch — nothing else to carry
+# Build netflector as a fully static musl binary and ship it on scratch — nothing else to carry
 # or to grow CVEs. Architecture-agnostic: buildx's TARGETARCH/TARGETVARIANT select the musl target,
 # and the builder runs on the native build host (BUILDPLATFORM) and cross-compiles, so the arm
 # images don't crawl under QEMU. Cross layers link with LLVM's lld (any arch, no per-arch gcc);
@@ -59,9 +59,9 @@ COPY src/ ./src/
 RUN --mount=type=cache,id=cargo-registry-${TARGETARCH}${TARGETVARIANT},target=/usr/local/cargo/registry \
     triple="$(cat /triple)"; \
     cargo build --release --locked --target "${triple}"; \
-    install -D "target/${triple}/release/reflector" /out/reflector
+    install -D "target/${triple}/release/netflector" /out/netflector
 
-# The reflector under Valgrind memcheck, for `e2e/run.py --valgrind`. A glibc release binary with debug
+# netflector under Valgrind memcheck, for `e2e/run.py --valgrind`. A glibc release binary with debug
 # symbols (unstripped): the same -O3/LTO codegen the scratch image ships, just with -g for readable traces
 # and dynamic glibc -- Valgrind supports that well, unlike the static musl target. amd64-only (the Valgrind
 # e2e job is); built and run on the one rust:slim base so the glibc versions match. run.py SIGTERMs the
@@ -79,7 +79,7 @@ COPY src/ ./src/
 RUN --mount=type=cache,id=cargo-registry-valgrind,target=/usr/local/cargo/registry \
     CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_STRIP=false \
     cargo build --release --locked \
-    && install -D target/release/reflector /usr/local/bin/reflector
+    && install -D target/release/netflector /usr/local/bin/netflector
 ENTRYPOINT ["valgrind", \
     "--leak-check=full", \
     "--show-leak-kinds=all", \
@@ -87,11 +87,11 @@ ENTRYPOINT ["valgrind", \
     "--track-fds=yes", \
     "--num-callers=30", \
     "--error-exitcode=1", \
-    "/usr/local/bin/reflector"]
-CMD ["/etc/reflector/config.toml"]
+    "/usr/local/bin/netflector"]
+CMD ["/etc/netflector/config.toml"]
 
 # Production image: one fully static binary on scratch -- nothing else to ship or grow CVEs. Keep this LAST
 # so a bare `docker build .` (no --target, as releases and the non-valgrind e2e use) defaults to it.
 FROM scratch AS runtime
-COPY --from=builder /out/reflector /usr/local/bin/reflector
-ENTRYPOINT ["/usr/local/bin/reflector"]
+COPY --from=builder /out/netflector /usr/local/bin/netflector
+ENTRYPOINT ["/usr/local/bin/netflector"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# reflector
+# netflector
 
 Reflects link-local service traffic between two network interfaces. Useful when devices that need to
 talk to each other sit on different L2 segments that don't forward each other's broadcasts or
@@ -34,9 +34,9 @@ these. The same shape serves one or a few specific devices (`macs`) or a whole n
 
 ## Platform support
 
-reflector runs on **Linux, macOS, and FreeBSD**.
+netflector runs on **Linux, macOS, and FreeBSD**.
 
-**Docker**: a multi-arch image is published to `ghcr.io/sbogomolov/reflector` for `linux/amd64`,
+**Docker**: a multi-arch image is published to `ghcr.io/netflector/netflector` for `linux/amd64`,
 `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; Docker pulls the variant matching the host. The
 32-bit ARM variants reach low-end embedded routers and SBCs, down to soft-float ARMv5, handy for the
 router that bridges the two segments.
@@ -59,8 +59,8 @@ components, so with [`rustup`](https://rustup.rs) the right toolchain (and any m
 installed on the first `cargo` invocation. The crate is edition 2024 (Rust ≥ 1.85), with a 1.93 MSRV.
 
 ```sh
-cargo build            # debug binary at target/debug/reflector
-cargo build --release  # optimized binary at target/release/reflector
+cargo build            # debug binary at target/debug/netflector
+cargo build --release  # optimized binary at target/release/netflector
 ```
 
 The release profile enables LTO, a single codegen unit, and symbol stripping for a small footprint
@@ -83,14 +83,14 @@ The runtime image is a single static musl binary on `scratch`: no shell, no pack
 build produces a single-arch image for the host:
 
 ```sh
-docker build -t reflector .
+docker build -t netflector .
 ```
 
 The Dockerfile's builder runs on the build host (no QEMU) and links the cross layers with LLVM's
 `lld`, so a multi-arch image builds on one machine:
 
 ```sh
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5 -t reflector .
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5 -t netflector .
 ```
 
 Releases take a different path (see [Release](#release)): each arch builds on its own runner and the
@@ -101,11 +101,11 @@ native runner, cross-compile.
 ## Run
 
 ```sh
-./target/release/reflector [--check-config] [--] [config.toml]
+./target/release/netflector [--check-config] [--] [config.toml]
 ```
 
 Configuration comes from a TOML file, from environment variables, or from both. With a path argument
-the file is read and merged with any `REFLECTOR_*` environment variables; with **no argument** the
+the file is read and merged with any `NETFLECTOR_*` environment variables; with **no argument** the
 configuration comes entirely from the environment (see [Environment variables](#environment-variables)).
 The process logs to stderr with UTC timestamps, shuts down cleanly on `SIGINT` / `SIGTERM`, and on
 `SIGUSR1` dumps the per-interface [packet counters](#configuration) to the log on demand (regardless of
@@ -123,13 +123,13 @@ on a machine where the configured interfaces do not exist (useful for validating
 a build host), but for the same reason it cannot tell you that an interface is missing:
 
 ```sh
-$ reflector --check-config /usr/local/etc/reflector.toml
+$ netflector --check-config /usr/local/etc/netflector.toml
 config ok: 1 reflector
 ```
 
 ### Runtime privileges
 
-The reflector opens one L2 packet-capture socket per interface: it both observes incoming packets and
+netflector opens one L2 packet-capture socket per interface: it both observes incoming packets and
 re-injects reflected ones through that same socket (the sender doesn't bind a port, so no port
 privileges are involved). mDNS and SSDP additionally join their multicast group(s) on it, which needs
 no privilege beyond opening the socket. That capture socket drives the requirements below.
@@ -140,14 +140,14 @@ Capture and injection use `AF_PACKET`; the DIAL proxy's TCP connect pins its int
 `SO_BINDTODEVICE`. Both require `CAP_NET_RAW`. Either run as root or grant the capability once:
 
 ```sh
-sudo setcap cap_net_raw=eip ./target/release/reflector
+sudo setcap cap_net_raw=eip ./target/release/netflector
 ```
 
 #### macOS
 
 Capture and injection use BPF (`/dev/bpf*`); the DIAL proxy's connect uses `IP_BOUND_IF`, which needs
 no extra privilege. BPF devices are owned by `root:wheel` with mode `0600` on a default install, so out
-of the box the reflector must run as root. To run unprivileged, install Wireshark's `ChmodBPF` helper.
+of the box netflector must run as root. To run unprivileged, install Wireshark's `ChmodBPF` helper.
 It creates an `access_bpf` group, adds the current user to it, and re-applies the right permissions to
 `/dev/bpf*` on every boot:
 
@@ -161,30 +161,30 @@ Log out and back in after installing for the group membership to take effect.
 
 Capture and injection use BPF (`/dev/bpf*`), like macOS. FreeBSD has no `IP_BOUND_IF`, so the DIAL
 proxy's connect pins its interface by binding the source address; no port privileges are needed. BPF
-devices are root-only by default, so out of the box the reflector must run as root. To run
+devices are root-only by default, so out of the box netflector must run as root. To run
 unprivileged, grant a group read/write on `/dev/bpf*` with a devfs ruleset (`/etc/devfs.rules` +
 `devfs_system_ruleset` in `/etc/rc.conf`) and add the user to that group.
 
 ### Run in Docker
 
-Prebuilt multi-arch images are published to `ghcr.io/sbogomolov/reflector`, tagged `latest` and per
+Prebuilt multi-arch images are published to `ghcr.io/netflector/netflector`, tagged `latest` and per
 release version, for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, and `linux/arm/v5`; Docker pulls the
 variant matching the host. The image is a single static binary on `scratch`: no shell, no package
-manager. Its entrypoint is the reflector with no default argument, so it configures itself from
-`REFLECTOR_*` [environment variables](#environment-variables); pass a config file path to use a file
+manager. Its entrypoint is netflector with no default argument, so it configures itself from
+`NETFLECTOR_*` [environment variables](#environment-variables); pass a config file path to use a file
 instead.
 
-Because the reflector captures at L2 on each interface, the container must be **on the real segments it
+Because netflector captures at L2 on each interface, the container must be **on the real segments it
 bridges**, not on a default NAT bridge network (which would hide that traffic from it). On a Linux host,
 `--network host` is the simplest way. Configure it with `-e` variables:
 
 ```sh
 docker run --rm \
     --network host \
-    -e REFLECTOR_TV_SOURCE_IF=eth0 \
-    -e REFLECTOR_TV_TARGET_IF=eth1 \
-    -e REFLECTOR_TV_MDNS=true \
-    ghcr.io/sbogomolov/reflector:latest
+    -e NETFLECTOR_TV_SOURCE_IF=eth0 \
+    -e NETFLECTOR_TV_TARGET_IF=eth1 \
+    -e NETFLECTOR_TV_MDNS=true \
+    ghcr.io/netflector/netflector:latest
 ```
 
 `CAP_NET_RAW` is required (see [Runtime privileges](#runtime-privileges)) and is in Docker's default
@@ -195,26 +195,26 @@ just that one:
 docker run --rm \
     --network host \
     --cap-drop ALL --cap-add NET_RAW \
-    -e REFLECTOR_TV_SOURCE_IF=eth0 \
-    -e REFLECTOR_TV_TARGET_IF=eth1 \
-    -e REFLECTOR_TV_MDNS=true \
-    ghcr.io/sbogomolov/reflector:latest
+    -e NETFLECTOR_TV_SOURCE_IF=eth0 \
+    -e NETFLECTOR_TV_TARGET_IF=eth1 \
+    -e NETFLECTOR_TV_MDNS=true \
+    ghcr.io/netflector/netflector:latest
 ```
 
 To use a config file instead of (or alongside) the environment, mount it and pass its path as the
 argument. This form also shows running it as a service, `-d` with a restart policy:
 
 ```sh
-docker run -d --name reflector --restart unless-stopped \
+docker run -d --name netflector --restart unless-stopped \
     --network host \
     --cap-drop ALL --cap-add NET_RAW \
-    -v /path/to/config.toml:/etc/reflector/config.toml:ro \
-    ghcr.io/sbogomolov/reflector:latest /etc/reflector/config.toml
+    -v /path/to/config.toml:/etc/netflector/config.toml:ro \
+    ghcr.io/netflector/netflector:latest /etc/netflector/config.toml
 ```
 
 #### On MikroTik RouterOS
 
-The `arm64`, `arm/v7`, and `arm/v5` variants let the reflector run on the router itself through the
+The `arm64`, `arm/v7`, and `arm/v5` variants let netflector run on the router itself through the
 RouterOS *Container* feature, bridging two of the router's VLANs without a separate host. Since it has
 to see both segments, give the container **two `veth` interfaces, one bridged into each VLAN**, and name
 them as the entry's `source_if` / `target_if`:
@@ -232,10 +232,10 @@ wsd       = true         # enable WS-Discovery, disabled by default
 ```
 
 On RouterOS, setting the container's environment variables is usually easier than mounting a file: the
-entry above becomes `REFLECTOR_TV_SOURCE_IF=veth-lan`, `REFLECTOR_TV_TARGET_IF=veth-iot`,
-`REFLECTOR_TV_MACS=B0:37:95:C5:60:BE`, `REFLECTOR_TV_WOL=true`, and so on (see
+entry above becomes `NETFLECTOR_TV_SOURCE_IF=veth-lan`, `NETFLECTOR_TV_TARGET_IF=veth-iot`,
+`NETFLECTOR_TV_MACS=B0:37:95:C5:60:BE`, `NETFLECTOR_TV_WOL=true`, and so on (see
 [Environment variables](#environment-variables)). To use the file instead, mount it to
-`/etc/reflector/config.toml` and set that path as the container's command argument. For the RouterOS
+`/etc/netflector/config.toml` and set that path as the container's command argument. For the RouterOS
 side (enabling container mode, creating the `veth`s, and attaching each to its VLAN), see MikroTik's
 [Container documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/84901929/Container).
 
@@ -274,34 +274,34 @@ proxy (so it requires `ssdp`; see [DIAL](#dial)).
 
 Every setting can also come from the environment, which is convenient for containers. A file argument is
 then optional; with none, the environment is the whole configuration. Variables are named
-`REFLECTOR_<TAG>_<PARAM>`:
+`NETFLECTOR_<TAG>_<PARAM>`:
 
 - `<TAG>` ties one entry's parameters together: any alphanumeric string (`1`, `2`, `TV`, …). It also
   becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
   `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
 
-The globals are `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
-`REFLECTOR_COUNTERS_INTERVAL_SECS`, so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are
+The globals are `NETFLECTOR_LOG_LEVEL`, `NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
+`NETFLECTOR_COUNTERS_INTERVAL_SECS`, so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are
 `true`/`false` or `1`/`0`; `WOL_PORTS`
 and `MACS` are comma-separated (`7,9` / `B0:...,C4:...`). The `[reflectors.tv]` entry above looks like
 this in the environment:
 
 ```sh
-REFLECTOR_LOG_LEVEL=info
-REFLECTOR_TV_SOURCE_IF=en0
-REFLECTOR_TV_TARGET_IF=lo0
-REFLECTOR_TV_MACS=B0:37:95:C5:60:BE
-REFLECTOR_TV_WOL=true
-REFLECTOR_TV_MDNS=true
-REFLECTOR_TV_SSDP=true
-REFLECTOR_TV_DIAL=true
-REFLECTOR_TV_WSD=true
+NETFLECTOR_LOG_LEVEL=info
+NETFLECTOR_TV_SOURCE_IF=en0
+NETFLECTOR_TV_TARGET_IF=lo0
+NETFLECTOR_TV_MACS=B0:37:95:C5:60:BE
+NETFLECTOR_TV_WOL=true
+NETFLECTOR_TV_MDNS=true
+NETFLECTOR_TV_SSDP=true
+NETFLECTOR_TV_DIAL=true
+NETFLECTOR_TV_WSD=true
 ```
 
 When a file and environment variables are both given they are merged: each contributes entries to one
-combined configuration, and each global variable (`REFLECTOR_LOG_LEVEL`,
-`REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, `REFLECTOR_COUNTERS_INTERVAL_SECS`) overrides its file
+combined configuration, and each global variable (`NETFLECTOR_LOG_LEVEL`,
+`NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, `NETFLECTOR_COUNTERS_INTERVAL_SECS`) overrides its file
 counterpart. The
 [duplicate detection](#duplicate-detection) below applies across both
 sources. An unknown `<PARAM>`, a non-alphanumeric or reserved tag, and a tag with no parameter are all
@@ -340,7 +340,7 @@ interface loses its address and brought back up once both can send it again.
 
 ### Reacting to address changes
 
-The reflector watches the kernel for interface address and lifecycle changes (a `NETLINK_ROUTE`
+netflector watches the kernel for interface address and lifecycle changes (a `NETLINK_ROUTE`
 socket on Linux, a `PF_ROUTE` socket on the BSDs) and adapts at runtime, without a restart. mDNS and SSDP bring a family
 up (joining its multicast group(s) and installing its capture registrations) once that family becomes
 reflectable (a source address for it is present on **both** interfaces), and tear it down when either
@@ -348,7 +348,7 @@ interface loses the address; the family resumes automatically when the address r
 captures installed and instead checks reachability per packet, so it has nothing to join or leave.
 Either way, a best-effort IPv6 family that had no address at startup begins reflecting as soon as one
 appears. Gaining a family logs at `info`; losing a *required* family logs at `error`, an optional one at
-`info`. The monitor is best-effort: if it cannot start, the reflector logs a warning and runs without
+`info`. The monitor is best-effort: if it cannot start, netflector logs a warning and runs without
 address refresh.
 
 It also survives an interface being destroyed and recreated (a fresh kernel identity, e.g. a PPPoE
@@ -399,21 +399,21 @@ device/printer discovery across segments.
 DIAL (DIscovery And Launch, the protocol behind "cast to TV" for YouTube, Netflix, etc.) lets a phone
 or laptop find a smart TV and launch an app on it. The catch: a DIAL device restricts its description
 and REST endpoints to its **own subnet**, so a client on a different segment discovers the device but
-cannot drive it. Setting `dial = true` on an SSDP entry makes the reflector bridge that gap.
+cannot drive it. Setting `dial = true` on an SSDP entry makes netflector bridge that gap.
 
 It is a **terminating HTTP reverse proxy**. When a DIAL `LOCATION` (in a relayed `NOTIFY` or `M-SEARCH`
-`200 OK`) crosses target→source, the reflector mints a per-device ephemeral TCP listener on
+`200 OK`) crosses target→source, netflector mints a per-device ephemeral TCP listener on
 `source_if`'s address and rewrites the `LOCATION` authority to point at that listener. A source-side
-client then connects to the reflector, which opens an upstream connection to the device **bound to
+client then connects to netflector, which opens an upstream connection to the device **bound to
 `target_if`'s address**, so the device sees an on-subnet client and serves it. Along the way it
 rewrites the four authority-bearing headers (`LOCATION`, the description's `Application-URL`, request
-`Host`, and response `Location`) from the device's authority to a reflector authority and back; HTTP
+`Host`, and response `Location`) from the device's authority to a netflector authority and back; HTTP
 bodies stream through untouched. App launch (`POST`) and stop (`DELETE`) work end to end.
 
 `dial = true` requires `ssdp` and is **IPv4-only** (the DIAL spec ties the device authority to an IPv4
 address); an `ipv6`-only entry with `dial = true` is rejected at startup. It is the only DIAL knob;
 every cap and timeout is a fixed constant. The proxy degrades benignly: a `LOCATION`/`Application-URL`
-the reflector can't rewrite (an `https` URL, a hostname instead of an IPv4 literal, a listener cap/bind
+netflector can't rewrite (an `https` URL, a hostname instead of an IPv4 literal, a listener cap/bind
 failure) is forwarded unchanged and logged, leaving on-subnet discovery unaffected.
 
 ### Duplicate detection
@@ -438,7 +438,7 @@ cargo doc --no-deps --document-private-items   # the rustdoc intra-doc link gate
 ```
 
 A subset of tests does privileged work (real packet capture, or binding a socket to an interface) and
-needs the same privileges the reflector itself does (see [Runtime privileges](#runtime-privileges)).
+needs the same privileges netflector itself does (see [Runtime privileges](#runtime-privileges)).
 Each probes for the privilege and self-skips cleanly when it's missing, so a default `cargo test` run is
 green on an under-privileged box.
 
@@ -448,7 +448,7 @@ a macOS/FreeBSD dev box (e.g. `./docker_test.sh test`).
 
 ### End-to-end tests
 
-The end-to-end suite drives the real data path: the reflector straddles two isolated network segments
+The end-to-end suite drives the real data path: netflector straddles two isolated network segments
 and the suite verifies traffic is reflected, multi-protocol. It runs on two backends. The default
 `docker` backend uses bridge networks and containers; it's opt-in (it builds/runs containers and
 creates temporary Docker networks):
@@ -459,10 +459,10 @@ python3 e2e/run.py --valgrind     # run the daemon under Valgrind memcheck
 python3 e2e/run.py --case reflects_matching_magic_packet   # one case
 ```
 
-`--valgrind` runs the reflector under memcheck (the `runtime-valgrind` image: a glibc release binary
+`--valgrind` runs netflector under memcheck (the `runtime-valgrind` image: a glibc release binary
 with debug symbols) and fails the run on any leak, leaked fd, or memcheck error. The runner builds
-`reflector:e2e` by default, uses `python:3.13-alpine` for UDP-probe containers, can print reflector logs
-with `--show-reflector-logs`, and leaves resources behind on failure with `--keep-on-failure`.
+`netflector:e2e` by default, uses `python:3.13-alpine` for UDP-probe containers, can print netflector logs
+with `--show-netflector-logs`, and leaves resources behind on failure with `--keep-on-failure`.
 
 The `native` backend runs the same cases without Docker, as root: network namespaces + veth pairs on
 Linux, vnet jails + epair(4) on FreeBSD -- one namespace/jail per participant either way. Build the
@@ -470,7 +470,7 @@ binary first; the harness never runs cargo as root:
 
 ```sh
 cargo build --release --locked
-sudo python3 e2e/run.py --backend native --binary target/release/reflector
+sudo python3 e2e/run.py --backend native --binary target/release/netflector
 ```
 
 CI runs the native suite on linux amd64/arm64 (glibc and the shipped static musl), on armv7/armv5
@@ -482,7 +482,7 @@ The `[package]` version in `Cargo.toml` is the single source of truth: `version.
 `release.sh` (the git tag), the published image tag, and the GitHub release name all derive from it. To
 cut a release:
 
-- Bump the version in `Cargo.toml`, refresh `Cargo.lock` (`cargo build` updates its `reflector`
+- Bump the version in `Cargo.toml`, refresh `Cargo.lock` (`cargo build` updates its `netflector`
   entry; CI builds `--locked`, so a stale lockfile fails the release), and merge it to `origin/main`.
 - From a clean `main` in sync with `origin/main`, run `./release.sh`.
 

--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -62,7 +62,7 @@ SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 # rc.conf.local write is never re-read; the per-service /etc/rc.conf.d/<name>
 # file is the one rc knob each script sources fresh.
 seed_iso() {
-    printf 'instance-id: reflector-ci\nlocal-hostname: reflector-freebsd\n' \
+    printf 'instance-id: netflector-ci\nlocal-hostname: netflector-freebsd\n' \
         > "$VM_DIR/meta-data"
     cat > "$VM_DIR/user-data" <<EOF
 #cloud-config

--- a/docker_test.sh
+++ b/docker_test.sh
@@ -27,7 +27,7 @@ cd "$(dirname "$0")"
 
 [ "$#" -eq 0 ] && set -- test
 
-IMAGE=reflector-devtest
+IMAGE=netflector-devtest
 docker build -q -t "$IMAGE" - >/dev/null <<'DOCKERFILE'
 FROM rust:slim
 RUN apt-get update \
@@ -39,11 +39,11 @@ exec docker run --rm \
     --cap-add=NET_ADMIN \
     --cap-add=NET_RAW \
     --sysctl net.ipv4.conf.all.accept_local=1 \
-    -v "$PWD":/reflector \
-    -v reflector-linux-target:/linux-target \
-    -v reflector-cargo-registry:/usr/local/cargo/registry \
-    -v reflector-rustup:/usr/local/rustup \
+    -v "$PWD":/netflector \
+    -v netflector-linux-target:/linux-target \
+    -v netflector-cargo-registry:/usr/local/cargo/registry \
+    -v netflector-rustup:/usr/local/rustup \
     -e CARGO_TARGET_DIR=/linux-target \
-    -w /reflector \
+    -w /netflector \
     "$IMAGE" \
     cargo "$@"

--- a/e2e/config-dial.toml
+++ b/e2e/config-dial.toml
@@ -1,6 +1,6 @@
 log_level = "debug"
 
-# A single DIAL entry, so the reflector's SSDP relay carries the device's 200 OK exactly once (the shared
+# A single DIAL entry, so netflector's SSDP relay carries the device's 200 OK exactly once (the shared
 # config.toml's any-MAC [reflectors.discovery] entry would otherwise double-reflect it). DIAL requires ssdp.
 [reflectors.dial-tv]
 source_if = "wol_src"

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 #
-# In-container UDP prober for the reflector Wake-on-LAN e2e tests. run.py drives two of these in
+# In-container UDP prober for the netflector Wake-on-LAN e2e tests. run.py drives two of these in
 # separate helper containers: a `receive` prober binds the receive port (and, for IPv6, joins the
 # all-nodes group on its pinned interface) and asserts what it sees, while a `send` prober emits the
-# magic packet (broadcast for IPv4, all-nodes multicast for IPv6) toward the reflector. The receiver's
+# magic packet (broadcast for IPv4, all-nodes multicast for IPv6) toward netflector. The receiver's
 # process exit code is the verdict run.py waits on: 0 = expectation held, non-zero = failed.
 #
 # The send/receive verbs cover WoL and the verbatim-relay protocols (mDNS, one-way SSDP). The
 # respond/search verbs drive the SSDP M-SEARCH round trip: a `respond` device unicasts a 200 OK back to
-# whoever searched, and a `search` searcher awaits that reply proxied across segments by the reflector.
+# whoever searched, and a `search` searcher awaits that reply proxied across segments by netflector.
 # The DIAL probe verbs (dial-device/dial-client) from the C++ harness are absent because the DIAL cases
 # (see DIAL_CASES in run.py) drive a dedicated HTTP emulator rather than this prober.
 
@@ -166,7 +166,7 @@ def receive(args: argparse.Namespace) -> int:
 
 def respond(args: argparse.Namespace) -> int:
     # The SSDP round-trip "device": wait for one (relayed) M-SEARCH on the group, then unicast a 200 OK
-    # straight back to its sender. The sender is the reflector's reserved port on the target segment,
+    # straight back to its sender. The sender is netflector's reserved port on the target segment,
     # which proxies the reply back to the searcher on the source segment.
     family = socket.AF_INET6 if args.family == 6 else socket.AF_INET
     bind_address = "::" if family == socket.AF_INET6 else "0.0.0.0"
@@ -187,7 +187,7 @@ def respond(args: argparse.Namespace) -> int:
             return 1
 
         print(f"responder received {len(payload)} bytes from {peer[0]}:{peer[1]}", flush=True)
-        # Reply straight back to the sender (the reflector's target_if:P); it proxies to the searcher.
+        # Reply straight back to the sender (netflector's target_if:P); it proxies to the searcher.
         # peer is the full tuple recvfrom returned (4-tuple for IPv6), preserving the link-local scope.
         sock.sendto(args.reply_hex, peer)
         print(f"responder replied {len(args.reply_hex)} bytes to {peer[0]}:{peer[1]}", flush=True)
@@ -196,7 +196,7 @@ def respond(args: argparse.Namespace) -> int:
 
 def search(args: argparse.Namespace) -> int:
     # The SSDP round-trip "searcher": send an M-SEARCH to the group from a known source port, then await
-    # the proxied unicast 200 OK the reflector relays back from the device on the target segment.
+    # the proxied unicast 200 OK netflector relays back from the device on the target segment.
     family = socket.AF_INET6 if args.family == 6 else socket.AF_INET
     bind_address = "::" if family == socket.AF_INET6 else "0.0.0.0"
 
@@ -253,7 +253,7 @@ DIAL_SERVICE_TYPE = "urn:dial-multiscreen-org:service:dial:1"
 
 
 def _own_address(interface: str, family: int) -> str:
-    # This container's address on the interface facing the reflector -- the address the reflector's
+    # This container's address on the interface facing netflector -- the address netflector's
     # egress-pinned upstream connect() lands on, and the host we advertise in LOCATION / Application-URL.
     # A dummy connect + getsockname resolves it without parsing `ip addr`. The DIAL device is single-homed
     # (target network only), so the route -- and hence the source address -- is unambiguous.
@@ -271,16 +271,16 @@ def dial_device(args: argparse.Namespace) -> int:
     # Emulate a DIAL device: answer the proxied M-SEARCH with a 200 OK whose LOCATION points at our own
     # (target-side) HTTP description endpoint, and serve the description + REST endpoints over TCP. We
     # record the peer address of every accepted HTTP connection: with the device single-homed on the
-    # target network, the only client that can reach these endpoints is the reflector's upstream connect,
-    # so the recorded peer must be the reflector's target_if address (run.py asserts this).
+    # target network, the only client that can reach these endpoints is netflector's upstream connect,
+    # so the recorded peer must be netflector's target_if address (run.py asserts this).
     own = _own_address(args.interface, args.family)
     peers: set[str] = set()
     host_errors: list[str] = []
     state_lock = threading.Lock()
 
     def note(peer_ip: str, host, expected: str) -> None:
-        # Record the upstream peer (must be the reflector's target_if address) and verify the request's Host
-        # was rewritten to this device's own authority -- the device must never see the reflector's authority.
+        # Record the upstream peer (must be netflector's target_if address) and verify the request's Host
+        # was rewritten to this device's own authority -- the device must never see netflector's authority.
         with state_lock:
             peers.add(peer_ip)
             if host != expected:
@@ -350,8 +350,8 @@ def dial_device(args: argparse.Namespace) -> int:
             self._chunked(200, b"")
 
     # Bind the HTTP servers on ephemeral ports (the description port is "dynamic" by design). In
-    # --unreachable mode no server is started: the advertised port is one we bind-then-close, so the
-    # reflector's upstream connect is refused -- exercising the connect-failure path.
+    # --unreachable mode no server is started: the advertised port is one we bind-then-close, so
+    # netflector's upstream connect is refused -- exercising the connect-failure path.
     bind_host = "::" if args.family == 6 else "0.0.0.0"
     if args.unreachable:
         with socket.socket(socket.AF_INET6 if args.family == 6 else socket.AF_INET, socket.SOCK_STREAM) as dead:
@@ -380,7 +380,7 @@ def dial_device(args: argparse.Namespace) -> int:
 
         if args.notify:
             # Passive discovery: advertise an unsolicited NOTIFY ssdp:alive periodically (as real devices
-            # do), so the later-listening client catches one; the reflector relays each and rewrites LOCATION.
+            # do), so the later-listening client catches one; netflector relays each and rewrites LOCATION.
             notify = (
                 "NOTIFY * HTTP/1.1\r\n"
                 f"HOST: {args.join_group}:{args.port}\r\n"
@@ -458,7 +458,7 @@ def _http_request(host, port, method, path, family, body=b""):
         for line in lines[1:]:
             key, _, value = line.partition(":")
             headers[key.strip().lower()] = value.strip()
-        # Read the body per its framing rather than waiting for the connection close: the reflector
+        # Read the body per its framing rather than waiting for the connection close: netflector
         # defers the client-side close to its eviction timer, so an EOF-driven read would block on that.
         if headers.get("transfer-encoding", "").lower() == "chunked":
             while not rest.endswith(b"0\r\n\r\n"):
@@ -482,7 +482,7 @@ def _authority(url: str) -> str:
 
 
 def _dial_discover(args):
-    # Return the (reflector-rewritten) SSDP response carrying the device LOCATION, or None on timeout. Active
+    # Return the (netflector-rewritten) SSDP response carrying the device LOCATION, or None on timeout. Active
     # discovery sends an M-SEARCH and reads the unicast 200 OK; passive discovery joins the group and waits
     # for the relayed NOTIFY ssdp:alive.
     family = socket.AF_INET6 if args.family == 6 else socket.AF_INET
@@ -534,11 +534,11 @@ def _dial_discover(args):
 
 
 def dial_client(args: argparse.Namespace) -> int:
-    # Run the full DIAL flow through the reflector and assert each rewritable authority was rewritten to
-    # the reflector's source-side address (and never leaks the device's true target-side address). The
-    # device is unreachable from this (source) network except via the reflector, so a missing rewrite
+    # Run the full DIAL flow through netflector and assert each rewritable authority was rewritten to
+    # netflector's source-side address (and never leaks the device's true target-side address). The
+    # device is unreachable from this (source) network except via netflector, so a missing rewrite
     # makes the HTTP step connect to an unroutable address and fail.
-    refl = args.reflector_authority   # the reflector's source_if address (host only; LOCATION ports are dynamic)
+    refl = args.netflector_authority  # netflector's source_if address (host only; LOCATION ports are dynamic)
     device = args.device_authority    # the device's TRUE target-side host, asserted absent from rewrites
 
     text = _dial_discover(args)
@@ -551,7 +551,7 @@ def dial_client(args: argparse.Namespace) -> int:
         return 1
     loc_host = _authority(location).rsplit(":", 1)[0]
     if loc_host != refl:
-        print(f"dial-client: LOCATION host {loc_host!r} is not the reflector authority {refl!r} "
+        print(f"dial-client: LOCATION host {loc_host!r} is not the netflector authority {refl!r} "
               f"(rewrite missing); full LOCATION {location!r}", file=sys.stderr, flush=True)
         return 1
     if device in _authority(location):
@@ -560,11 +560,11 @@ def dial_client(args: argparse.Namespace) -> int:
     desc_host, _, desc_port_s = _authority(location).rpartition(":")
     desc_port = int(desc_port_s)
     desc_path = "/" + location.split("://", 1)[1].split("/", 1)[1]
-    print(f"dial-client: LOCATION rewritten to reflector authority {desc_host}:{desc_port}", flush=True)
+    print(f"dial-client: LOCATION rewritten to netflector authority {desc_host}:{desc_port}", flush=True)
 
     if args.expect_fetch_failure:
         # The LOCATION was rewritten (the listener was minted), but the device's upstream is dead, so the
-        # proxied fetch must fail -- and fail PROMPTLY. The reflector must FIN the client when the upstream
+        # proxied fetch must fail -- and fail PROMPTLY. netflector must FIN the client when the upstream
         # connect is refused, not leave it hanging until the eviction timer (~5s). A 2s budget cleanly
         # separates the prompt close from that stall.
         start = time.monotonic()
@@ -573,7 +573,7 @@ def dial_client(args: argparse.Namespace) -> int:
         except Exception as exc:  # noqa: BLE001 - any failure (refused / reset / EOF / timeout) is the point
             elapsed = time.monotonic() - start
             if elapsed > 2.0:
-                print(f"dial-client: fetch failed but only after {elapsed:.1f}s (> 2s) -- the reflector did "
+                print(f"dial-client: fetch failed but only after {elapsed:.1f}s (> 2s) -- netflector did "
                       f"not close the client promptly on upstream failure", file=sys.stderr, flush=True)
                 return 1
             print(f"dial-client: description fetch failed promptly after {elapsed:.1f}s "
@@ -593,7 +593,7 @@ def dial_client(args: argparse.Namespace) -> int:
         return 1
     app_host = _authority(app_url).rsplit(":", 1)[0]
     if app_host != refl or device in _authority(app_url):
-        print(f"dial-client: Application-URL {app_url!r} not rewritten to reflector authority {refl!r}",
+        print(f"dial-client: Application-URL {app_url!r} not rewritten to netflector authority {refl!r}",
               file=sys.stderr, flush=True)
         return 1
     rest_host, _, rest_port_s = _authority(app_url).rpartition(":")
@@ -612,7 +612,7 @@ def dial_client(args: argparse.Namespace) -> int:
         return 1
     run_host = _authority(run_loc).rsplit(":", 1)[0]
     if run_host != refl or device in _authority(run_loc):
-        print(f"dial-client: 201 LOCATION {run_loc!r} not rewritten to reflector authority {refl!r}",
+        print(f"dial-client: 201 LOCATION {run_loc!r} not rewritten to netflector authority {refl!r}",
               file=sys.stderr, flush=True)
         return 1
     print(f"dial-client: 201 LOCATION rewritten to {_authority(run_loc)}", flush=True)
@@ -628,7 +628,7 @@ def dial_client(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="UDP probe used by reflector Docker e2e tests")
+    parser = argparse.ArgumentParser(description="UDP probe used by netflector Docker e2e tests")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     send_parser = subparsers.add_parser("send", help="send a Wake-on-LAN magic packet")
@@ -682,7 +682,7 @@ def main() -> int:
         "dial-device", help="emulate a DIAL device: SSDP 200 OK + description + REST HTTP endpoints")
     device_parser.add_argument("--port", required=True, type=int, help="SSDP UDP port to bind (1900)")
     device_parser.add_argument("--join-group", required=True, help="SSDP multicast group to join")
-    device_parser.add_argument("--interface", required=True, help="interface facing the reflector")
+    device_parser.add_argument("--interface", required=True, help="interface facing netflector")
     device_parser.add_argument("--family", default=4, type=int, choices=(4, 6), help="IP version")
     device_parser.add_argument("--timeout", required=True, type=float, help="seconds to await the M-SEARCH")
     device_parser.add_argument("--serve-seconds", required=True, type=float,
@@ -690,11 +690,11 @@ def main() -> int:
     device_parser.add_argument("--notify", action="store_true",
                                help="passive discovery: advertise periodic NOTIFY instead of awaiting an M-SEARCH")
     device_parser.add_argument("--unreachable", action="store_true",
-                               help="advertise a dead HTTP port (no server) so the reflector's upstream is refused")
+                               help="advertise a dead HTTP port (no server) so netflector's upstream is refused")
     device_parser.set_defaults(func=dial_device)
 
     client_parser = subparsers.add_parser(
-        "dial-client", help="run the DIAL flow through the reflector and assert the rewrites")
+        "dial-client", help="run the DIAL flow through netflector and assert the rewrites")
     client_parser.add_argument("--source-port", type=int, help="M-SEARCH source port (active discovery only)")
     client_parser.add_argument("--port", required=True, type=int, help="SSDP destination/group port (1900)")
     client_parser.add_argument("--address", required=True, help="SSDP multicast group")
@@ -706,8 +706,8 @@ def main() -> int:
                                help="passive discovery: listen for a NOTIFY instead of sending an M-SEARCH")
     client_parser.add_argument("--expect-fetch-failure", action="store_true",
                                help="expect the proxied description fetch to fail (upstream unreachable)")
-    client_parser.add_argument("--reflector-authority", required=True,
-                               help="reflector source_if address (host only; LOCATION ports are dynamic)")
+    client_parser.add_argument("--netflector-authority", required=True,
+                               help="netflector source_if address (host only; LOCATION ports are dynamic)")
     client_parser.add_argument("--device-authority", required=True,
                                help="device's true target-side host, asserted absent from the rewrites")
     client_parser.set_defaults(func=dial_client)

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 #
-# End-to-end tests for the (Rust) reflector, runnable on two backends.
+# End-to-end tests for netflector, runnable on two backends.
 #
-# Each case stands up two isolated dual-stack segments (a source and a target), runs the reflector
+# Each case stands up two isolated dual-stack segments (a source and a target), runs netflector
 # straddling both with its interface names pinned to wol_src / wol_dst, then runs a sender prober on
 # one segment and a receiver prober on the other and asserts the traffic is (or is not) reflected
 # across. The default docker backend realizes segments as bridge networks and participants as
-# containers (reflector image built from ./Dockerfile, CAP_NET_RAW on that container only; probers
+# containers (netflector image built from ./Dockerfile, CAP_NET_RAW on that container only; probers
 # run unprivileged). The native backend (root; Linux or FreeBSD) uses plain processes over netns +
 # veth pairs (Linux) or vnet jails + epairs (FreeBSD) instead -- same cases, no Docker:
 #
 #   python3 e2e/run.py
 #   python3 e2e/run.py --case reflects_matching_magic_packet
-#   python3 e2e/run.py --skip-build --image reflector:e2e
-#   sudo python3 e2e/run.py --backend native --binary target/release/reflector
+#   python3 e2e/run.py --skip-build --image netflector:e2e
+#   sudo python3 e2e/run.py --backend native --binary target/release/netflector
 
 from __future__ import annotations
 
@@ -34,8 +34,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 E2E_DIR = Path(__file__).resolve().parent
 
-DEFAULT_REFLECTOR_IMAGE = "reflector:e2e"
-VALGRIND_REFLECTOR_IMAGE = "reflector:e2e-valgrind"
+DEFAULT_NETFLECTOR_IMAGE = "netflector:e2e"
+VALGRIND_NETFLECTOR_IMAGE = "netflector:e2e-valgrind"
 DEFAULT_HELPER_IMAGE = "python:3.13-alpine"
 CONFIGURED_MAC = "02:42:ac:11:00:09"
 # A second address in wol-mac's `macs` allow-set, to prove the list admits every member, not just the first.
@@ -51,7 +51,7 @@ MDNS_GROUP_V6 = "ff02::fb"
 MDNS_PORT = 5353
 MDNS_WRONG_PORT = 5354
 # A 12-byte DNS header + "test". The query has QR=0 (flags 0x0000); the response sets QR+AA
-# (flags 0x8400). The reflector classifies on the QR bit alone.
+# (flags 0x8400). netflector classifies on the QR bit alone.
 MDNS_QUERY_HEX = "00000000000100000000000074657374"
 MDNS_RESPONSE_HEX = "00008400000100010000000074657374"
 # 8 bytes: below the 12-byte DNS-header minimum, so classify() returns None and drops it.
@@ -64,7 +64,7 @@ SSDP_PORT = 1900
 # A non-SSDP UDP port: the dispatcher filter pins dst_port=1900, so a datagram to the group on this
 # port is captured but never dispatched to the reflector.
 SSDP_WRONG_PORT = 1901
-# SSDP discovery messages (HTTPU). The reflector classifies on the leading method token only and relays
+# SSDP discovery messages (HTTPU). netflector classifies on the leading method token only and relays
 # the bytes verbatim, so the receiver expects exactly what was sent; the HOST line is immaterial here.
 SSDP_MSEARCH_HEX = (
     "M-SEARCH * HTTP/1.1\r\n"
@@ -73,7 +73,7 @@ SSDP_MSEARCH_HEX = (
     "MX: 2\r\n"
     "ST: ssdp:all\r\n\r\n"
 ).encode().hex()
-# An M-SEARCH with the maximum MX (clamped to 5s by the reflector), so its session lives ~7s (MX + the
+# An M-SEARCH with the maximum MX (clamped to 5s by netflector), so its session lives ~7s (MX + the
 # 2s reply grace). The interface-recreate round trip needs that width: it destroys and recreates the
 # target between the searcher's two sends, and the second must land while the first's session is alive.
 SSDP_MSEARCH_MX5_HEX = (
@@ -89,14 +89,14 @@ SSDP_NOTIFY_HEX = (
     "NT: upnp:rootdevice\r\n"
     "NTS: ssdp:alive\r\n\r\n"
 ).encode().hex()
-# A search response that strayed onto the group: neither M-SEARCH nor NOTIFY, so the reflector
+# A search response that strayed onto the group: neither M-SEARCH nor NOTIFY, so netflector
 # classifies it as non-SSDP and drops it.
 SSDP_HTTP_RESPONSE_HEX = (
     "HTTP/1.1 200 OK\r\n"
     "ST: ssdp:all\r\n\r\n"
 ).encode().hex()
 # The unicast 200 OK a device sends back to an M-SEARCH; the round-trip responder replies with this and
-# the searcher asserts it arrives verbatim after the reflector proxies it across segments.
+# the searcher asserts it arrives verbatim after netflector proxies it across segments.
 SSDP_OK_HEX = (
     "HTTP/1.1 200 OK\r\n"
     "CACHE-CONTROL: max-age=1800\r\n"
@@ -118,7 +118,7 @@ SSDP_DIAL_MSEARCH_HEX = (
 ).encode().hex()
 DIAL_CLIENT_SOURCE_PORT = 49153
 # --- WSD (WS-Discovery): SOAP-over-UDP. Groups 239.255.255.250 / ff02::c (shared with SSDP) on UDP
-# 3702 -- the port distinguishes it from SSDP. The reflector classifies on the <Action> URI segment and
+# 3702 -- the port distinguishes it from SSDP. netflector classifies on the <Action> URI segment and
 # relays the bytes verbatim, so the receiver expects exactly what was sent. Real ONVIF-style envelopes
 # (2005/04 namespace). ---
 WSD_GROUP_V4 = SSDP_GROUP_V4
@@ -181,7 +181,7 @@ WSD_RESOLVE_HEX = (
     "</d:Resolve></s:Body></s:Envelope>"
 ).encode().hex()
 # The unicast ProbeMatches a device answers a Probe with; the round-trip responder replies with this and
-# the searcher asserts it arrives verbatim after the reflector proxies it back across segments.
+# the searcher asserts it arrives verbatim after netflector proxies it back across segments.
 WSD_PROBEMATCHES_HEX = (
     '<?xml version="1.0" encoding="utf-8"?>'
     '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
@@ -219,24 +219,24 @@ WSD_RESOLVEMATCHES_HEX = (
     "<d:MetadataVersion>1</d:MetadataVersion>"
     "</d:ResolveMatch></d:ResolveMatches></s:Body></s:Envelope>"
 ).encode().hex()
-# --- Address-change cases: knock out one (interface, family) source on the reflector, prove
-# reflection of that family stops, then restore it and prove it resumes. The reflector reacts on
+# --- Address-change cases: knock out one (interface, family) source on netflector, prove
+# reflection of that family stops, then restore it and prove it resumes. netflector reacts on
 # its own event loop after the netlink notification, so each check polls across that async window.
 ADDR_CHANGE_REFLECTED_WINDOW = 4.0
 ADDR_CHANGE_SILENCE_WINDOW = 2.5
 ADDR_CHANGE_SILENCE_CONSECUTIVE = 2
 ADDR_CHANGE_POLL_DEADLINE = 60.0
 # A substring of the line the daemon logs immediately before entering its event loop.
-REFLECTOR_READY_LOG = "running; press Ctrl-C or send SIGTERM to stop"
+NETFLECTOR_READY_LOG = "running; press Ctrl-C or send SIGTERM to stop"
 RECEIVER_READY_LOG = "receiver ready: UDP socket bound"
 CONTAINER_READY_TIMEOUT_SECONDS = 15.0
 # A clean SIGTERM exit triggers valgrind's leak analysis; give `docker stop` this much grace before it
 # SIGKILLs, so the analysis (which can take tens of seconds) finishes and its exit code is read.
 VALGRIND_STOP_GRACE_SECONDS = 60
-REFLECTOR_SOURCE_IFNAME = "wol_src"
-REFLECTOR_TARGET_IFNAME = "wol_dst"
+NETFLECTOR_SOURCE_IFNAME = "wol_src"
+NETFLECTOR_TARGET_IFNAME = "wol_dst"
 RECEIVER_IFNAME = "probe0"
-REFLECTOR_IFNAMES = {"source": REFLECTOR_SOURCE_IFNAME, "target": REFLECTOR_TARGET_IFNAME}
+NETFLECTOR_IFNAMES = {"source": NETFLECTOR_SOURCE_IFNAME, "target": NETFLECTOR_TARGET_IFNAME}
 DECOY_IFNAME = "rfxdecoy"
 
 IPV6_ALL_NODES = "ff02::1"
@@ -258,7 +258,7 @@ class TestCase:
     timeout_seconds: float
     send_mac: str | None = None
     send_payload_hex: str | None = None
-    # IP version exercised end to end. The reflector runs both pipelines from one config; each case
+    # IP version exercised end to end. netflector runs both pipelines from one config; each case
     # drives just one of them.
     family: int = 4
     # Reflection direction. "forward" sends from the source network and receives on the target (WoL);
@@ -272,7 +272,7 @@ class TestCase:
     # Also require the reflected packet's source to be routable (non-link-local) — the per-scope v6
     # source selection: a site-local group (ff05::c) must not be sourced from a link-local address.
     expect_routable_source: bool = False
-    # Reflector config file (relative to e2e/) mounted into the reflector container. Most cases share
+    # netflector config file (relative to e2e/) mounted into the netflector container. Most cases share
     # config.toml; a case needing a distinct reflector set (e.g. single-family) names its own.
     config: str = "config.toml"
 
@@ -567,7 +567,7 @@ SSDP_CASES = [
         group=SSDP_GROUP_V4,
         direction="forward",
     ),
-    # The dispatcher filter pins dst_port=1900. Listen on the SEND port, not 1900: the reflector
+    # The dispatcher filter pins dst_port=1900. Listen on the SEND port, not 1900: netflector
     # re-emits to the captured dest port verbatim, so a regression that dispatched this 1901 datagram
     # would re-emit it to the group on 1901 -- invisible to a 1900-bound receiver. Binding the send
     # port keeps the "not reflected" assertion able to observe a misforward.
@@ -700,7 +700,7 @@ class RoundTripCase:
     family: int  # 4 or 6
     group: str
     timeout_seconds: float = 8.0
-    # When False, no responder is started and the searcher must receive nothing -- the reflector must
+    # When False, no responder is started and the searcher must receive nothing -- netflector must
     # not fabricate or loop back a reply to a search no device answered.
     expect_reply: bool = True
     # Protocol parameters, defaulting to SSDP's M-SEARCH round trip; WSD overrides them (its Probe ->
@@ -735,7 +735,7 @@ ROUNDTRIP_CASES = [
 
 @dataclasses.dataclass(frozen=True)
 class SearchRecreateCase:
-    # A search session across an interface recreation. One searcher opens a session; a reflector
+    # A search session across an interface recreation. One searcher opens a session; a netflector
     # interface is then destroyed and recreated. The session's reserved port and response registration
     # live on the TARGET, so recreating the target drops every session (logged, via on_iface_change) and
     # the retransmit opens a fresh one; recreating the SOURCE leaves the session intact (the reply leg
@@ -746,7 +746,7 @@ class SearchRecreateCase:
     # so the decoy is inert there. The wide MX keeps the first session alive until the recreation. This
     # is the search-session path the passive mDNS and DIAL recreate cases never reach.
     name: str
-    interface: str = "target"  # which reflector interface is destroyed + recreated
+    interface: str = "target"  # which netflector interface is destroyed + recreated
     family: int = 4
     group: str = SSDP_GROUP_V4
     port: int = SSDP_PORT
@@ -785,12 +785,12 @@ DIAL_CASES = [
 
 @dataclasses.dataclass(frozen=True)
 class DialAddressChangeCase:
-    # A full DIAL pass, then the same pass again after the reflector's source IPv4 changes, then again
+    # A full DIAL pass, then the same pass again after netflector's source IPv4 changes, then again
     # after its target IPv4 changes -- to a *different* address each time. A passing re-run is the 7d
     # proof: a proxy not evicted on the change would re-advertise a LOCATION on the vanished source
     # address (the fetch can't reach it) or bind the vanished target on its upstream connect. The device
-    # advertises NOTIFY throughout (passive discovery), so each phase's fresh client rediscovers and the
-    # reflector re-mints against the current addresses.
+    # advertises NOTIFY throughout (passive discovery), so each phase's fresh client rediscovers and
+    # netflector re-mints against the current addresses.
     name: str
     family: int = 4
     group: str = SSDP_GROUP_V4
@@ -807,14 +807,14 @@ DIAL_ADDRESS_CHANGE_CASES = [
 
 @dataclasses.dataclass(frozen=True)
 class DialRecreateCase:
-    # A full DIAL pass, then the same pass again after one reflector interface is destroyed and
+    # A full DIAL pass, then the same pass again after one netflector interface is destroyed and
     # recreated. The hardest DIAL recovery scenario: a recreation replaces the kernel objects
     # underneath the minted proxy -- its listener binds, target-address snapshot, and egress-pin all
     # belong to the dead interface's world -- so a passing re-run proves the recreation evicted the
     # proxy and re-minted against the recreated interface. One case per (interface, decoy): the decoy
     # forces a changed-index recreation (vs FreeBSD's same-index reuse), pinning both detection paths.
     name: str
-    interface: str = "target"  # which reflector interface is destroyed + recreated
+    interface: str = "target"  # which netflector interface is destroyed + recreated
     decoy: bool = False  # plant a decoy on the freed index so the recreation lands on a different one
     family: int = 4
     group: str = SSDP_GROUP_V4
@@ -847,12 +847,12 @@ PROBE_SPECS = {
 @dataclasses.dataclass(frozen=True)
 class Phase:
     # One knock-out within an address-change case: take down a single (interface, family) source
-    # address on the reflector, prove reflection of `protocol`/`family` stops, then restore it and
+    # address on netflector, prove reflection of `protocol`/`family` stops, then restore it and
     # prove reflection resumes -- all via real traffic.
     label: str
     protocol: str  # "wol" | "mdns" -> PROBE_SPECS
     family: int  # 4 | 6
-    interface: str  # "source" (wol_src) | "target" (wol_dst): which reflector interface to toggle
+    interface: str  # "source" (wol_src) | "target" (wol_dst): which netflector interface to toggle
     # Recreate cases only: plant a throwaway interface between the delete and the recreate. It
     # occupies the freed slot, so FreeBSD's lowest-free index allocator is forced to hand the
     # recreated interface a DIFFERENT index; without it the same index comes back. The two
@@ -886,7 +886,7 @@ ADDRESS_CHANGE_CASES = [
 class RecreateCase:
     name: str
     config: str  # config file (relative to e2e/), defining a dual-family reflector set
-    phases: tuple[Phase, ...]  # interface = which reflector interface is destroyed+recreated
+    phases: tuple[Phase, ...]  # interface = which netflector interface is destroyed+recreated
 
 
 # One case per (interface, decoy) so a failure names the exact scenario. All probe forward
@@ -968,14 +968,14 @@ SEGMENT_V6_PREFIX = {"source": "fd00:e2e0:1", "target": "fd00:e2e0:2"}
 
 
 class Backend:
-    # The execution environment for one case: two isolated dual-stack segments, the reflector
+    # The execution environment for one case: two isolated dual-stack segments, netflector
     # straddling both, and single-homed probe helpers referenced by role name ("receiver",
     # "sender", "device", ...). Docker realizes segments as bridge networks and participants as
     # containers; native (Linux) as netns + veth pairs and plain processes. Runners hold case
     # logic only and drive everything through this interface, so every case runs identically
     # under both backends.
 
-    # Whether the probe helpers keep working while a segment's reflector-side interface is
+    # Whether the probe helpers keep working while a segment's netflector-side interface is
     # deleted. Docker probes own separate bridge endpoints, so yes; the native fabrics realize
     # a segment as one veth/epair pair, so deleting it takes the probe end with it and the
     # recreate case skips its silence probe there (there is no wire left to probe on).
@@ -1002,7 +1002,7 @@ class Backend:
         # debuggable state.
         pass
 
-    def start_reflector(self, config_path: Path) -> None:
+    def start_netflector(self, config_path: Path) -> None:
         raise NotImplementedError
 
     def start_probe(
@@ -1030,17 +1030,17 @@ class Backend:
     def remove(self, role: str) -> None:
         raise NotImplementedError
 
-    def stop_reflector(self, grace_seconds: int) -> int:
-        # SIGTERM the reflector, allow `grace_seconds` for a clean exit (valgrind's leak
+    def stop_netflector(self, grace_seconds: int) -> int:
+        # SIGTERM netflector, allow `grace_seconds` for a clean exit (valgrind's leak
         # analysis needs it), then kill; returns the exit code.
         raise NotImplementedError
 
     def admin(self, script: str, *, capture: bool = False) -> str:
-        # Run a shell script inside the reflector's network view (addr/route/sysctl mutation).
+        # Run a shell script inside netflector's network view (addr/route/sysctl mutation).
         raise NotImplementedError
 
     def set_address(self, ifname: str, family: int, *, up: bool, cidr: str | None = None) -> str | None:
-        # Bring one (interface, family) source address down or back up in the reflector's
+        # Bring one (interface, family) source address down or back up in netflector's
         # network view. IPv6 drops every v6 address and, on re-enable, has the kernel regenerate
         # a usable link-local; v4 deletes and later re-adds the exact CIDR (returned on removal
         # so the caller can restore it). This base implementation speaks Linux (ip + /proc
@@ -1063,7 +1063,7 @@ class Backend:
         return captured
 
     def add_decoy_route(self, dest_ip: str, ifname: str) -> bool:
-        # Plant a host route to `dest_ip` via the (wrong) `ifname` in the reflector's network
+        # Plant a host route to `dest_ip` via the (wrong) `ifname` in netflector's network
         # view; returns whether it was armed. Linux-shaped: the DIAL egress pin there is
         # SO_BINDTODEVICE, which constrains the route lookup and so defeats the decoy. FreeBSD
         # has no pin primitive (net/tcp.rs relies on the source-address bind alone), so an armed
@@ -1072,18 +1072,18 @@ class Backend:
         return True
 
     def delete_interface(self, segment: str) -> None:
-        # Destroy `segment`'s reflector-side interface outright (its far peer dies with it):
+        # Destroy `segment`'s netflector-side interface outright (its far peer dies with it):
         # the first half of an interface recreation, as a PPPoE drop or bridge teardown would
-        # produce. The reflector's capture is left bound to a dead kernel object.
+        # produce. netflector's capture is left bound to a dead kernel object.
         raise NotImplementedError
 
     def recreate_interface(self, segment: str) -> None:
         # The second half: recreate the interface under the same name and addresses -- a fresh
-        # kernel identity the reflector must reconcile its capture onto.
+        # kernel identity netflector must reconcile its capture onto.
         raise NotImplementedError
 
     def add_decoy_interface(self) -> None:
-        # Plant a throwaway interface in the reflector's network view, occupying the index a
+        # Plant a throwaway interface in netflector's network view, occupying the index a
         # just-deleted interface freed (see Phase.decoy). Removed with
         # [`remove_decoy_interface`]; the fabric teardown also covers it on failure.
         raise NotImplementedError
@@ -1091,7 +1091,7 @@ class Backend:
     def remove_decoy_interface(self) -> None:
         raise NotImplementedError
 
-    def reflector_ip(self, segment: str) -> str:
+    def netflector_ip(self, segment: str) -> str:
         raise NotImplementedError
 
     def probe_ip(self, role: str, segment: str) -> str:
@@ -1117,7 +1117,7 @@ class DockerBackend(Backend):
 
     def setup_segments(self) -> None:
         # Both networks are dual-stack: IPv4 cases are unaffected, and IPv6 cases need the
-        # bridges to carry IPv6 so the reflector can listen on / emit to ff02::1. The subnets are
+        # bridges to carry IPv6 so netflector can listen on / emit to ff02::1. The subnets are
         # given explicitly (not IPAM-auto) so the recreate cases can pin the same --ip/--ip6 when
         # they reconnect the endpoint -- docker rejects a static address on an auto-subnet network.
         for segment in SEGMENTS:
@@ -1138,12 +1138,12 @@ class DockerBackend(Backend):
     def keep_artifacts(self) -> str:
         return f"Docker resources {self.prefix}"
 
-    def start_reflector(self, config_path: Path) -> None:
-        container = f"{self.prefix}-reflector"
-        self.roles["reflector"] = container
+    def start_netflector(self, config_path: Path) -> None:
+        container = f"{self.prefix}-netflector"
+        self.roles["netflector"] = container
         # Pin in-container interface names per network. Without this, Docker's interface naming
-        # at start time is non-deterministic when multiple endpoints are attached, which made the
-        # reflector's SO_BINDTODEVICE land on the wrong bridge ~16% of runs. Using a non-"eth"
+        # at start time is non-deterministic when multiple endpoints are attached, which made
+        # netflector's SO_BINDTODEVICE land on the wrong bridge ~16% of runs. Using a non-"eth"
         # prefix avoids the prefix-collision caveat in moby/moby#49155. Requires Docker 28.0+
         # (the com.docker.network.endpoint.ifname driver-opt).
         docker(
@@ -1152,11 +1152,11 @@ class DockerBackend(Backend):
                 "--name",
                 container,
                 "--network",
-                f"name={self.networks['source']},driver-opt=com.docker.network.endpoint.ifname={REFLECTOR_SOURCE_IFNAME}",
+                f"name={self.networks['source']},driver-opt=com.docker.network.endpoint.ifname={NETFLECTOR_SOURCE_IFNAME}",
                 "--network",
-                f"name={self.networks['target']},driver-opt=com.docker.network.endpoint.ifname={REFLECTOR_TARGET_IFNAME}",
+                f"name={self.networks['target']},driver-opt=com.docker.network.endpoint.ifname={NETFLECTOR_TARGET_IFNAME}",
                 # Skip Duplicate Address Detection on the link-local addresses. Without this the
-                # kernel's autogenerated fe80:: is tentative (unusable) when the reflector resolves
+                # kernel's autogenerated fe80:: is tentative (unusable) when netflector resolves
                 # at startup, so it falls back to the Docker-assigned ULA as its sole v6 source and
                 # never distinguishes link-local from routable -- masking the per-scope source
                 # selection. With DAD off the fe80:: is usable immediately, so v6 (link-local) and
@@ -1166,9 +1166,9 @@ class DockerBackend(Backend):
                 "--cap-add",
                 "NET_RAW",
                 "--mount",
-                f"type=bind,source={config_path},target=/etc/reflector/config.toml,readonly",
+                f"type=bind,source={config_path},target=/etc/netflector/config.toml,readonly",
                 self.args.image,
-                "/etc/reflector/config.toml",
+                "/etc/netflector/config.toml",
             ]
         )
         docker(["start", container])
@@ -1185,7 +1185,7 @@ class DockerBackend(Backend):
             "--name",
             container,
             # Pin the helper's interface name so the probe can scope multicast egress / group
-            # joins to it deterministically (see start_reflector for the rationale).
+            # joins to it deterministically (see start_netflector for the rationale).
             "--network",
             f"name={self.networks[segment]},driver-opt=com.docker.network.endpoint.ifname={ifname}",
             "--mount",
@@ -1223,18 +1223,18 @@ class DockerBackend(Backend):
         if container is not None:
             docker(["rm", "-f", container], check=False, echo=False)
 
-    def stop_reflector(self, grace_seconds: int) -> int:
-        docker(["stop", "-t", str(grace_seconds), self.roles["reflector"]])
-        return self.wait("reflector")
+    def stop_netflector(self, grace_seconds: int) -> int:
+        docker(["stop", "-t", str(grace_seconds), self.roles["netflector"]])
+        return self.wait("netflector")
 
     def admin(self, script: str, *, capture: bool = False) -> str:
-        # Address/route changes need CAP_NET_ADMIN and a writable /proc/sys, which the reflector
+        # Address/route changes need CAP_NET_ADMIN and a writable /proc/sys, which the netflector
         # container (scratch image, NET_RAW only) has by neither. Run a throwaway privileged
-        # container in the reflector's network namespace, so `ip addr` / the disable_ipv6 sysctl
-        # act on the very interfaces the reflector watches -- without widening the reflector's
+        # container in netflector's network namespace, so `ip addr` / the disable_ipv6 sysctl
+        # act on the very interfaces netflector watches -- without widening netflector's
         # own privileges.
         result = docker([
-            "run", "--rm", "--privileged", "--network", f"container:{self.roles['reflector']}",
+            "run", "--rm", "--privileged", "--network", f"container:{self.roles['netflector']}",
             self.args.helper_image, "sh", "-ec", script,
         ])
         return result.stdout.strip() if capture else ""
@@ -1249,7 +1249,7 @@ class DockerBackend(Backend):
     def delete_interface(self, segment: str) -> None:
         # Detaching the bridge endpoint destroys the veth pair, the in-container interface
         # included. Capture the endpoint's addresses first, so the reconnect can pin them.
-        container = self.roles["reflector"]
+        container = self.roles["netflector"]
         network = self.networks[segment]
         fmt = (
             '{{(index .NetworkSettings.Networks "' + network + '").IPAddress}}'
@@ -1262,29 +1262,29 @@ class DockerBackend(Backend):
     def recreate_interface(self, segment: str) -> None:
         # Reconnect under the same pinned interface name and addresses: a fresh veth, a fresh
         # kernel identity. The driver-opt on connect needs the same Docker 28.0+ as create
-        # (see start_reflector).
+        # (see start_netflector).
         v4, v6 = self._detached_addrs.pop(segment)
         command = [
             "network", "connect",
-            "--driver-opt", f"com.docker.network.endpoint.ifname={REFLECTOR_IFNAMES[segment]}",
+            "--driver-opt", f"com.docker.network.endpoint.ifname={NETFLECTOR_IFNAMES[segment]}",
             "--ip", v4,
         ]
         if v6:
             command += ["--ip6", v6]
-        docker([*command, self.networks[segment], self.roles["reflector"]])
+        docker([*command, self.networks[segment], self.roles["netflector"]])
 
     def add_decoy_interface(self) -> None:
-        # The privileged admin sidecar shares the reflector's network namespace, so the veth
+        # The privileged admin sidecar shares netflector's network namespace, so the veth
         # lands where the freed index lived. Linux never reuses indexes, so the decoy is inert
-        # here -- it runs anyway to keep the case uniform across backends (and exercises the
-        # reflector's unwatched-churn policy for free).
+        # here -- it runs anyway to keep the case uniform across backends (and exercises
+        # netflector's unwatched-churn policy for free).
         self.admin(f"ip link add {DECOY_IFNAME} type veth peer name {DECOY_IFNAME}p")
 
     def remove_decoy_interface(self) -> None:
         self.admin(f"ip link del {DECOY_IFNAME}")
 
-    def reflector_ip(self, segment: str) -> str:
-        return self._container_ip(self.roles["reflector"], self.networks[segment])
+    def netflector_ip(self, segment: str) -> str:
+        return self._container_ip(self.roles["netflector"], self.networks[segment])
 
     def probe_ip(self, role: str, segment: str) -> str:
         return self._container_ip(self.roles[role], self.networks[segment])
@@ -1312,10 +1312,10 @@ class DockerBackend(Backend):
                 print(inspect.stdout, end="", file=sys.stderr, flush=True)
 
 
-# Native segment addressing over SEGMENT_V4_SUBNET / SEGMENT_V6_PREFIX: the reflector is always host 1
+# Native segment addressing over SEGMENT_V4_SUBNET / SEGMENT_V6_PREFIX: netflector is always host 1
 # and a segment's helper host 2, replacing Docker's IPAM discovery with a fixed plan (the kernel adds
 # fe80:: itself).
-NATIVE_REFLECTOR_HOST = 1
+NATIVE_NETFLECTOR_HOST = 1
 NATIVE_HELPER_HOST = 2
 
 
@@ -1324,9 +1324,9 @@ class NativeBackend(Backend):
     # are plain processes with stdout/stderr teed to per-role files in a case tmpdir (the
     # docker-logs replacement), and addressing follows the fixed plan above instead of IPAM
     # discovery. Subclasses provide the fabric: segment construction/teardown, the exec prefix
-    # that places a probe in a segment's stack, and the reflector's launch.
+    # that places a probe in a segment's stack, and netflector's launch.
     #
-    # Fidelity gap vs the docker backend: the reflector runs here with the harness's full root
+    # Fidelity gap vs the docker backend: netflector runs here with the harness's full root
     # privileges, not the CAP_NET_RAW-only confinement of the scratch container -- a change that
     # grows a privilege requirement passes natively and only fails in the docker lane. CI runs
     # both, so the docker lane stays the privilege-contract gate.
@@ -1354,7 +1354,7 @@ class NativeBackend(Backend):
         # The command prefix that places a probe process in `segment`'s network stack.
         raise NotImplementedError
 
-    def _reflector_command(self, config_path: Path) -> list[str]:
+    def _netflector_command(self, config_path: Path) -> list[str]:
         raise NotImplementedError
 
     def _teardown_fabric(self) -> None:
@@ -1382,10 +1382,10 @@ class NativeBackend(Backend):
     def _spawn(self, role: str, command: list[str]) -> None:
         self.remove(role)
         print(f"+ {format_command(command)}", flush=True)
-        # Scrub REFLECTOR_* so the daemon sees only its config file, as it would in the docker
-        # backend's clean container env -- a stray host REFLECTOR_LOG_LEVEL (or worse, an env
+        # Scrub NETFLECTOR_* so the daemon sees only its config file, as it would in the docker
+        # backend's clean container env -- a stray host NETFLECTOR_LOG_LEVEL (or worse, an env
         # reflector entry) must not alter the system under test.
-        env = {key: value for key, value in os.environ.items() if not key.startswith("REFLECTOR_")}
+        env = {key: value for key, value in os.environ.items() if not key.startswith("NETFLECTOR_")}
         out = open(self.logdir / f"{role}.out", "wb")
         err = open(self.logdir / f"{role}.err", "wb")
         try:
@@ -1394,8 +1394,8 @@ class NativeBackend(Backend):
             out.close()
             err.close()
 
-    def start_reflector(self, config_path: Path) -> None:
-        self._spawn("reflector", self._reflector_command(config_path))
+    def start_netflector(self, config_path: Path) -> None:
+        self._spawn("netflector", self._netflector_command(config_path))
 
     def start_probe(
         self, role: str, segment: str, ifname: str, probe_args: list[str], *, detach: bool = True
@@ -1437,8 +1437,8 @@ class NativeBackend(Backend):
             proc.kill()
             proc.wait()
 
-    def stop_reflector(self, grace_seconds: int) -> int:
-        proc = self.procs["reflector"]
+    def stop_netflector(self, grace_seconds: int) -> int:
+        proc = self.procs["netflector"]
         if proc.poll() is None:
             proc.send_signal(signal.SIGTERM)
             try:
@@ -1448,8 +1448,8 @@ class NativeBackend(Backend):
                 proc.wait()
         return proc.returncode
 
-    def reflector_ip(self, segment: str) -> str:
-        return f"{SEGMENT_V4_SUBNET[segment]}.{NATIVE_REFLECTOR_HOST}"
+    def netflector_ip(self, segment: str) -> str:
+        return f"{SEGMENT_V4_SUBNET[segment]}.{NATIVE_NETFLECTOR_HOST}"
 
     def probe_ip(self, role: str, segment: str) -> str:
         del role  # one helper per segment; the plan gives them all the same host number
@@ -1469,11 +1469,11 @@ class NativeLinuxBackend(NativeBackend):
     # wol_src + wol_dst (so the checked-in configs work unchanged), and one persistent far
     # namespace per segment holds the peer end, always named probe0. Every participant gets its
     # own namespace for the same reasons Docker gave them one: wildcard binds and --expect-none
-    # windows must only see the segment's traffic, unicast to the reflector must cross the wire
+    # windows must only see the segment's traffic, unicast to netflector must cross the wire
     # rather than short-circuit via lo, and the host's daemons (systemd-resolved speaks mDNS)
     # must not reach the test wires. Successive probe processes for a case run inside the same
     # far namespace: probes respawn, namespaces persist. The recreate cases delete and re-add
-    # whole pairs (fresh kernel identities under the same names), which the reflector survives
+    # whole pairs (fresh kernel identities under the same names), which netflector survives
     # by reconciling its captures; the probes are immune, resolving interfaces fresh at spawn.
 
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
@@ -1509,15 +1509,15 @@ class NativeLinuxBackend(NativeBackend):
         self._wait_carrier()
 
     def _setup_segment(self, segment: str) -> None:
-        dut_ifname = REFLECTOR_IFNAMES[segment]
+        dut_ifname = NETFLECTOR_IFNAMES[segment]
         self._ip([
             "link", "add", dut_ifname, "netns", self.ns["dut"],
             "type", "veth", "peer", "name", RECEIVER_IFNAME, "netns", self.ns[segment],
         ])
         v4, v6 = SEGMENT_V4_SUBNET[segment], SEGMENT_V6_PREFIX[segment]
         dut, far = self.ns["dut"], self.ns[segment]
-        self._ip(["-n", dut, "addr", "add", f"{v4}.{NATIVE_REFLECTOR_HOST}/24", "dev", dut_ifname])
-        self._ip(["-n", dut, "addr", "add", f"{v6}::{NATIVE_REFLECTOR_HOST}/64", "dev", dut_ifname])
+        self._ip(["-n", dut, "addr", "add", f"{v4}.{NATIVE_NETFLECTOR_HOST}/24", "dev", dut_ifname])
+        self._ip(["-n", dut, "addr", "add", f"{v6}::{NATIVE_NETFLECTOR_HOST}/64", "dev", dut_ifname])
         self._ip(["-n", far, "addr", "add", f"{v4}.{NATIVE_HELPER_HOST}/24", "dev", RECEIVER_IFNAME])
         self._ip(["-n", far, "addr", "add", f"{v6}::{NATIVE_HELPER_HOST}/64", "dev", RECEIVER_IFNAME])
         self._ip(["-n", dut, "link", "set", dut_ifname, "up"])
@@ -1528,7 +1528,7 @@ class NativeLinuxBackend(NativeBackend):
 
     def delete_interface(self, segment: str) -> None:
         # Deleting the dut end destroys the pair, the far probe0 included.
-        self._ip(["-n", self.ns["dut"], "link", "del", REFLECTOR_IFNAMES[segment]])
+        self._ip(["-n", self.ns["dut"], "link", "del", NETFLECTOR_IFNAMES[segment]])
 
     def recreate_interface(self, segment: str) -> None:
         self._setup_segment(segment)
@@ -1545,9 +1545,9 @@ class NativeLinuxBackend(NativeBackend):
         self._ip(["-n", self.ns["dut"], "link", "del", DECOY_IFNAME])
 
     def _wait_carrier(self) -> None:
-        # A veth reports operstate "up" only once BOTH ends are up; don't start the reflector
+        # A veth reports operstate "up" only once BOTH ends are up; don't start netflector
         # (or probes) on a link that hasn't settled.
-        pending = [(self.ns["dut"], ifname) for ifname in REFLECTOR_IFNAMES.values()]
+        pending = [(self.ns["dut"], ifname) for ifname in NETFLECTOR_IFNAMES.values()]
         pending += [(self.ns[segment], RECEIVER_IFNAME) for segment in SEGMENTS]
         deadline = time.monotonic() + 5.0
         for ns, ifname in pending:
@@ -1572,11 +1572,11 @@ class NativeLinuxBackend(NativeBackend):
     def _probe_exec(self, segment: str) -> list[str]:
         return ["ip", "netns", "exec", self.ns[segment]]
 
-    def _reflector_command(self, config_path: Path) -> list[str]:
+    def _netflector_command(self, config_path: Path) -> list[str]:
         return ["ip", "netns", "exec", self.ns["dut"], str(self.args.binary), str(config_path)]
 
     def admin(self, script: str, *, capture: bool = False) -> str:
-        # The harness already runs as root, so the reflector's network view is one netns exec
+        # The harness already runs as root, so netflector's network view is one netns exec
         # away -- no privileged sidecar needed.
         result = run_command(["ip", "netns", "exec", self.ns["dut"], "sh", "-ec", script])
         return result.stdout.strip() if capture else ""
@@ -1648,14 +1648,14 @@ class NativeFreeBSDBackend(NativeBackend):
 
     def _configure_segment(self, segment: str, a_end: str, b_end: str) -> None:
         # The epair ends already sit inside the dut/far jails; rename, address, and route them.
-        dut_ifname = REFLECTOR_IFNAMES[segment]
+        dut_ifname = NETFLECTOR_IFNAMES[segment]
         jexec_dut = ["jexec", self.jails["dut"]]
         jexec_far = ["jexec", self.jails[segment]]
         run_command([*jexec_dut, "ifconfig", a_end, "name", dut_ifname])
         run_command([*jexec_far, "ifconfig", b_end, "name", RECEIVER_IFNAME])
         v4, v6 = SEGMENT_V4_SUBNET[segment], SEGMENT_V6_PREFIX[segment]
-        run_command([*jexec_dut, "ifconfig", dut_ifname, "inet", f"{v4}.{NATIVE_REFLECTOR_HOST}/24"])
-        run_command([*jexec_dut, "ifconfig", dut_ifname, "inet6", f"{v6}::{NATIVE_REFLECTOR_HOST}/64"])
+        run_command([*jexec_dut, "ifconfig", dut_ifname, "inet", f"{v4}.{NATIVE_NETFLECTOR_HOST}/24"])
+        run_command([*jexec_dut, "ifconfig", dut_ifname, "inet6", f"{v6}::{NATIVE_NETFLECTOR_HOST}/64"])
         run_command([*jexec_dut, "ifconfig", dut_ifname, "up"])
         run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet", f"{v4}.{NATIVE_HELPER_HOST}/24"])
         run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet6", f"{v6}::{NATIVE_HELPER_HOST}/64"])
@@ -1666,7 +1666,7 @@ class NativeFreeBSDBackend(NativeBackend):
 
     def delete_interface(self, segment: str) -> None:
         # Destroying the dut end tears down the pair, the far probe0 included.
-        run_command(["jexec", self.jails["dut"], "ifconfig", REFLECTOR_IFNAMES[segment], "destroy"])
+        run_command(["jexec", self.jails["dut"], "ifconfig", NETFLECTOR_IFNAMES[segment], "destroy"])
 
     def recreate_interface(self, segment: str) -> None:
         # A fresh epair, moved into the LIVE jails -- setup assigns interfaces at jail
@@ -1701,7 +1701,7 @@ class NativeFreeBSDBackend(NativeBackend):
         # whole pair, including the b end inside its probe jail -- so no jail removal can return
         # a probe0 to a stack where the other jail's probe0 already sits. The host-side destroy
         # covers a setup that failed before the interfaces moved into the dut jail.
-        for ifname in REFLECTOR_IFNAMES.values():
+        for ifname in NETFLECTOR_IFNAMES.values():
             run_command(["jexec", self.jails["dut"], "ifconfig", ifname, "destroy"],
                         check=False, echo=False)
             run_command(["ifconfig", ifname, "destroy"], check=False, echo=False)
@@ -1716,7 +1716,7 @@ class NativeFreeBSDBackend(NativeBackend):
     def _probe_exec(self, segment: str) -> list[str]:
         return ["jexec", self.jails[segment]]
 
-    def _reflector_command(self, config_path: Path) -> list[str]:
+    def _netflector_command(self, config_path: Path) -> list[str]:
         return ["jexec", self.jails["dut"], str(self.args.binary), str(config_path)]
 
     def admin(self, script: str, *, capture: bool = False) -> str:
@@ -1787,7 +1787,7 @@ class CaseRunner:
     def __init__(self, args: argparse.Namespace, case: TestCase) -> None:
         self.args = args
         self.case = case
-        self.prefix = f"reflector-e2e-{case.name.replace('_', '-')}-{uuid.uuid4().hex[:8]}"
+        self.prefix = f"netflector-e2e-{case.name.replace('_', '-')}-{uuid.uuid4().hex[:8]}"
         self.backend = make_backend(args, self.prefix)
         self.config_path = E2E_DIR / case.config
 
@@ -1799,10 +1799,10 @@ class CaseRunner:
         # can join the multicast group on it. The address-change runner re-selects per phase (its
         # phases differ in direction), so this stays a method rather than inline __init__ code.
         if direction == "reverse":
-            self.sender_segment, self.sender_ifname = "target", REFLECTOR_TARGET_IFNAME
+            self.sender_segment, self.sender_ifname = "target", NETFLECTOR_TARGET_IFNAME
             self.receiver_segment = "source"
         else:
-            self.sender_segment, self.sender_ifname = "source", REFLECTOR_SOURCE_IFNAME
+            self.sender_segment, self.sender_ifname = "source", NETFLECTOR_SOURCE_IFNAME
             self.receiver_segment = "target"
         self.receiver_ifname = RECEIVER_IFNAME
 
@@ -1824,23 +1824,23 @@ class CaseRunner:
         self.backend.cleanup()
         return False
 
-    def check_reflector_valgrind(self) -> None:
-        # SIGTERM the reflector so it shuts down cleanly and valgrind runs its leak analysis, then
+    def check_netflector_valgrind(self) -> None:
+        # SIGTERM netflector so it shuts down cleanly and valgrind runs its leak analysis, then
         # read its exit code: the image's --error-exitcode=1 fires on any leak, leaked fd, or
         # memcheck error.
-        exit_code = self.backend.stop_reflector(VALGRIND_STOP_GRACE_SECONDS)
+        exit_code = self.backend.stop_netflector(VALGRIND_STOP_GRACE_SECONDS)
         if exit_code != 0:
             print(f"\n--- valgrind report: {self.case.name} ---", file=sys.stderr, flush=True)
-            _, err = self.backend.logs("reflector")
+            _, err = self.backend.logs("netflector")
             if err:
                 print(err, end="", file=sys.stderr, flush=True)
             raise RuntimeError(
-                f"valgrind reported errors in case {self.case.name} (reflector exited {exit_code})"
+                f"valgrind reported errors in case {self.case.name} (netflector exited {exit_code})"
             )
 
-    def start_reflector(self) -> None:
-        self.backend.start_reflector(self.config_path)
-        self.wait_for_reflector()
+    def start_netflector(self) -> None:
+        self.backend.start_netflector(self.config_path)
+        self.wait_for_netflector()
 
     def wait_for_log(self, role: str, marker: str, description: str) -> None:
         deadline = time.monotonic() + CONTAINER_READY_TIMEOUT_SECONDS
@@ -1862,8 +1862,8 @@ class CaseRunner:
             f"timed out waiting for {description} readiness marker ({marker}); last state: {last_state}"
         )
 
-    def wait_for_reflector(self) -> None:
-        self.wait_for_log("reflector", REFLECTOR_READY_LOG, "reflector")
+    def wait_for_netflector(self) -> None:
+        self.wait_for_log("netflector", NETFLECTOR_READY_LOG, "netflector")
 
     def start_receiver(self, case: TestCase | None = None) -> None:
         case = case or self.case
@@ -1932,9 +1932,9 @@ class CaseRunner:
         if exit_code != 0:
             raise RuntimeError(f"receiver failed with exit code {exit_code}")
 
-    def print_reflector_logs(self) -> None:
-        out, err = self.backend.logs("reflector")
-        print(f"--- reflector logs: {self.case.name} ---", flush=True)
+    def print_netflector_logs(self) -> None:
+        out, err = self.backend.logs("netflector")
+        print(f"--- netflector logs: {self.case.name} ---", flush=True)
         if out:
             print(out, end="", flush=True)
         if err:
@@ -1947,7 +1947,7 @@ class CaseRunner:
     ) -> str | None:
         # Bring one (interface, family) source address down or back up; the verbs live in the
         # backend (Linux vs FreeBSD). Returns the removed v4 CIDR so the caller can restore it.
-        ifname = REFLECTOR_SOURCE_IFNAME if interface == "source" else REFLECTOR_TARGET_IFNAME
+        ifname = NETFLECTOR_SOURCE_IFNAME if interface == "source" else NETFLECTOR_TARGET_IFNAME
         return self.backend.set_address(ifname, family, up=up, cidr=cidr)
 
     def print_diagnostics(self) -> None:
@@ -1957,25 +1957,25 @@ class CaseRunner:
     def run(self) -> None:
         print(f"\n=== {self.case.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
         self.start_receiver()
         self.run_sender()
         self.wait_for_result()
         print(f"PASS {self.case.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 class RoundTripRunner(CaseRunner):
-    # The SSDP M-SEARCH round trip: a searcher on the source segment sends an M-SEARCH; the
-    # reflector relays it to the group on the target from a reserved port; a responder (device)
-    # on the target unicasts a 200 OK back to that reserved port; the reflector proxies the reply
+    # The SSDP M-SEARCH round trip: a searcher on the source segment sends an M-SEARCH;
+    # netflector relays it to the group on the target from a reserved port; a responder (device)
+    # on the target unicasts a 200 OK back to that reserved port; netflector proxies the reply
     # to the searcher. The negative case (expect_reply=False) starts no responder and asserts the
-    # searcher hears nothing -- the reflector must not fabricate a reply.
+    # searcher hears nothing -- netflector must not fabricate a reply.
     def __init__(self, args: argparse.Namespace, case: RoundTripCase) -> None:
         # The base __init__ only reads case.name and case.direction; a TestCase shim reuses all
-        # its segment/reflector setup + cleanup with no duplication.
+        # its segment/netflector setup + cleanup with no duplication.
         shim = TestCase(name=case.name, send_port=case.port, receive_port=case.port,
             expect_mac=None, timeout_seconds=case.timeout_seconds, family=case.family,
             group=case.group, direction="forward", config=case.config)
@@ -1994,7 +1994,7 @@ class RoundTripRunner(CaseRunner):
 
     def run_searcher(self) -> None:
         expectation = ["--expect-payload-hex", self.rt.reply_hex] if self.rt.expect_reply else ["--expect-none"]
-        ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
+        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
         self.backend.start_probe("searcher", "source", ifname, [
             "search",
             "--source-port", str(SEARCHER_SOURCE_PORT), "--port", str(self.rt.port),
@@ -2016,25 +2016,25 @@ class RoundTripRunner(CaseRunner):
     def run(self) -> None:
         print(f"\n=== {self.rt.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
         if self.rt.expect_reply:
             self.start_responder()  # must be listening before the search goes out
         self.run_searcher()
         self.wait_for_searcher()
         # The per-searcher session must be torn down once it expires (SSDP: MX 2 + 2s grace ~= 4s;
         # WSD: a fixed 5s window): the deadline timer sweeps it, drops its port reservation, and
-        # unregisters its response capture -- logged by the reflector. wait_for_log raises if it
+        # unregisters its response capture -- logged by netflector. wait_for_log raises if it
         # never fires.
-        self.wait_for_log("reflector", self.rt.evict_log, "session eviction")
+        self.wait_for_log("netflector", self.rt.evict_log, "session eviction")
         print(f"{self.rt.name}: session evicted after expiry", flush=True)
         print(f"PASS {self.rt.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 class SearchRecreateRunner(RoundTripRunner):
-    # See SearchRecreateCase. Reuses RoundTripRunner's segment/reflector/responder setup (the shim
+    # See SearchRecreateCase. Reuses RoundTripRunner's segment/netflector/responder setup (the shim
     # __init__ reads only the fields both cases share), but opens a session, recreates one interface,
     # and re-searches. A target recreation drops the session (asserted via the cleared-sessions log); a
     # source recreation leaves it, so the retransmit re-reflects on the same reserved port (asserted
@@ -2048,7 +2048,7 @@ class SearchRecreateRunner(RoundTripRunner):
         # One M-SEARCH; with no_wait, send and exit (any reply is routed elsewhere), else assert the
         # 200 OK proxies back.
         expectation = ["--no-wait"] if no_wait else ["--expect-payload-hex", self.rt.reply_hex]
-        ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
+        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
         self.backend.start_probe(role, "source", ifname, [
             "search",
             "--source-port", str(SEARCHER_SOURCE_PORT), "--port", str(self.rt.port),
@@ -2070,14 +2070,14 @@ class SearchRecreateRunner(RoundTripRunner):
         # different one (the changed-index path); without it, FreeBSD reuses the index (the same-index
         # path). Both must behave the same, so both variants run.
         interface = self.rt.interface
-        ifname = REFLECTOR_IFNAMES[interface]
+        ifname = NETFLECTOR_IFNAMES[interface]
         self.backend.delete_interface(interface)
-        self.wait_for_log("reflector", f"interface {ifname} is gone", f"{interface} deletion")
+        self.wait_for_log("netflector", f"interface {ifname} is gone", f"{interface} deletion")
         if self.rt.decoy:
             self.backend.add_decoy_interface()
         self.backend.recreate_interface(interface)
         self.wait_for_log(
-            "reflector", f"interface {ifname}: returned as ifindex", f"{interface} recreation"
+            "netflector", f"interface {ifname}: returned as ifindex", f"{interface} recreation"
         )
         if self.rt.decoy:
             self.backend.remove_decoy_interface()
@@ -2085,7 +2085,7 @@ class SearchRecreateRunner(RoundTripRunner):
     def run(self) -> None:
         print(f"\n=== {self.rt.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
 
         # First search: opens a session (its reservation + response registration are on the target).
         self.start_responder()
@@ -2105,7 +2105,7 @@ class SearchRecreateRunner(RoundTripRunner):
             self.start_responder()
             self._search("searcher-retransmit")
             self.wait_for_log(
-                "reflector", "cleared all sessions after the target interface changed", "session cleared"
+                "netflector", "cleared all sessions after the target interface changed", "session cleared"
             )
             print(f"{self.rt.name}: session cleared, round trip resumed after the target recreation", flush=True)
         else:
@@ -2113,12 +2113,12 @@ class SearchRecreateRunner(RoundTripRunner):
             # reply routes to the baseline's MAC, so this container needn't receive it. The re-reflected
             # log proves the session survived and that the source ingress rebound and re-joined its group.
             self._search("searcher-retransmit", no_wait=True)
-            self.wait_for_log("reflector", "re-reflected SSDP search", "session reused")
+            self.wait_for_log("netflector", "re-reflected SSDP search", "session reused")
             print(f"{self.rt.name}: session survived the source recreation", flush=True)
         print(f"PASS {self.rt.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 class DialRunner(CaseRunner):
@@ -2130,7 +2130,7 @@ class DialRunner(CaseRunner):
             group=case.group, direction="forward")
         super().__init__(args, shim)
         self.dial = case
-        # The DIAL reflector loads a config with a single DIAL entry. The shared config's any-MAC
+        # The DIAL case's netflector loads a config with a single DIAL entry. The shared config's any-MAC
         # [reflectors.discovery] entry also reflects SSDP, which would double-reflect the device's
         # 200 OK (only one copy rewritten) -- so the DIAL case gets its own config to keep the
         # relayed reply unambiguous.
@@ -2138,8 +2138,8 @@ class DialRunner(CaseRunner):
 
     def start_device(self) -> None:
         # Single-homed on the target segment: the device's HTTP endpoints are reachable only via
-        # the reflector's egress-pinned upstream connect, so the peer it records is the
-        # reflector's target_if address -- never the source-side client (which cannot route to the
+        # netflector's egress-pinned upstream connect, so the peer it records is
+        # netflector's target_if address -- never the source-side client (which cannot route to the
         # target subnet directly).
         ifname = self.backend.helper_ifname(RECEIVER_IFNAME)
         probe_args = [
@@ -2155,16 +2155,16 @@ class DialRunner(CaseRunner):
         self.backend.start_probe("device", "target", ifname, probe_args)
         self.wait_for_log("device", "dial-device ready", "dial-device")
 
-    def _client_args(self, reflector_authority: str, device_authority: str) -> list[str]:
-        # The client is single-homed on the source segment. It is told the reflector's source_if
+    def _client_args(self, netflector_authority: str, device_authority: str) -> list[str]:
+        # The client is single-homed on the source segment. It is told netflector's source_if
         # address (what the rewritten authorities must point at) and the device's true target_if
         # address (which must never leak through a rewrite).
-        ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
+        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
         probe_args = [
             "dial-client",
             "--port", str(SSDP_PORT), "--address", self.dial.group, "--interface", ifname,
             "--family", str(self.dial.family), "--timeout", str(self.dial.timeout_seconds),
-            "--reflector-authority", reflector_authority, "--device-authority", device_authority,
+            "--netflector-authority", netflector_authority, "--device-authority", device_authority,
         ]
         if self.dial.passive:
             probe_args.append("--passive")  # listen for the relayed NOTIFY instead of sending an M-SEARCH
@@ -2176,8 +2176,8 @@ class DialRunner(CaseRunner):
 
     def run_client(self) -> None:
         device_target_ip = self.backend.probe_ip("device", "target")
-        refl_source_ip = self.backend.reflector_ip("source")
-        ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
+        refl_source_ip = self.backend.netflector_ip("source")
+        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
         self.backend.start_probe(
             "client", "source", ifname, self._client_args(refl_source_ip, device_target_ip)
         )
@@ -2194,10 +2194,10 @@ class DialRunner(CaseRunner):
 
     def assert_device_verdicts(self) -> None:
         # Two device-side checks: (1) the device exits non-zero if any request reached it with a
-        # Host that was not rewritten to its own authority (the reflector must rewrite Host
-        # source->device); (2) the reflector's upstream connect is egress-pinned to target_if, so
-        # the only peer the device recorded must be exactly the reflector's target_if address.
-        refl_target_ip = self.backend.reflector_ip("target")
+        # Host that was not rewritten to its own authority (netflector must rewrite Host
+        # source->device); (2) netflector's upstream connect is egress-pinned to target_if, so
+        # the only peer the device recorded must be exactly netflector's target_if address.
+        refl_target_ip = self.backend.netflector_ip("target")
         exit_code = self.backend.wait("device")
         out, err = self.backend.logs("device")
         if out:
@@ -2213,30 +2213,30 @@ class DialRunner(CaseRunner):
             raise RuntimeError("dial-device did not report the upstream peers it saw")
         seen = ast.literal_eval(line.split(marker, 1)[1].strip())
         if seen != [refl_target_ip]:
-            raise RuntimeError(f"device saw upstream peers {seen}, expected only the reflector's target_if "
+            raise RuntimeError(f"device saw upstream peers {seen}, expected only netflector's target_if "
                                f"address [{refl_target_ip!r}] (egress not pinned to target_if)")
         print(f"dial: every request's Host was rewritten to the device, and every upstream connection came "
-              f"from the reflector's target_if address {refl_target_ip}", flush=True)
+              f"from netflector's target_if address {refl_target_ip}", flush=True)
 
     def _force_upstream_egress_ambiguity(self) -> None:
         # Make the upstream egress pin load-bearing. The device is single-homed on the target
-        # segment, so the reflector's connect reaches it via target_if by routing alone, and
+        # segment, so netflector's connect reaches it via target_if by routing alone, and
         # SO_BINDTODEVICE (TcpSocket PinEgress) would be untestable -- assert_device_verdicts'
-        # "peer == reflector target_if address" passes even if the pin were dropped. Plant a
+        # "peer == netflector target_if address" passes even if the pin were dropped. Plant a
         # more-specific host route to the device via the WRONG interface (source_if): an unpinned
         # connect now follows it, ARPs the device on the source segment (where it does not live)
         # and fails, so the whole DIAL flow breaks. Only the egress pin -- which constrains the
         # route lookup to target_if -- still reaches the device, so PASS now requires it.
         # (FreeBSD declines: no pin primitive there, see Backend.add_decoy_route.)
         device_ip = self.backend.probe_ip("device", "target")
-        if not self.backend.add_decoy_route(device_ip, REFLECTOR_SOURCE_IFNAME):
+        if not self.backend.add_decoy_route(device_ip, NETFLECTOR_SOURCE_IFNAME):
             print(f"{self.dial.name}: no egress-pin primitive on this backend; decoy route skipped",
                   flush=True)
 
     def run(self) -> None:
         print(f"\n=== {self.dial.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
         self.start_device()      # must be serving before the client searches
         if not self.dial.unreachable:
             # The unreachable case asserts a PROMPT connect failure; a decoy route would change
@@ -2253,16 +2253,16 @@ class DialRunner(CaseRunner):
         else:
             self.assert_device_verdicts()  # device-side verdict: Host rewrite + egress-pinned upstream
         print(f"PASS {self.dial.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 class DialAddressChangeRunner(DialRunner):
-    # A DIAL pass, then the same pass after the reflector's source IPv4 changes, then after its
+    # A DIAL pass, then the same pass after netflector's source IPv4 changes, then after its
     # target IPv4 changes -- each to a different same-subnet address. The device stays up (passive
     # NOTIFY + HTTP) across all three; a fresh client runs each pass. _set_address (base) does the
-    # change in the reflector's network view; the reflector reacts on its own event loop, so each
+    # change in netflector's network view; netflector reacts on its own event loop, so each
     # change waits for the "gained IPv4 <new>" log before the next pass.
     def _different_cidr(self, cidr: str) -> str:
         # A different host on the same subnet: both backends hand out low addresses (Docker IPAM
@@ -2274,25 +2274,25 @@ class DialAddressChangeRunner(DialRunner):
         return f"{'.'.join(octets)}/{prefix}"
 
     def _change_v4(self, interface: str) -> str:
-        # Replace the reflector's IPv4 on `interface` with a different same-subnet address, then
-        # wait for the reflector to observe it -- which is when 7d evicts the now-stale proxy.
+        # Replace netflector's IPv4 on `interface` with a different same-subnet address, then
+        # wait for netflector to observe it -- which is when 7d evicts the now-stale proxy.
         # Returns the new host.
         old_cidr = self._set_address(interface, 4, up=False)        # del old, capture its CIDR
         new_cidr = self._different_cidr(old_cidr)
         self._set_address(interface, 4, up=True, cidr=new_cidr)     # add the different one
         new_host = new_cidr.split("/")[0]
         print(f"{self.dial.name}: {interface} IPv4 {old_cidr} -> {new_cidr}", flush=True)
-        self.wait_for_log("reflector", f"gained IPv4 {new_host}", f"{interface} IPv4 change")
+        self.wait_for_log("netflector", f"gained IPv4 {new_host}", f"{interface} IPv4 change")
         return new_host
 
-    def _dial_pass(self, label: str, reflector_authority: str, device_authority: str) -> None:
-        # One full DIAL flow through the reflector from a fresh client, asserting every rewrite
-        # points at `reflector_authority` (the reflector's CURRENT source IPv4) and never leaks
+    def _dial_pass(self, label: str, netflector_authority: str, device_authority: str) -> None:
+        # One full DIAL flow through netflector from a fresh client, asserting every rewrite
+        # points at `netflector_authority` (netflector's CURRENT source IPv4) and never leaks
         # `device_authority`.
         role = f"client-{label.replace(' ', '-')}"
-        ifname = self.backend.helper_ifname(REFLECTOR_SOURCE_IFNAME)
+        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
         self.backend.start_probe(
-            role, "source", ifname, self._client_args(reflector_authority, device_authority)
+            role, "source", ifname, self._client_args(netflector_authority, device_authority)
         )
         exit_code = self.backend.wait(role)
         out, err = self.backend.logs(role)
@@ -2302,15 +2302,15 @@ class DialAddressChangeRunner(DialRunner):
             print(err, end="", file=sys.stderr, flush=True)
         if exit_code != 0:
             raise RuntimeError(f"{self.dial.name}: DIAL pass '{label}' failed with exit code {exit_code}")
-        print(f"{self.dial.name}: DIAL pass '{label}' succeeded (rewrites -> {reflector_authority})", flush=True)
+        print(f"{self.dial.name}: DIAL pass '{label}' succeeded (rewrites -> {netflector_authority})", flush=True)
 
     def run(self) -> None:
         print(f"\n=== {self.dial.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
         self.start_device()  # passive: advertises NOTIFY + serves HTTP for serve_seconds
         device_ip = self.backend.probe_ip("device", "target")
-        source_ip = self.backend.reflector_ip("source")
+        source_ip = self.backend.netflector_ip("source")
 
         # Baseline, then re-run after each interface's IPv4 moves to a different address. A
         # passing re-run requires 7d to have evicted the proxy bound to the vanished address.
@@ -2321,25 +2321,25 @@ class DialAddressChangeRunner(DialRunner):
         self._dial_pass("after target IPv4 change", source_ip, device_ip)
 
         print(f"PASS {self.dial.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 class DialRecreateRunner(DialAddressChangeRunner):
     # See DialRecreateCase. Inherits the pass machinery; only the mutation differs: instead of
-    # replacing addresses, it destroys and recreates one reflector interface (optionally behind a
+    # replacing addresses, it destroys and recreates one netflector interface (optionally behind a
     # decoy), synchronized on the daemon's own parking/recreation log lines.
 
     def _recreate(self, interface: str) -> None:
-        ifname = REFLECTOR_IFNAMES[interface]
+        ifname = NETFLECTOR_IFNAMES[interface]
         self.backend.delete_interface(interface)
-        self.wait_for_log("reflector", f"interface {ifname} is gone", f"{interface} deletion")
+        self.wait_for_log("netflector", f"interface {ifname} is gone", f"{interface} deletion")
         if self.dial.decoy:
             self.backend.add_decoy_interface()
         self.backend.recreate_interface(interface)
         self.wait_for_log(
-            "reflector", f"interface {ifname}: returned as ifindex", f"{interface} recreation"
+            "netflector", f"interface {ifname}: returned as ifindex", f"{interface} recreation"
         )
         if self.dial.decoy:
             self.backend.remove_decoy_interface()
@@ -2347,10 +2347,10 @@ class DialRecreateRunner(DialAddressChangeRunner):
     def run(self) -> None:
         print(f"\n=== {self.dial.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
         self.start_device()  # passive: advertises NOTIFY + serves HTTP
         device_ip = self.backend.probe_ip("device", "target")
-        source_ip = self.backend.reflector_ip("source")
+        source_ip = self.backend.netflector_ip("source")
 
         self._dial_pass("baseline", source_ip, device_ip)
 
@@ -2365,20 +2365,20 @@ class DialRecreateRunner(DialAddressChangeRunner):
             self.start_device()
             device_ip = self.backend.probe_ip("device", "target")
         else:
-            source_ip = self.backend.reflector_ip("source")  # re-pinned to the same address
+            source_ip = self.backend.netflector_ip("source")  # re-pinned to the same address
         self._dial_pass(f"after {interface} recreation", source_ip, device_ip)
 
         print(f"PASS {self.dial.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 class AddressChangeRunner(CaseRunner):
     # Proves the dynamic family bring-up/teardown end to end: with a dual-family reflector
     # running, knock out one (interface, family) source address at a time and verify -- with real
     # traffic, not logs -- that reflection of exactly that family stops, then resumes once the
-    # address returns. The reflector reacts on its own event loop after the netlink notification,
+    # address returns. netflector reacts on its own event loop after the netlink notification,
     # so every check polls across that async window. All phases probe forward (source -> target).
     def __init__(self, args: argparse.Namespace, case: AddressChangeCase) -> None:
         shim = TestCase(
@@ -2481,43 +2481,43 @@ class AddressChangeRunner(CaseRunner):
 
     def _assert_address_changes_logged(self) -> None:
         # Full-parity log check (the Rust equivalent of the C++'s capability-down assertion):
-        # every phase removed then restored a source address, so the reflector's InterfaceMonitor
+        # every phase removed then restored a source address, so netflector's InterfaceMonitor
         # must have logged both transitions -- with the monitor off it logs neither. And no
         # reflect-failure WARN may appear: a send attempted on an addressless egress would mean
         # the per-packet gate failed to catch the drop.
-        out, err = self.backend.logs("reflector")
+        out, err = self.backend.logs("netflector")
         text = f"{out}\n{err}"
         for phase in self.ac.phases:
-            ifname = REFLECTOR_SOURCE_IFNAME if phase.interface == "source" else REFLECTOR_TARGET_IFNAME
+            ifname = NETFLECTOR_SOURCE_IFNAME if phase.interface == "source" else NETFLECTOR_TARGET_IFNAME
             family = f"IPv{phase.family}"
             for verb in ("lost", "gained"):
                 needle = f"interface {ifname}: {verb} {family}"
                 if needle not in text:
                     raise RuntimeError(
-                        f"{self.ac.name}: reflector never logged \"{needle}\" -- the interface monitor "
+                        f"{self.ac.name}: netflector never logged \"{needle}\" -- the interface monitor "
                         f"did not observe the change"
                     )
         if "cannot reflect" in text:
             raise RuntimeError(
-                f"{self.ac.name}: reflector logged a reflect failure -- a send was attempted on an "
+                f"{self.ac.name}: netflector logged a reflect failure -- a send was attempted on an "
                 f"addressless egress (the gate did not catch the drop)"
             )
 
     def run(self) -> None:
         print(f"\n=== {self.ac.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
         for phase in self.ac.phases:
             self._run_phase(phase)
         self._assert_address_changes_logged()
         print(f"PASS {self.ac.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 class RecreateRunner(AddressChangeRunner):
-    # Proves interface hot-swap recovery end to end: destroy and recreate one reflector-side
+    # Proves interface hot-swap recovery end to end: destroy and recreate one netflector-side
     # interface (same name and addresses, fresh kernel identity -- a PPPoE reconnect or bridge
     # rebuild in miniature) and verify with real traffic that reflection through it resumes
     # once the reconcile re-binds the capture. Inherits the probe/poll machinery; only the
@@ -2564,7 +2564,7 @@ class RecreateRunner(AddressChangeRunner):
         else:
             # The segment's wire died with the interface, so there is nothing to probe on;
             # the "is gone" log assertion stands in as the observed-death proof. The pause
-            # lets the reflector see the departure and park before the name returns --
+            # lets netflector see the departure and park before the name returns --
             # otherwise it would (correctly) log only the recreation.
             print(f"{desc}: segment wire gone; skipping the silence probe", flush=True)
             time.sleep(2.0)
@@ -2580,15 +2580,15 @@ class RecreateRunner(AddressChangeRunner):
         print(f"{desc}: reflection resumed after interface recreation", flush=True)
 
     def _assert_recreations_logged(self) -> None:
-        # The reflector must have observed each phase as a real hot-swap, in its parts: the
+        # netflector must have observed each phase as a real hot-swap, in its parts: the
         # parking line when the interface vanished, the address losses parking implies (the
         # egress gate closing), the recreation line when its capture re-bound, and the address
         # gains of the re-resolve. Their absence would mean reflection "recovered" some other
         # way than the reconcile.
-        out, err = self.backend.logs("reflector")
+        out, err = self.backend.logs("netflector")
         text = f"{out}\n{err}"
         for phase in self.ac.phases:
-            ifname = REFLECTOR_IFNAMES[phase.interface]
+            ifname = NETFLECTOR_IFNAMES[phase.interface]
             needles = (
                 f"interface {ifname} is gone",
                 f"interface {ifname}: returned as ifindex",
@@ -2598,21 +2598,21 @@ class RecreateRunner(AddressChangeRunner):
             for needle in needles:
                 if needle not in text:
                     raise RuntimeError(
-                        f"{self.ac.name}: reflector never logged \"{needle}\" -- the reconcile "
+                        f"{self.ac.name}: netflector never logged \"{needle}\" -- the reconcile "
                         f"did not drive the recovery"
                     )
 
     def run(self) -> None:
         print(f"\n=== {self.ac.name} ===", flush=True)
         self.backend.setup_segments()
-        self.start_reflector()
+        self.start_netflector()
         for phase in self.ac.phases:
             self._run_phase(phase)
         self._assert_recreations_logged()
         print(f"PASS {self.ac.name}", flush=True)
-        if self.args.show_reflector_logs:
+        if self.args.show_netflector_logs:
             time.sleep(0.5)
-            self.print_reflector_logs()
+            self.print_netflector_logs()
 
 
 def make_runner(args: argparse.Namespace,
@@ -2635,7 +2635,7 @@ def make_runner(args: argparse.Namespace,
     return CaseRunner(args, case)
 
 
-def build_reflector_image(image: str, target: str | None = None) -> None:
+def build_netflector_image(image: str, target: str | None = None) -> None:
     target_args = ["--target", target] if target is not None else []
     docker(["build", *target_args, "-t", image, "."], capture=False)
 
@@ -2656,23 +2656,23 @@ def select_cases(case_names: list[str]) -> list[
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run reflector e2e tests (Docker or native backend)")
+    parser = argparse.ArgumentParser(description="Run netflector e2e tests (Docker or native backend)")
     parser.add_argument("--backend", choices=["docker", "native"], default="docker",
         help="execution environment: Docker bridge networks + containers, or (Linux, root) "
              "netns + veth pairs + plain processes (default: docker)")
-    parser.add_argument("--image", default=DEFAULT_REFLECTOR_IMAGE,
-        help="reflector image tag to run (default: reflector:e2e; docker backend only)")
+    parser.add_argument("--image", default=DEFAULT_NETFLECTOR_IMAGE,
+        help="netflector image tag to run (default: netflector:e2e; docker backend only)")
     parser.add_argument("--skip-build", action="store_true",
         help="use --image without building it first (docker backend only)")
     parser.add_argument("--valgrind", action="store_true",
-        help="run the reflector under Valgrind memcheck (the runtime-valgrind image; fails on any leak, fd leak, or memcheck error)")
+        help="run netflector under Valgrind memcheck (the runtime-valgrind image; fails on any leak, fd leak, or memcheck error)")
     parser.add_argument("--helper-image", default=DEFAULT_HELPER_IMAGE,
         help="Python image used for UDP probes (docker backend only)")
     parser.add_argument("--binary", type=Path, default=None,
-        help="reflector binary to run (native backend, required); build it unprivileged first, "
+        help="netflector binary to run (native backend, required); build it unprivileged first, "
              "e.g. cargo build --release --locked")
     parser.add_argument("--keep-on-failure", action="store_true", help="leave resources behind after a failure")
-    parser.add_argument("--show-reflector-logs", action="store_true", help="print reflector logs after each passing case")
+    parser.add_argument("--show-netflector-logs", action="store_true", help="print netflector logs after each passing case")
     parser.add_argument(
         "--case",
         action="append",
@@ -2701,8 +2701,8 @@ def main() -> int:
     else:
         DockerBackend.require_available()
         # --valgrind selects the valgrind image unless one was passed explicitly.
-        if args.valgrind and args.image == DEFAULT_REFLECTOR_IMAGE:
-            args.image = VALGRIND_REFLECTOR_IMAGE
+        if args.valgrind and args.image == DEFAULT_NETFLECTOR_IMAGE:
+            args.image = VALGRIND_NETFLECTOR_IMAGE
 
     cases = select_cases(args.case)
     print(f"expected magic payload: {magic_packet_hex(CONFIGURED_MAC)}", flush=True)
@@ -2712,15 +2712,15 @@ def main() -> int:
         # path that validated here would otherwise point somewhere else at exec time.
         args.binary = args.binary.resolve()
         if not args.binary.is_file():
-            raise RuntimeError(f"reflector binary not found: {args.binary}")
+            raise RuntimeError(f"netflector binary not found: {args.binary}")
     elif not args.skip_build:
-        build_reflector_image(args.image, "runtime-valgrind" if args.valgrind else None)
+        build_netflector_image(args.image, "runtime-valgrind" if args.valgrind else None)
 
     for case in cases:
         with make_runner(args, case) as runner:
             runner.run()
             if args.valgrind:
-                runner.check_reflector_valgrind()
+                runner.check_netflector_valgrind()
 
     suffix = " under valgrind" if args.valgrind else ""
     print(f"\nPASS {len(cases)} e2e case(s){suffix}", flush=True)

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -43,13 +43,13 @@ mod tests {
     use super::open_or_skip;
     use crate::net::LinkType;
 
-    // Live capture against a real interface (`REFLECTOR_TEST_IFACE`). Backend-neutral
+    // Live capture against a real interface (`NETFLECTOR_TEST_IFACE`). Backend-neutral
     // because a real interface is Ethernet-framed on both backends: BPF reports
     // DLT_EN10MB, AF_PACKET delivers the Ethernet header.
     #[test]
     fn live_capture_decodes_real_frames() -> std::io::Result<()> {
-        let Some(iface) = std::env::var_os("REFLECTOR_TEST_IFACE") else {
-            eprintln!("skip live_capture: set REFLECTOR_TEST_IFACE to an Ethernet interface");
+        let Some(iface) = std::env::var_os("NETFLECTOR_TEST_IFACE") else {
+            eprintln!("skip live_capture: set NETFLECTOR_TEST_IFACE to an Ethernet interface");
             return Ok(());
         };
         let iface = iface.to_string_lossy();

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn captures_a_known_frame_on_lo() -> io::Result<()> {
-        const PROBE: &[u8] = b"reflector-afpacket-capture-probe";
+        const PROBE: &[u8] = b"netflector-afpacket-capture-probe";
         let Some(mut capture) = open_or_skip("lo", "afpacket_capture")? else {
             return Ok(());
         };
@@ -396,7 +396,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn send_loops_back_on_lo() -> io::Result<()> {
-        const PROBE: &[u8] = b"reflector-afpacket-send-probe";
+        const PROBE: &[u8] = b"netflector-afpacket-send-probe";
         let Some(mut capture) = open_or_skip("lo", "afpacket_send")? else {
             return Ok(());
         };

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -438,7 +438,7 @@ mod tests {
         family: u32,
         version: u8,
     ) -> bool {
-        const PROBE: &[u8] = b"reflector-loopback-probe";
+        const PROBE: &[u8] = b"netflector-loopback-probe";
         let receiver = std::net::UdpSocket::bind(bind).unwrap();
         let target = receiver.local_addr().unwrap();
         let sender = std::net::UdpSocket::bind(bind).unwrap();
@@ -511,7 +511,7 @@ mod tests {
     fn loopback_send_reaches_a_local_socket() -> io::Result<()> {
         use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, UdpSocket};
 
-        const PROBE: &[u8] = b"reflector-loopback-send-probe";
+        const PROBE: &[u8] = b"netflector-loopback-send-probe";
 
         let Some(cap) = open_or_skip("lo0", "loopback_send")? else {
             return Ok(());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use crate::error::UsageError;
 /// What the command line asked for.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Invocation<'a> {
-    /// Run the reflector, configured from the given file (if any) plus `REFLECTOR_*`.
+    /// Run netflector, configured from the given file (if any) plus `NETFLECTOR_*`.
     Run(Option<&'a Path>),
     /// Load and validate that same configuration, then exit.
     CheckConfig(Option<&'a Path>),
@@ -22,11 +22,11 @@ pub(crate) enum Invocation<'a> {
 /// Parse `args` (with `argv[0]` already stripped).
 ///
 /// `--help` and `--version` win over everything else, so they answer even when the rest of the
-/// line is nonsense. Otherwise the reflector takes at most one positional; extras are rejected
+/// line is nonsense. Otherwise netflector takes at most one positional; extras are rejected
 /// rather than ignored, since a second path is far more likely a typo than an intent.
 ///
 /// `--` ends option parsing, so a config file whose name begins with a dash is still reachable
-/// (`reflector -- --check-config` reads a file called `--check-config`). Without it such a path
+/// (`netflector -- --check-config` reads a file called `--check-config`). Without it such a path
 /// would be unreachable, since every leading-dash argument is otherwise read as an option.
 ///
 /// # Errors
@@ -74,16 +74,16 @@ pub(crate) fn parse(args: &[OsString]) -> Result<Invocation<'_>, UsageError> {
 
 /// `--help` text. Ends with a newline; print it with `print!`.
 pub(crate) const HELP: &str = concat!(
-    "reflector ",
+    "netflector ",
     env!("CARGO_PKG_VERSION"),
     "
 
 Reflects link-local service traffic (Wake-on-LAN, mDNS, SSDP, WS-Discovery, DIAL) between
 two network interfaces.
 
-usage: reflector [--check-config] [--] [CONFIG]
+usage: netflector [--check-config] [--] [CONFIG]
 
-  CONFIG           TOML config file. REFLECTOR_* environment variables are merged on top of
+  CONFIG           TOML config file. NETFLECTOR_* environment variables are merged on top of
                    it. Omit it to configure from the environment alone. Put `--` first if the
                    file name begins with a dash.
 
@@ -110,10 +110,10 @@ mod tests {
 
     #[test]
     fn a_lone_positional_is_the_config_path() {
-        let a = args(&["reflector.toml"]);
+        let a = args(&["netflector.toml"]);
         assert_eq!(
             parse(&a).unwrap(),
-            Invocation::Run(Some(Path::new("reflector.toml")))
+            Invocation::Run(Some(Path::new("netflector.toml")))
         );
     }
 
@@ -121,23 +121,23 @@ mod tests {
     fn check_config_takes_the_same_optional_path() {
         let a = args(&["--check-config"]);
         assert_eq!(parse(&a).unwrap(), Invocation::CheckConfig(None));
-        let b = args(&["--check-config", "reflector.toml"]);
+        let b = args(&["--check-config", "netflector.toml"]);
         assert_eq!(
             parse(&b).unwrap(),
-            Invocation::CheckConfig(Some(Path::new("reflector.toml")))
+            Invocation::CheckConfig(Some(Path::new("netflector.toml")))
         );
         // The flag may follow the path as readily as precede it.
-        let c = args(&["reflector.toml", "--check-config"]);
+        let c = args(&["netflector.toml", "--check-config"]);
         assert_eq!(
             parse(&c).unwrap(),
-            Invocation::CheckConfig(Some(Path::new("reflector.toml")))
+            Invocation::CheckConfig(Some(Path::new("netflector.toml")))
         );
     }
 
     #[test]
     fn help_and_version_win_over_the_rest_of_the_line() {
         for flag in ["-h", "--help"] {
-            let a = args(&[flag, "reflector.toml", "--nonsense"]);
+            let a = args(&[flag, "netflector.toml", "--nonsense"]);
             assert_eq!(parse(&a).unwrap(), Invocation::Help);
         }
         for flag in ["-V", "--version"] {
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn a_second_positional_is_rejected_not_ignored() {
-        let a = args(&["reflector.toml", "extra"]);
+        let a = args(&["netflector.toml", "extra"]);
         assert!(matches!(parse(&a), Err(UsageError::TooManyArgs(arg)) if arg == "extra"));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ pub(crate) struct Ssdp {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Reflector {
     /// Display name for logs, from the `[reflectors.<name>]` key or
-    /// `REFLECTOR_<tag>_NAME`.
+    /// `NETFLECTOR_<tag>_NAME`.
     pub(crate) name: ReflectorName,
     /// Interface to listen on.
     pub(crate) source_if: InterfaceName,
@@ -275,13 +275,13 @@ pub(crate) fn read_config_file(path: &Path) -> Result<String, ConfigError> {
 /// so the rest of loading is logged at that level. Environment overrides the file,
 /// which overrides the default.
 ///
-/// Deliberately lightweight: it reads only `REFLECTOR_LOG_LEVEL` and the file's
+/// Deliberately lightweight: it reads only `NETFLECTOR_LOG_LEVEL` and the file's
 /// top-level `log_level`, never touching the reflector tables, so it can't fail
 /// on a reflector error that should instead surface (logged) from the full parse.
 ///
 /// # Errors
 /// Returns [`ConfigError::Parse`] for malformed TOML, or [`ConfigError::EnvBadValue`]
-/// if `REFLECTOR_LOG_LEVEL` is not a valid level.
+/// if `NETFLECTOR_LOG_LEVEL` is not a valid level.
 pub(crate) fn resolve_log_level(
     toml_text: Option<&str>,
     env: &[(String, String)],

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,4 +1,4 @@
-//! Environment-variable configuration (`REFLECTOR_*`).
+//! Environment-variable configuration (`NETFLECTOR_*`).
 //!
 //! [`parse_env`] produces the same [`RawConfig`] as the TOML path, so downstream
 //! validation is shared. Values parse through their [`FromStr`] type, with failures
@@ -12,7 +12,7 @@ use super::raw::{RawConfig, RawReflector};
 use super::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
 use crate::net::mac::MacSet;
 
-/// Accumulates a reflector's fields across its `REFLECTOR_<tag>_<param>` variables,
+/// Accumulates a reflector's fields across its `NETFLECTOR_<tag>_<param>` variables,
 /// then converts to a [`RawReflector`] once all are seen.
 #[derive(Debug, Default)]
 struct PartialReflector {
@@ -78,10 +78,10 @@ impl PartialReflector {
     }
 }
 
-/// Parse `REFLECTOR_*` variables into the raw configuration they describe.
+/// Parse `NETFLECTOR_*` variables into the raw configuration they describe.
 ///
-/// `REFLECTOR_LOG_LEVEL`, `REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
-/// `REFLECTOR_COUNTERS_INTERVAL_SECS` set the globals; every other `REFLECTOR_<tag>_<param>`
+/// `NETFLECTOR_LOG_LEVEL`, `NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
+/// `NETFLECTOR_COUNTERS_INTERVAL_SECS` set the globals; every other `NETFLECTOR_<tag>_<param>`
 /// contributes to the reflector keyed by the lowercased `tag`. Unprefixed variables are ignored.
 pub(super) fn parse_env(
     vars: impl IntoIterator<Item = (String, String)>,
@@ -92,7 +92,7 @@ pub(super) fn parse_env(
     let mut partials: BTreeMap<String, PartialReflector> = BTreeMap::new();
 
     for (key, value) in vars {
-        let Some(rest) = key.strip_prefix("REFLECTOR_") else {
+        let Some(rest) = key.strip_prefix("NETFLECTOR_") else {
             continue;
         };
         match rest {
@@ -145,7 +145,7 @@ pub(super) fn parse_env(
     })
 }
 
-/// Resolve `REFLECTOR_LOG_LEVEL` alone, ignoring the rest of the environment.
+/// Resolve `NETFLECTOR_LOG_LEVEL` alone, ignoring the rest of the environment.
 ///
 /// Raises the logger to the configured verbosity *before* the full parse runs, so
 /// the parse itself (env merge, reflector build) logs at that level.
@@ -153,7 +153,7 @@ pub(super) fn log_level_from_env(
     vars: &[(String, String)],
 ) -> Result<Option<LogLevel>, ConfigError> {
     vars.iter()
-        .find(|(key, _)| key == "REFLECTOR_LOG_LEVEL")
+        .find(|(key, _)| key == "NETFLECTOR_LOG_LEVEL")
         .map(|(key, value)| env_value::<LogLevel>(value, key))
         .transpose()
 }
@@ -206,10 +206,10 @@ mod tests {
     #[test]
     fn env_only_minimal_reflector() {
         let cfg = from_env(&[
-            ("REFLECTOR_TV_SOURCE_IF", "lan"),
-            ("REFLECTOR_TV_TARGET_IF", "iot"),
-            ("REFLECTOR_TV_MDNS", "true"),
-            ("PATH", "/usr/bin"), // non-REFLECTOR vars are ignored
+            ("NETFLECTOR_TV_SOURCE_IF", "lan"),
+            ("NETFLECTOR_TV_TARGET_IF", "iot"),
+            ("NETFLECTOR_TV_MDNS", "true"),
+            ("PATH", "/usr/bin"), // non-NETFLECTOR vars are ignored
         ])
         .unwrap();
         assert_eq!(cfg.reflectors.len(), 1);
@@ -223,13 +223,13 @@ mod tests {
     #[test]
     fn env_globals_and_bool_forms() {
         let cfg = from_env(&[
-            ("REFLECTOR_LOG_LEVEL", "debug"),
-            ("REFLECTOR_DEBUG_MEMORY_INTERVAL_SECS", "30"),
-            ("REFLECTOR_COUNTERS_INTERVAL_SECS", "45"),
-            ("REFLECTOR_TV_SOURCE_IF", "a"),
-            ("REFLECTOR_TV_TARGET_IF", "b"),
-            ("REFLECTOR_TV_WOL", "1"),
-            ("REFLECTOR_TV_MDNS", "false"),
+            ("NETFLECTOR_LOG_LEVEL", "debug"),
+            ("NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS", "30"),
+            ("NETFLECTOR_COUNTERS_INTERVAL_SECS", "45"),
+            ("NETFLECTOR_TV_SOURCE_IF", "a"),
+            ("NETFLECTOR_TV_TARGET_IF", "b"),
+            ("NETFLECTOR_TV_WOL", "1"),
+            ("NETFLECTOR_TV_MDNS", "false"),
         ])
         .unwrap();
         assert_eq!(cfg.log_level, LogLevel::Debug);
@@ -249,9 +249,9 @@ mod tests {
     #[test]
     fn env_wsd_flag() {
         let cfg = from_env(&[
-            ("REFLECTOR_CAMS_SOURCE_IF", "lan"),
-            ("REFLECTOR_CAMS_TARGET_IF", "cams"),
-            ("REFLECTOR_CAMS_WSD", "true"),
+            ("NETFLECTOR_CAMS_SOURCE_IF", "lan"),
+            ("NETFLECTOR_CAMS_TARGET_IF", "cams"),
+            ("NETFLECTOR_CAMS_WSD", "true"),
         ])
         .unwrap();
         assert!(cfg.reflectors[0].wsd);
@@ -260,10 +260,10 @@ mod tests {
     #[test]
     fn env_name_overrides_label_not_key() {
         let cfg = from_env(&[
-            ("REFLECTOR_TV_SOURCE_IF", "a"),
-            ("REFLECTOR_TV_TARGET_IF", "b"),
-            ("REFLECTOR_TV_MDNS", "true"),
-            ("REFLECTOR_TV_NAME", "Living Room"),
+            ("NETFLECTOR_TV_SOURCE_IF", "a"),
+            ("NETFLECTOR_TV_TARGET_IF", "b"),
+            ("NETFLECTOR_TV_MDNS", "true"),
+            ("NETFLECTOR_TV_NAME", "Living Room"),
         ])
         .unwrap();
         // NAME sets the display name (canonicalized lowercase), overriding the `TV` tag.
@@ -273,10 +273,10 @@ mod tests {
     #[test]
     fn env_wol_ports_csv() {
         let cfg = from_env(&[
-            ("REFLECTOR_TV_SOURCE_IF", "a"),
-            ("REFLECTOR_TV_TARGET_IF", "b"),
-            ("REFLECTOR_TV_WOL", "true"),
-            ("REFLECTOR_TV_WOL_PORTS", "7, 9, 4000"),
+            ("NETFLECTOR_TV_SOURCE_IF", "a"),
+            ("NETFLECTOR_TV_TARGET_IF", "b"),
+            ("NETFLECTOR_TV_WOL", "true"),
+            ("NETFLECTOR_TV_WOL_PORTS", "7, 9, 4000"),
         ])
         .unwrap();
         let ports: Vec<u16> = cfg.reflectors[0]
@@ -293,10 +293,10 @@ mod tests {
     #[test]
     fn env_macs_csv() {
         let cfg = from_env(&[
-            ("REFLECTOR_TV_SOURCE_IF", "a"),
-            ("REFLECTOR_TV_TARGET_IF", "b"),
-            ("REFLECTOR_TV_MDNS", "true"),
-            ("REFLECTOR_TV_MACS", "00:00:00:00:00:01, 00:00:00:00:00:02"),
+            ("NETFLECTOR_TV_SOURCE_IF", "a"),
+            ("NETFLECTOR_TV_TARGET_IF", "b"),
+            ("NETFLECTOR_TV_MDNS", "true"),
+            ("NETFLECTOR_TV_MACS", "00:00:00:00:00:01, 00:00:00:00:00:02"),
         ])
         .unwrap();
         let macs = cfg.reflectors[0].macs.as_ref().unwrap();
@@ -310,10 +310,10 @@ mod tests {
         // `mac` was replaced by `macs` in 0.9.0.
         assert!(matches!(
             from_env(&[
-                ("REFLECTOR_TV_SOURCE_IF", "a"),
-                ("REFLECTOR_TV_TARGET_IF", "b"),
-                ("REFLECTOR_TV_MDNS", "true"),
-                ("REFLECTOR_TV_MAC", "02:42:ac:11:00:09"),
+                ("NETFLECTOR_TV_SOURCE_IF", "a"),
+                ("NETFLECTOR_TV_TARGET_IF", "b"),
+                ("NETFLECTOR_TV_MDNS", "true"),
+                ("NETFLECTOR_TV_MAC", "02:42:ac:11:00:09"),
             ])
             .unwrap_err(),
             ConfigError::EnvUnknownParam { param, .. } if param == "mac"
@@ -323,9 +323,9 @@ mod tests {
     #[test]
     fn env_reuses_cross_field_validation() {
         let e = from_env(&[
-            ("REFLECTOR_TV_SOURCE_IF", "a"),
-            ("REFLECTOR_TV_TARGET_IF", "a"),
-            ("REFLECTOR_TV_MDNS", "true"),
+            ("NETFLECTOR_TV_SOURCE_IF", "a"),
+            ("NETFLECTOR_TV_TARGET_IF", "a"),
+            ("NETFLECTOR_TV_MDNS", "true"),
         ])
         .unwrap_err();
         assert!(matches!(e, ConfigError::SameInterface { value, .. } if value.as_str() == "a"));
@@ -341,7 +341,7 @@ mod tests {
             mdns = true
         "#;
         let cfg =
-            Config::from_sources(Some(toml), env(&[("REFLECTOR_LOG_LEVEL", "error")])).unwrap();
+            Config::from_sources(Some(toml), env(&[("NETFLECTOR_LOG_LEVEL", "error")])).unwrap();
         assert_eq!(cfg.log_level, LogLevel::Error);
     }
 
@@ -356,9 +356,9 @@ mod tests {
         let cfg = Config::from_sources(
             Some(toml),
             env(&[
-                ("REFLECTOR_RADIO_SOURCE_IF", "c"),
-                ("REFLECTOR_RADIO_TARGET_IF", "d"),
-                ("REFLECTOR_RADIO_MDNS", "true"),
+                ("NETFLECTOR_RADIO_SOURCE_IF", "c"),
+                ("NETFLECTOR_RADIO_TARGET_IF", "d"),
+                ("NETFLECTOR_RADIO_MDNS", "true"),
             ]),
         )
         .unwrap();
@@ -379,9 +379,9 @@ mod tests {
         let e = Config::from_sources(
             Some(toml),
             env(&[
-                ("REFLECTOR_TV_SOURCE_IF", "c"),
-                ("REFLECTOR_TV_TARGET_IF", "d"),
-                ("REFLECTOR_TV_MDNS", "true"),
+                ("NETFLECTOR_TV_SOURCE_IF", "c"),
+                ("NETFLECTOR_TV_TARGET_IF", "d"),
+                ("NETFLECTOR_TV_MDNS", "true"),
             ]),
         )
         .unwrap_err();
@@ -401,9 +401,9 @@ mod tests {
         let e = Config::from_sources(
             Some(toml),
             env(&[
-                ("REFLECTOR_TV_SOURCE_IF", "c"),
-                ("REFLECTOR_TV_TARGET_IF", "d"),
-                ("REFLECTOR_TV_MDNS", "true"),
+                ("NETFLECTOR_TV_SOURCE_IF", "c"),
+                ("NETFLECTOR_TV_TARGET_IF", "d"),
+                ("NETFLECTOR_TV_MDNS", "true"),
             ]),
         )
         .unwrap_err();
@@ -414,7 +414,7 @@ mod tests {
     fn env_malformed_var_rejected() {
         // No underscore to split into <tag>_<param>.
         assert!(matches!(
-            from_env(&[("REFLECTOR_TV", "x")]).unwrap_err(),
+            from_env(&[("NETFLECTOR_TV", "x")]).unwrap_err(),
             ConfigError::EnvMalformedVar { .. }
         ));
     }
@@ -423,12 +423,12 @@ mod tests {
     fn env_invalid_tag_rejected() {
         // Empty tag.
         assert!(matches!(
-            from_env(&[("REFLECTOR__SOURCE_IF", "x")]).unwrap_err(),
+            from_env(&[("NETFLECTOR__SOURCE_IF", "x")]).unwrap_err(),
             ConfigError::EnvInvalidTag { .. }
         ));
         // Non-alphanumeric tag.
         assert!(matches!(
-            from_env(&[("REFLECTOR_T-V_SOURCE_IF", "x")]).unwrap_err(),
+            from_env(&[("NETFLECTOR_T-V_SOURCE_IF", "x")]).unwrap_err(),
             ConfigError::EnvInvalidTag { tag, .. } if tag == "T-V"
         ));
     }
@@ -436,9 +436,9 @@ mod tests {
     #[test]
     fn env_reserved_tag_rejected() {
         for var in [
-            "REFLECTOR_LOG_SOMETHING",
-            "REFLECTOR_DEBUG_SOMETHING",
-            "REFLECTOR_COUNTERS_SOURCE_IF",
+            "NETFLECTOR_LOG_SOMETHING",
+            "NETFLECTOR_DEBUG_SOMETHING",
+            "NETFLECTOR_COUNTERS_SOURCE_IF",
         ] {
             assert!(matches!(
                 from_env(&[(var, "x")]).unwrap_err(),
@@ -451,8 +451,8 @@ mod tests {
     fn env_unknown_param_rejected() {
         assert!(matches!(
             from_env(&[
-                ("REFLECTOR_TV_SOURCE_IF", "a"),
-                ("REFLECTOR_TV_BOGUS", "1"),
+                ("NETFLECTOR_TV_SOURCE_IF", "a"),
+                ("NETFLECTOR_TV_BOGUS", "1"),
             ])
             .unwrap_err(),
             ConfigError::EnvUnknownParam { param, .. } if param == "bogus"
@@ -463,9 +463,9 @@ mod tests {
     fn env_bad_value_is_structured() {
         assert!(matches!(
             from_env(&[
-                ("REFLECTOR_TV_SOURCE_IF", ""),
-                ("REFLECTOR_TV_TARGET_IF", "b"),
-                ("REFLECTOR_TV_MDNS", "true"),
+                ("NETFLECTOR_TV_SOURCE_IF", ""),
+                ("NETFLECTOR_TV_TARGET_IF", "b"),
+                ("NETFLECTOR_TV_MDNS", "true"),
             ])
             .unwrap_err(),
             ConfigError::EnvBadValue {
@@ -474,14 +474,14 @@ mod tests {
             }
         ));
         assert!(matches!(
-            from_env(&[("REFLECTOR_TV_MACS", "zz")]).unwrap_err(),
+            from_env(&[("NETFLECTOR_TV_MACS", "zz")]).unwrap_err(),
             ConfigError::EnvBadValue {
                 source: ParseValueError::Macs(_),
                 ..
             }
         ));
         assert!(matches!(
-            from_env(&[("REFLECTOR_TV_WOL", "maybe")]).unwrap_err(),
+            from_env(&[("NETFLECTOR_TV_WOL", "maybe")]).unwrap_err(),
             ConfigError::EnvBadValue {
                 value,
                 source: ParseValueError::Bool(_),
@@ -489,7 +489,7 @@ mod tests {
             } if value == "maybe"
         ));
         assert!(matches!(
-            from_env(&[("REFLECTOR_COUNTERS_INTERVAL_SECS", "soon")]).unwrap_err(),
+            from_env(&[("NETFLECTOR_COUNTERS_INTERVAL_SECS", "soon")]).unwrap_err(),
             ConfigError::EnvBadValue {
                 source: ParseValueError::Integer(_),
                 ..
@@ -501,8 +501,8 @@ mod tests {
     fn env_reflector_missing_required_field() {
         assert!(matches!(
             from_env(&[
-                ("REFLECTOR_TV_TARGET_IF", "b"),
-                ("REFLECTOR_TV_MDNS", "true"),
+                ("NETFLECTOR_TV_TARGET_IF", "b"),
+                ("NETFLECTOR_TV_MDNS", "true"),
             ])
             .unwrap_err(),
             ConfigError::EnvMissingField {
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     fn env_only_no_reflectors_rejected() {
         assert!(matches!(
-            Config::from_sources(None, env(&[("REFLECTOR_LOG_LEVEL", "info")])).unwrap_err(),
+            Config::from_sources(None, env(&[("NETFLECTOR_LOG_LEVEL", "info")])).unwrap_err(),
             ConfigError::NoReflectors
         ));
     }
@@ -523,10 +523,10 @@ mod tests {
     #[test]
     fn env_name_is_trimmed_and_lowercased() {
         let cfg = from_env(&[
-            ("REFLECTOR_TV_SOURCE_IF", "a"),
-            ("REFLECTOR_TV_TARGET_IF", "b"),
-            ("REFLECTOR_TV_MDNS", "true"),
-            ("REFLECTOR_TV_NAME", "  Living Room  "),
+            ("NETFLECTOR_TV_SOURCE_IF", "a"),
+            ("NETFLECTOR_TV_TARGET_IF", "b"),
+            ("NETFLECTOR_TV_MDNS", "true"),
+            ("NETFLECTOR_TV_NAME", "  Living Room  "),
         ])
         .unwrap();
         assert_eq!(cfg.reflectors[0].name.as_str(), "living room");
@@ -544,9 +544,9 @@ mod tests {
         let e = Config::from_sources(
             Some(toml),
             env(&[
-                ("REFLECTOR_RADIO_SOURCE_IF", "lan"),
-                ("REFLECTOR_RADIO_TARGET_IF", "iot"),
-                ("REFLECTOR_RADIO_MDNS", "true"),
+                ("NETFLECTOR_RADIO_SOURCE_IF", "lan"),
+                ("NETFLECTOR_RADIO_TARGET_IF", "iot"),
+                ("NETFLECTOR_RADIO_MDNS", "true"),
             ]),
         )
         .unwrap_err();
@@ -563,10 +563,10 @@ mod tests {
     fn env_whitespace_name_rejected() {
         assert!(matches!(
             from_env(&[
-                ("REFLECTOR_TV_SOURCE_IF", "a"),
-                ("REFLECTOR_TV_TARGET_IF", "b"),
-                ("REFLECTOR_TV_MDNS", "true"),
-                ("REFLECTOR_TV_NAME", "   "),
+                ("NETFLECTOR_TV_SOURCE_IF", "a"),
+                ("NETFLECTOR_TV_TARGET_IF", "b"),
+                ("NETFLECTOR_TV_MDNS", "true"),
+                ("NETFLECTOR_TV_NAME", "   "),
             ])
             .unwrap_err(),
             ConfigError::EnvBadValue {

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -78,7 +78,7 @@ pub(crate) enum ConfigError {
         target_if: InterfaceName,
     },
 
-    #[error("environment variable \"{var}\" is malformed (expected REFLECTOR_<tag>_<param>)")]
+    #[error("environment variable \"{var}\" is malformed (expected NETFLECTOR_<tag>_<param>)")]
     EnvMalformedVar { var: String },
 
     #[error(

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -31,7 +31,7 @@ pub(super) struct RawConfig {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct RawReflector {
-    /// Display name; set only by the environment layer (`REFLECTOR_<tag>_NAME`).
+    /// Display name; set only by the environment layer (`NETFLECTOR_<tag>_NAME`).
     /// File reflectors take their name from the `[reflectors.<name>]` table key.
     #[serde(skip)]
     pub(super) name: Option<ReflectorName>,
@@ -64,7 +64,7 @@ impl RawConfig {
         self.counters_interval_secs = env.counters_interval_secs.or(self.counters_interval_secs);
         for (name, reflector) in env.reflectors {
             // Compare folded: an env tag is already lowercase and unpadded, but a TOML table key is
-            // stored verbatim, so `[reflectors.TV]` (or `"  tv  "`) and env `REFLECTOR_TV_*` name the
+            // stored verbatim, so `[reflectors.TV]` (or `"  tv  "`) and env `NETFLECTOR_TV_*` name the
             // same reflector and must collide rather than silently produce two.
             if self
                 .reflectors

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1041,7 +1041,7 @@ mod tests {
         let mut reactor = Reactor::new()?;
         let mut dispatcher = PacketDispatcher::new();
         let key = dispatcher.table.find_or_add_interface(LOOPBACK_IFACE)?;
-        dispatcher.table.set_test_name(key, "reflector-gone0");
+        dispatcher.table.set_test_name(key, "netflector-gone0");
 
         dispatcher.reconcile_interfaces(&mut reactor);
 
@@ -1251,7 +1251,7 @@ mod tests {
         assert!(!v6.matches(&packet("10.0.0.1:5353", "224.0.0.251:5353", None, None)));
     }
 
-    const PROBE: &[u8] = b"reflector-dispatch-probe";
+    const PROBE: &[u8] = b"netflector-dispatch-probe";
     /// The echo re-emits to this port, distinct from the filter's, so the looped-back
     /// echo can't re-match and amplify.
     const ECHO_DST_PORT: u16 = 1;

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -1,4 +1,4 @@
-//! Observability counters: what the reflector did with each packet, tallied per message type and
+//! Observability counters: what netflector did with each packet, tallied per message type and
 //! interface.
 //!
 //! A single packet can match several handlers: mirrored `a→b`/`b→a` reflectors put one reflecting and

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -578,7 +578,7 @@ mod tests {
     fn rebind_to_absent_parks_the_entry() -> io::Result<()> {
         let mut table = InterfaceTable::new();
         let key = table.find_or_add_interface(LOOPBACK_IFACE)?;
-        table.entries[key.0 as usize].interface.name = "reflector-gone0".into();
+        table.entries[key.0 as usize].interface.name = "netflector-gone0".into();
         let real = if_index(LOOPBACK_IFACE).expect("loopback has an ifindex");
         assert_eq!(
             table.stale_interfaces(),
@@ -615,7 +615,7 @@ mod tests {
             }
             return Err(e);
         }
-        table.entries[key.0 as usize].interface.name = "reflector-gone0".into();
+        table.entries[key.0 as usize].interface.name = "netflector-gone0".into();
         table.rebind_interface(key, 0)?; // park: joiner reset, no rejoin
         table.refresh_all();
         assert!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ use crate::reflector::BuildError;
 /// Crate-wide result alias, so signatures read `Result<T>`.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Anything that can go wrong while configuring or running the reflector.
+/// Anything that can go wrong while configuring or running netflector.
 ///
 /// Opaque on purpose: callers only print it (`Display`). The structured cause
 /// stays crate-internal. Each subsystem keeps its own matchable error type; `?`
@@ -98,9 +98,9 @@ impl From<UsageError> for Error {
 #[derive(Debug, Error)]
 pub(crate) enum UsageError {
     /// More than the single optional config path was given; the payload is the first extra argument.
-    #[error("unexpected extra argument \"{0}\"; try `reflector --help`")]
+    #[error("unexpected extra argument \"{0}\"; try `netflector --help`")]
     TooManyArgs(String),
     /// An option the CLI does not know; the payload is the option as written.
-    #[error("unknown option \"{0}\"; try `reflector --help`")]
+    #[error("unknown option \"{0}\"; try `netflector --help`")]
     UnknownOption(String),
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -222,7 +222,7 @@ fn log_field_change<A: PartialEq + fmt::Display>(
 }
 
 /// An IPv6 source candidate's rank, ordered worst-to-best so a higher variant outranks a lower one
-/// (the derived `Ord` follows declaration order). The reflector reflects link-local service traffic, so
+/// (the derived `Ord` follows declaration order). netflector reflects link-local service traffic, so
 /// a link-local source is preferred, then ULA, then global; a multicast / `::` / `::1` address is never
 /// a source.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Debug)]
@@ -433,11 +433,11 @@ mod tests {
 
     // Opt-in diagnostic: trace-log every address (and each v6's flag status) the resolver
     // finds on a real interface. Run with, e.g.:
-    //   REFLECTOR_TEST_IFACE=en0 cargo test -- --nocapture resolve_traces_test_interface
+    //   NETFLECTOR_TEST_IFACE=en0 cargo test -- --nocapture resolve_traces_test_interface
     #[test]
     fn resolve_traces_test_interface() {
-        let Some(iface) = std::env::var_os("REFLECTOR_TEST_IFACE") else {
-            eprintln!("skip: set REFLECTOR_TEST_IFACE to inspect an interface");
+        let Some(iface) = std::env::var_os("NETFLECTOR_TEST_IFACE") else {
+            eprintln!("skip: set NETFLECTOR_TEST_IFACE to inspect an interface");
             return;
         };
         let iface = iface.to_string_lossy();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! reflector: reflects link-local service traffic (Wake-on-LAN, mDNS, SSDP, WS-Discovery,
+//! netflector: reflects link-local service traffic (Wake-on-LAN, mDNS, SSDP, WS-Discovery,
 //! and an optional DIAL proxy) between two network interfaces.
 //!
 //! The behavior lives in this library crate so it stays testable in-process;
@@ -34,7 +34,7 @@ use self::reflector::InterfaceMap;
 /// Run whatever the command line asked for.
 ///
 /// `args` is the process argument list with `argv[0]` already stripped: an optional TOML config path,
-/// which `REFLECTOR_*` environment variables are merged on top of, plus `--check-config`, `--version`
+/// which `NETFLECTOR_*` environment variables are merged on top of, plus `--check-config`, `--version`
 /// and `--help`. Run the binary with `--help` for the full text.
 ///
 /// # Errors
@@ -47,7 +47,7 @@ pub fn run(args: &[OsString]) -> Result<()> {
             Ok(())
         }
         Invocation::Version => {
-            println!("reflector {}", env!("CARGO_PKG_VERSION"));
+            println!("netflector {}", env!("CARGO_PKG_VERSION"));
             Ok(())
         }
         Invocation::CheckConfig(path) => check_config(path),
@@ -73,7 +73,7 @@ fn check_config(path: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-/// Run the reflector to completion.
+/// Run netflector to completion.
 ///
 /// # Errors
 /// Returns [`Error`] if configuration loading or validation fails, or if the
@@ -87,14 +87,14 @@ fn reflect(path: Option<&Path>) -> Result<()> {
     // Resolve the log level first from a minimal read of env + file, so the full parse below
     // logs at the configured verbosity (see resolve_log_level).
     logging::set_level(config::resolve_log_level(toml_text.as_deref(), &env)?);
-    log::info!("reflector {} starting", env!("CARGO_PKG_VERSION"));
+    log::info!("netflector {} starting", env!("CARGO_PKG_VERSION"));
     if let Some(path) = path {
         log::debug!(
-            "loading configuration from {} with REFLECTOR_* overrides",
+            "loading configuration from {} with NETFLECTOR_* overrides",
             path.display()
         );
     } else {
-        log::debug!("loading configuration from REFLECTOR_* environment only");
+        log::debug!("loading configuration from NETFLECTOR_* environment only");
     }
 
     let config = Config::from_sources(toml_text.as_deref(), env)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
 //! Thin binary entry point.
 //!
-//! All logic lives in the `reflector` library so it can be tested without
+//! All logic lives in the `netflector` library so it can be tested without
 //! spawning a process. `main` installs the logger, collects the environment,
-//! and turns a [`reflector::Result`] into an exit code: on failure it logs the
+//! and turns a [`netflector::Result`] into an exit code: on failure it logs the
 //! error and exits non-zero.
 
 use std::ffi::OsString;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    reflector::init_logging();
+    netflector::init_logging();
     // args_os, not args: a non-UTF-8 argument (a path can be non-UTF-8 on Unix) makes args() panic.
     let args: Vec<OsString> = std::env::args_os().skip(1).collect();
-    match reflector::run(&args) {
+    match netflector::run(&args) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             // Log facade, not eprintln, so a fatal error reads like every other line

--- a/src/net/ssdp/dial.rs
+++ b/src/net/ssdp/dial.rs
@@ -13,7 +13,7 @@ pub(crate) fn is_dial_service_message(payload: &[u8]) -> bool {
 }
 
 /// Parse the device authority from a DIAL discovery message's `LOCATION:` header, the byte span
-/// mapped into the whole `payload` so the SSDP path splices a reflector authority over it. The
+/// mapped into the whole `payload` so the SSDP path splices a netflector authority over it. The
 /// `LOCATION` must be a rewritable `http://ipv4[:port]` URL; `None` otherwise (forward unchanged).
 pub(crate) fn parse_dial_location_authority(payload: &[u8]) -> Option<Authority> {
     for line in payload.split(|&b| b == b'\n') {

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -31,7 +31,7 @@ use std::time::{Duration, Instant};
 
 use self::poll::Poller;
 
-/// How many ready fds one [`wait`](poll::Poller::wait) reports. The reflector watches
+/// How many ready fds one [`wait`](poll::Poller::wait) reports. netflector watches
 /// only a handful of fds; level-triggering re-reports any overflow on the next wait,
 /// so a small buffer never loses events.
 const EVENT_CAPACITY: NonZeroUsize = NonZeroUsize::new(64).unwrap();

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -358,11 +358,11 @@ mod tests {
     fn process_env_sees_a_set_variable() {
         // SAFETY: nothing else in the test binary reads or writes the process
         // environment concurrently (config tests take env as a parameter).
-        unsafe { std::env::set_var("REFLECTOR_SYS_ENV_PROBE", "probe-value") };
+        unsafe { std::env::set_var("NETFLECTOR_SYS_ENV_PROBE", "probe-value") };
         let env = process_env();
         assert!(
             env.iter()
-                .any(|(k, v)| k == "REFLECTOR_SYS_ENV_PROBE" && v == "probe-value")
+                .any(|(k, v)| k == "NETFLECTOR_SYS_ENV_PROBE" && v == "probe-value")
         );
     }
 }


### PR DESCRIPTION
"reflector" is the category noun (avahi's config literally has `enable-reflector=yes`)
and collides with Arch's `extra/reflector`. netflector is unclaimed on GitHub,
crates.io, and in the distro package namespaces.

The project identity moves: crate, binary, `netflector.toml`, the `NETFLECTOR_*` env
prefix, GHCR image, syslog tags, and the e2e harness. The domain vocabulary stays:
a configured entry is still a reflector, `[reflectors.<name>]` is unchanged, and
packets are reflected, not netflected.

Deliberately untouched: `dist/freebsd/net/reflector` and `ci/port-sync.py` package
the released v0.12.1, which really is named reflector; they get re-pinned after the
repo moves and v0.13.0 exists. release.yml now publishes
`ghcr.io/${{ github.repository }}`, so the image follows the repo rename. Do not tag
a release before the repo is at netflector/netflector.

## Testing

- fmt, clippy `-D warnings`, rustdoc: clean on host and Linux
- unit tests: 441 host, 440 Linux, 0 failed
- full Docker e2e suite: 57/57
- `netflect` as a verb: zero occurrences; `REFLECTOR_*`: zero leftovers
- two adversarial review passes (the second on a different model family); all
  confirmed findings fixed
