### PR TITLE
Fail the e2e ready-wait fast when the container is gone

### DIFF
--- a/e2e/run.py
+++ b/e2e/run.py
@@ -1214,6 +1214,10 @@ class DockerBackend(Backend):
             echo=False,
         )
         if result.returncode != 0:
+            # A vanished container must fail the wait immediately, not spin out the ready
+            # timeout; any other inspect failure (a daemon hiccup) is worth retrying.
+            if "no such object" in result.stderr.lower():
+                return False, "container no longer exists"
             return True, "unknown"
         state = result.stdout.strip()
         return not state.startswith("false "), state


### PR DESCRIPTION
DockerBackend.status() mapped every failed docker inspect to "still running, state unknown", so a container that vanished mid-startup kept wait_for_log polling for the full ready timeout before failing with a generic message. A literal "no such object" means the container no longer exists: report it dead so the wait raises immediately. Any other inspect failure (a daemon hiccup) still reads as unknown and is retried.

Part of the rename-findings series.

## Testing

4 Docker e2e cases covering the wait paths (WoL receive, expect-none, mdns address-change, mdns interface-recreate) pass; the "no such object" message text verified against the local docker CLI.