### PR TITLE
Tune the FreeBSD CI guests; ubuntu-26.04 compat fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,12 +465,12 @@ jobs:
           # the packages come from the Ubuntu archive, and a broken archive still fails the
           # install below loudly.
           sudo apt-get update || true
-          sudo apt-get install -y --no-install-recommends lld qemu-user-static
+          sudo apt-get install -y --no-install-recommends lld qemu-user-binfmt
       - name: Add the Rust target
         if: matrix.target.triple != ''
         run: rustup target add ${{ matrix.target.triple }}
       # The same lld cross-link config the Dockerfile writes for cross layers; binfmt_misc (from
-      # qemu-user-static) execs the ARM binary under qemu transparently, netns exec included. The
+      # qemu-user-binfmt) execs the ARM binary under qemu transparently, netns exec included. The
       # native musl lanes write no config: rustc's default toolchain, like release.yml's rows.
       - name: Configure the arm32 cross-linker
         if: matrix.target.emulated
@@ -593,7 +593,7 @@ jobs:
   # (MikroTik), so those lanes run the shipped musl configuration under QEMU rather than only
   # cross-building it -- catching pointer-width / alignment / cast bugs the 64-bit lanes can't.
   # There lld cross-links (the same config the Dockerfile uses for cross layers, no per-arch gcc)
-  # and the cargo target runner executes via qemu-arm-static (armv7 = armhf, hard-float; armv5 =
+  # and the cargo target runner executes via qemu-arm (armv7 = armhf, hard-float; armv5 =
   # armel, soft-float, the EN7562 boxes).
   test:
     name: Test (${{ matrix.target.name }}, ${{ matrix.profile.name }})
@@ -610,7 +610,7 @@ jobs:
           - { name: debug, flags: '' }
           - { name: release, flags: '--release' }
         # triple '' = the runner's native gnu toolchain; a triple without `emulated` is that musl
-        # target built and run natively; `emulated` lanes cross-link and run under qemu-arm-static.
+        # target built and run natively; `emulated` lanes cross-link and run under qemu-arm.
         target:
           - { name: linux-amd64-glibc, runner: ubuntu-24.04, triple: '' }
           - { name: linux-arm64-glibc, runner: ubuntu-24.04-arm, triple: '' }
@@ -639,13 +639,13 @@ jobs:
           # the packages come from the Ubuntu archive, and a broken archive still fails the
           # install below loudly.
           sudo apt-get update || true
-          sudo apt-get install -y --no-install-recommends lld qemu-user-static
+          sudo apt-get install -y --no-install-recommends lld qemu-user-binfmt
       - name: Add the Rust target
         if: matrix.target.triple != ''
         run: rustup target add ${{ matrix.target.triple }}
       # Link the arm32 musl target with lld (cross-capable, unlike the host gcc) and run the test
       # binary under QEMU -- the same lld config the Dockerfile writes for cross layers, plus a
-      # qemu-arm-static runner for the target. The cfg(target_env = "musl") scope leaves host
+      # qemu-arm runner for the target. The cfg(target_env = "musl") scope leaves host
       # build-scripts/proc-macros on the default linker. The native musl lanes write no config at
       # all: rustc's default toolchain links them, exactly like the release rows.
       - name: Configure the cross linker and QEMU runner
@@ -658,7 +658,7 @@ jobs:
           rustflags = ["-C", "linker-flavor=ld.lld"]
 
           [target.${{ matrix.target.triple }}]
-          runner = "qemu-arm-static"
+          runner = "qemu-arm"
           EOF
       - name: Show toolchain
         run: rustc -V && cargo -V
@@ -670,8 +670,10 @@ jobs:
       - name: cargo test (root)
         if: ${{ !matrix.target.emulated }}
         run: |
+          # Not -E: sudo-rs (the default sudo since Ubuntu 25.10) ignores it. HOME is where the
+          # rustup shim finds the toolchain, and the only variable the suite needs.
           triple='${{ matrix.target.triple }}'
-          sudo -E "$(command -v cargo)" test --locked ${{ matrix.profile.flags }} ${triple:+--target "$triple"}
+          sudo --preserve-env=HOME "$(command -v cargo)" test --locked ${{ matrix.profile.flags }} ${triple:+--target "$triple"}
       - name: cargo test (under QEMU)
         if: matrix.target.emulated
         run: cargo test --locked --target ${{ matrix.target.triple }} ${{ matrix.profile.flags }}
