### PR TITLE
Discover the DIAL device's address without a broadcast connect

### DIFF
--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -262,8 +262,15 @@ def _own_address(interface: str, family: int) -> str:
         if family == 6:
             probe.connect(("ff02::1", 9, 0, socket.if_nametoindex(interface)))
         else:
-            probe.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-            probe.connect(("255.255.255.255", 9))
+            # FreeBSD 15 refuses a broadcast connect (ENETUNREACH, SO_BROADCAST or not), so pin the
+            # interface like the v6 branch and connect to the multicast group instead; that needs no
+            # route at all (the vnet-jail case) and works the same on Linux.
+            mreqn = struct.pack(
+                "@4s4si", socket.inet_aton("0.0.0.0"), b"\x00\x00\x00\x00",
+                socket.if_nametoindex(interface),
+            )
+            probe.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, mreqn)
+            probe.connect(("239.255.255.250", 9))
         return probe.getsockname()[0]
 
 


### PR DESCRIPTION
`_own_address` learned its v4 address by connecting a UDP socket to `255.255.255.255`. FreeBSD 15 refuses that with ENETUNREACH (`SO_BROADCAST` or not), which failed every DIAL case on a 15.1 box — found while proving the FreeBSD:15 package tree for the publish pipeline. The fix mirrors what the v6 branch already does: pin the interface via `IP_MULTICAST_IF` (ifindex `mreqn`, the pack probe.py already uses portably) and dummy-connect to the SSDP group, which needs no route at all.

## Testing

- FreeBSD 15.1 VM: full native e2e suite, 57/57 (previously failed at the first DIAL case)
- FreeBSD 14.4 VM: 4/4 DIAL cases (regression check where the broadcast connect used to work)
- Docker/Linux: 4/4 DIAL cases
- The no-route property proven directly in a scratch vnet jail on 15.1