### PR TITLE
Point the port at v0.13.1 and adopt its BSD-2-Clause licence

### DIFF
--- a/dist/freebsd/net/netflector/Makefile
+++ b/dist/freebsd/net/netflector/Makefile
@@ -1,13 +1,13 @@
 PORTNAME=	netflector
 DISTVERSIONPREFIX=	v
-DISTVERSION=	0.13.0
+DISTVERSION=	0.13.1
 CATEGORIES=	net
 
 MAINTAINER=	sergii@bogomolov.io
 COMMENT=	Reflect link-local service discovery between interfaces
 WWW=		https://github.com/netflector/netflector
 
-LICENSE=	APACHE20
+LICENSE=	BSD2CLAUSE
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 ONLY_FOR_ARCHS=	aarch64 amd64

--- a/dist/freebsd/net/netflector/distinfo
+++ b/dist/freebsd/net/netflector/distinfo
@@ -1,4 +1,4 @@
-TIMESTAMP = 1784059767
+TIMESTAMP = 1784073836
 SHA256 (rust/crates/equivalent-1.0.2.crate) = 877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f
 SIZE (rust/crates/equivalent-1.0.2.crate) = 7419
 SHA256 (rust/crates/hashbrown-0.17.1.crate) = ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a
@@ -39,5 +39,5 @@ SHA256 (rust/crates/unicode-ident-1.0.24.crate) = e6e4313cd5fcd3dad5cafa179702e2
 SIZE (rust/crates/unicode-ident-1.0.24.crate) = 49298
 SHA256 (rust/crates/winnow-1.0.3.crate) = 0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1
 SIZE (rust/crates/winnow-1.0.3.crate) = 187990
-SHA256 (netflector-netflector-v0.13.0_GH0.tar.gz) = 99d450a4f2836ab153fb660abc739c6161429b02b40d6fbdf00c5137ac1df67e
-SIZE (netflector-netflector-v0.13.0_GH0.tar.gz) = 325957
+SHA256 (netflector-netflector-v0.13.1_GH0.tar.gz) = 567e49e0be4dd4f154a080c6ff3ed9d3d816f6fa63e521b6dcbd431901b7e1eb
+SIZE (netflector-netflector-v0.13.1_GH0.tar.gz) = 322779


### PR DESCRIPTION
`ci/port-sync.py --update` re-pins DISTVERSION and distinfo to v0.13.1 — the first release whose tarball ships the BSD-2 LICENSE, so the port's `LICENSE` flips with it and `LICENSE_FILE` keeps pointing at the tree's own text. Crate list unchanged (no dependency moves between 0.13.0 and 0.13.1).

## Testing

Full committer QA on the FreeBSD VM: portlint -AC clean, checksum fetches and verifies the v0.13.1 tarball (its LICENSE opens with the BSD-2 copyright line), stage / stage-qa / check-plist green, package installs with `Licenses: BSD2CLAUSE`, binary prints `netflector 0.13.1`, deinstall clean. The port-build lane repeats the sequence on a pristine tree.