@@ -719,7 +721,7 @@ jobs:
       - name: cargo test (under memcheck)
         run: |
           export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,indirect --track-fds=yes --num-callers=30 --error-exitcode=1'
-          sudo -E "$(command -v cargo)" test --locked
+          sudo --preserve-env=HOME,CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER "$(command -v cargo)" test --locked
 
   # The FreeBSD port pins every byte it builds from: the release tarball and all 20 crates, each with a
   # SHA256 in distinfo. If Cargo.lock moves and those are not regenerated, the port either fails to build

--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -85,6 +85,18 @@ write_files:
     content: |
       firstboot_pkg_upgrade_enable="NO"
 EOF
+    # TCG only: noble's QEMU 8.2 keys translation blocks by virtual PC (the 8.2.1 stable
+    # revert of PCREL TB sharing), so ASLR makes every short-lived process retranslate
+    # libc at fresh addresses. Pinning layouts restores reuse across the e2e exec storm.
+    # KVM does not translate; the amd64 guest stays production-like.
+    if [ "$ARCH" = arm64 ]; then
+        cat >> "$VM_DIR/user-data" <<EOF
+  - path: /etc/sysctl.conf.local
+    content: |
+      kern.elf64.aslr.enable=0
+      kern.elf64.aslr.pie_enable=0
+EOF
+    fi
     genisoimage -quiet -output "$VM_DIR/seed.iso" -volid cidata -joliet -rock \
         "$VM_DIR/user-data" "$VM_DIR/meta-data"
 }
