### PR TITLE
Fix two doc comments, a misplaced doc block, and a missing test assert

### DIFF
--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -439,9 +439,6 @@ mod tests {
     use crate::interface::{LOOPBACK_IFACE, if_index};
 
     impl InterfaceTable {
-        /// Push a capture-less entry (no fd) so a routing test can mint a valid [`CaptureKey`] and
-        /// exercise the record path without opening a capture; the dangling [`InterfaceKey`] is
-        /// never resolved. Reachable from the dispatcher's own tests, hence `pub(in crate::dispatch)`.
         /// Overwrite an entry's cached identity, standing in for the kernel recreating the
         /// interface out from under the table. For the dispatcher's reconcile tests.
         pub(in crate::dispatch) fn set_test_ifindex(
@@ -458,6 +455,9 @@ mod tests {
             self.entries[interface.0 as usize].interface.name = name.to_owned();
         }
 
+        /// Push a capture-less entry (no fd) so a routing test can mint a valid [`CaptureKey`] and
+        /// exercise the record path without opening a capture; the dangling [`InterfaceKey`] is
+        /// never resolved. Reachable from the dispatcher's own tests, hence `pub(in crate::dispatch)`.
         pub(in crate::dispatch) fn add_test_capture(&mut self) -> CaptureKey {
             let key =
                 CaptureKey(u32::try_from(self.captures.len()).expect("capture count fits a u32"));

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -216,7 +216,7 @@ fn ipv6_addr(bytes: &[u8]) -> Result<Ipv6Addr, ParseError> {
         .map_err(|_| ParseError::Truncated)
 }
 
-/// Read a 6-byte MAC field, the [`ipv4_addr`] counterpart.
+/// Read a 6-byte MAC field.
 fn read_mac(bytes: &[u8]) -> Result<MacAddr, ParseError> {
     <[u8; 6]>::try_from(bytes)
         .map(MacAddr::from)
@@ -303,6 +303,7 @@ mod tests {
 
         let packet = Packet::parse(LinkType::DltNull, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V6(src));
+        assert_eq!(packet.dest, SocketAddr::V6(dst));
         assert_eq!(packet.ttl, 255);
         assert_eq!(packet.payload, &payload);
     }

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -123,7 +123,7 @@ impl PacketHandler for ResponseReflector {
 /// search to handle, [`Verdict::Skip`] = the other direction, [`Verdict::Junk`] = log and drop);
 /// `window` is the per-search session lifetime; `make_reply` mints the per-session reply transform.
 pub(crate) struct SearchReflector {
-    /// The source capture: this reflector's ingress, and the egress its responses leave reply on.
+    /// The source capture: this reflector's ingress, and the egress its responses leave on.
     source: CaptureKey,
     /// The target capture: where the search is re-emitted and the replies are captured.
     target: CaptureKey,


### PR DESCRIPTION
- read_mac's doc called a MAC field "the ipv4_addr counterpart", copy-pasted from ipv6_addr.
- set_test_ifindex's doc opened with a paragraph describing add_test_capture, which itself had none: moved it home.
- SearchReflector's source doc read "the egress its responses leave reply on".
- round_trips_dlt_null_ipv6 asserted source, ttl and payload but never dest, unlike its IPv4 and Ethernet v6 siblings.

Part of the rename-findings series.

## Testing

fmt, clippy, rustdoc clean on host and Linux; 441 unit tests green including the strengthened DLT_NULL v6 round-trip (BSD-gated, runs natively on the macOS host).