### PR TITLE
Retry the Miri nightly lookup on transient failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,7 +649,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Resolve the newest nightly that ships Miri
         run: |
-          date=$(curl -fsSL https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+          date=$(curl -fsSL --retry 5 --retry-connrefused https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
           # The endpoint serves a bare date. Anything else (an error page, an outage) must fail here
           # rather than turn into a confusing rustup error two steps later.
           case "$date" in


### PR DESCRIPTION
The Miri lane resolves its nightly from rust-lang's components-history endpoint with a bare curl; a transient 5xx or dropped connection reds that matrix row for nothing the repo did. --retry 5 covers transient HTTP errors and timeouts with exponential backoff, --retry-connrefused covers a Pages outage. A genuine 404 (endpoint moved) still fails immediately, and the bare-date validation below the curl stays as the last line of defense.

Part of the rename-findings series.

## Testing

The exact command runs locally and returns 2026-07-14.