@@ -107,7 +119,10 @@ launch() {
     # only ever boot from disk anyway.
     common=(
         -smp "$(nproc)" -m 6144
-        -drive "file=$VM_DIR/$IMAGE,format=qcow2,if=virtio"
+        # cache=unsafe: flushes become no-ops (UFS journal commits, pkg's per-package
+        # fsyncs). The failure mode is a stale image after a HOST crash, and these VMs
+        # do not outlive the job.
+        -drive "file=$VM_DIR/$IMAGE,format=qcow2,if=virtio,cache=unsafe"
         -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
         -device virtio-net-pci,netdev=net0,romfile=
         -display none -serial "file:$VM_DIR/console.log"
@@ -124,11 +139,14 @@ launch() {
         # has no CD controller, so the seed rides a read-only virtio disk --
         # nuageinit finds it by filesystem label, not device type.
         cp /usr/share/AAVMF/AAVMF_VARS.fd "$VM_DIR/AAVMF_VARS.fd"
-        # pauth-impdef swaps QARMA for a trivial cipher: the FreeBSD 15 kernel is PAC-built,
-        # and emulating the real cipher on every kernel function prologue tripled exec-heavy
-        # e2e time under TCG. Hardware and the 14 guests are unaffected.
+        # pauth=off: the FreeBSD 15 kernel is PAC-built, and under TCG even a cheap PAC
+        # helper runs on every kernel function prologue (the real QARMA cipher tripled
+        # exec-heavy e2e time). Without the feature the instructions are hint-space NOPs;
+        # nothing this CI tests is built with PAC. gic-version=3: the default for <= 8
+        # CPUs is GICv2, whose CPU interface is MMIO -- every interrupt ack/EOI takes the
+        # slow path under the global lock; v3 uses system registers.
         qemu-system-aarch64 \
-            -machine virt -accel tcg,thread=multi -cpu max,pauth-impdef=on \
+            -machine virt,gic-version=3 -accel tcg,thread=multi -cpu max,pauth=off \
             -drive "if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.fd" \
             -drive "if=pflash,format=raw,file=$VM_DIR/AAVMF_VARS.fd" \
             -drive "file=$VM_DIR/seed.iso,format=raw,if=virtio,readonly=on" \
@@ -148,6 +166,11 @@ wait_ssh() {
         sleep 2
     done
     echo "ssh up after ${SECONDS}s"
+    # async: UFS goes fully write-behind (throwaway disk); noatime: FreeBSD has no
+    # relatime, so without it every binary/library read in the exec storm queues an
+    # atime metadata write.
+    ssh "${SSH_OPTS[@]}" -p "$SSH_PORT" root@127.0.0.1 'mount -u -o async,noatime /'
+    echo "root remounted async,noatime"
     run 'uname -a && freebsd-version'
 }
 

--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -138,15 +138,18 @@ launch() {
         # read-only AAVMF code image plus a writable per-VM vars copy) and
         # has no CD controller, so the seed rides a read-only virtio disk --
         # nuageinit finds it by filesystem label, not device type.
+        # neoverse-n1, not max: -cpu max hangs edk2 2025.11 inside the firmware under
+        # QEMU 10 TCG (banner, then silence; A/B'd against the firmware image and
+        # pauth=off -- the CPU model is the trigger), and its optional features only
+        # cost TCG time anyway. The FreeBSD 15 kernel is PAC-built, and under TCG even
+        # a cheap PAC helper runs on every kernel function prologue (the real QARMA
+        # cipher tripled exec-heavy e2e time); N1 has no PAuth at all, so those
+        # instructions fall back to hint-space NOPs. gic-version=3: the default for
+        # <= 8 CPUs is GICv2, whose CPU interface is MMIO -- every interrupt ack/EOI
+        # takes the slow path under the global lock; v3 uses system registers.
         cp /usr/share/AAVMF/AAVMF_VARS.fd "$VM_DIR/AAVMF_VARS.fd"
-        # pauth=off: the FreeBSD 15 kernel is PAC-built, and under TCG even a cheap PAC
-        # helper runs on every kernel function prologue (the real QARMA cipher tripled
-        # exec-heavy e2e time). Without the feature the instructions are hint-space NOPs;
-        # nothing this CI tests is built with PAC. gic-version=3: the default for <= 8
-        # CPUs is GICv2, whose CPU interface is MMIO -- every interrupt ack/EOI takes the
-        # slow path under the global lock; v3 uses system registers.
         qemu-system-aarch64 \
-            -machine virt,gic-version=3 -accel tcg,thread=multi -cpu max,pauth=off \
+            -machine virt,gic-version=3 -accel tcg,thread=multi -cpu neoverse-n1 \
             -drive "if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.fd" \
             -drive "if=pflash,format=raw,file=$VM_DIR/AAVMF_VARS.fd" \
             -drive "file=$VM_DIR/seed.iso,format=raw,if=virtio,readonly=on" \

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -9,13 +9,13 @@ source_if = "wol_src"
 target_if = "wol_dst"
 macs = ["02:42:ac:11:00:09", "02:42:ac:11:00:0c"]
 wol = true
-wol_ports = [40009]
+wol_ports = [9009]
 
 [reflectors.wol-any]
 source_if = "wol_src"
 target_if = "wol_dst"
 wol = true
-wol_ports = [40011]
+wol_ports = [9011]
 
 [reflectors.discovery]
 source_if = "wol_src"

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import binascii
+import errno
 import http.server
 import socket
 import struct
@@ -62,6 +63,22 @@ def is_ipv6(address: str) -> bool:
 
 def is_ipv4_multicast(address: str) -> bool:
     return 224 <= int(address.split(".")[0]) <= 239
+
+
+def bind_reporting_conflict(sock: socket.socket, address: str, port: int) -> None:
+    # A conflict should be impossible (fresh namespace, REUSEADDR set), so name the squatter:
+    # /proc/net/udp* lists every UDP socket in this namespace (Linux only).
+    try:
+        sock.bind((address, port))
+    except OSError as err:
+        if err.errno == errno.EADDRINUSE:
+            for table in ("/proc/net/udp", "/proc/net/udp6"):
+                try:
+                    with open(table) as f:
+                        sys.stderr.write(f"--- {table} ---\n{f.read()}")
+                except OSError:
+                    pass
+        raise
 
 
 def join_group(sock: socket.socket, family: int, group: str, interface: str) -> None:
@@ -119,7 +136,7 @@ def receive(args: argparse.Namespace) -> int:
 
     with socket.socket(family, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((bind_address, args.port))
+        bind_reporting_conflict(sock, bind_address, args.port)
         if args.join_group is not None:
             # Multicast is only delivered to sockets that joined the group on the receiving
             # interface; broadcast/all-nodes (the WoL IPv4 path) needs no join.
@@ -173,7 +190,7 @@ def respond(args: argparse.Namespace) -> int:
 
     with socket.socket(family, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((bind_address, args.port))
+        bind_reporting_conflict(sock, bind_address, args.port)
         if args.join_group is not None:
             join_group(sock, family, args.join_group, args.interface)
         # Readiness marker so run.py can sequence the searcher after the responder is listening.

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -41,9 +41,12 @@ CONFIGURED_MAC = "02:42:ac:11:00:09"
 # A second address in wol-mac's `macs` allow-set, to prove the list admits every member, not just the first.
 SECOND_CONFIGURED_MAC = "02:42:ac:11:00:0c"
 WRONG_MAC = "02:42:ac:11:00:0a"
-CONFIGURED_PORT = 40009
-UNCONFIGURED_PORT = 40010
-ANY_MAC_PORT = 40011
+# Below every platform's ephemeral range (Linux 32768+, FreeBSD 10000+, macOS 49152+): a fixed
+# test port inside it can collide with a kernel-assigned port in the same namespace -- seen once
+# in CI as EADDRINUSE on the receiver's bind, from an engine-side socket in a fresh container.
+CONFIGURED_PORT = 9009
+UNCONFIGURED_PORT = 9010
+ANY_MAC_PORT = 9011
 MALFORMED_MAGIC_PAYLOAD_HEX = "ff" * 6 + "0242ac11000a" * 15 + "0242ac11000b"
 # --- mDNS (RFC 6762): multicast group 224.0.0.251 / ff02::fb on UDP 5353. ---
 MDNS_GROUP_V4 = "224.0.0.251"


### PR DESCRIPTION
Four changes from an adversarially-verified QEMU tuning pass (22 recommendations survived of 34; the rejected ones are banked as negative results):

- **`cache=unsafe`** on the OS disk, both lanes: guest flushes become no-ops; throwaway VMs don't care about host-crash staleness.
- **`-cpu neoverse-n1`** (was `max` + PAC tweaks): `-cpu max` hangs edk2 2025.11 under QEMU 10 TCG before the loader runs -- a four-way A/B on the 26.04 preview pinned the CPU model as the trigger, not the firmware image and not pauth. N1 boots on QEMU 8.2 and 10 alike, and having no PAuth at all it also eliminates the per-kernel-prologue PAC cost that `pauth=off` addressed.
- **`gic-version=3`**: the <=8-CPU default is GICv2, whose CPU interface is MMIO (every interrupt ack/EOI is a slow-path exit under the global lock); v3 uses system registers.
- **Guest side**: root remounted `async,noatime` after boot (no relatime on FreeBSD -- every exec queued an atime write); arm64 guest disables ASLR (noble's QEMU 8.2 keys TBs by virtual PC per the 8.2.1 stable revert, so randomized layouts retranslate libc for every process in the e2e exec storm).

Running the full suite on the ubuntu-26.04 preview surfaced three portable fixes, kept here; the runner flip itself waits for GA:

- sudo-rs (the default sudo since Ubuntu 25.10) ignores blanket `-E`: the root test lanes and valgrind-test pass exactly the variables they need via `--preserve-env` (supported since sudo 1.8.21).
- `qemu-user-static` is virtual-only on 26.04 (Debian merged the static binaries into `qemu-user` under bare names): install `qemu-user-binfmt`, run the emulated unit lanes via `qemu-arm`. Nothing in CI execs a foreign-arch binary in a foreign rootfs, so noble's dynamic variant serves equally.
- The WoL e2e ports (40009-40011) sat inside Linux's ephemeral range; a kernel-assigned transient socket collided once (EADDRINUSE on a fresh container's very first bind). Now 9009-9011 -- below the ephemeral floor on Linux, FreeBSD, and macOS -- and probe.py dumps `/proc/net/udp*` if a bind conflict ever recurs.

## Testing

Tuning A/B on 24.04: 15-arm64 e2e 17.2/16.9 -> 12.4/12.7 min, 14-arm64 13.7/13.9 -> 10.7/11.4. The full suite also ran green on the ubuntu-26.04 preview with this tree (57 jobs; arm64 FreeBSD e2e 8.7-13.6 min on QEMU 10). Head run (24.04, neoverse-n1): all green; arm64 e2e 10.3-12.8 min, unit rows 2-2.8 -- on par with `max,pauth=off`.
