### PR TITLE
Add man pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,6 +804,36 @@ jobs:
       - name: rustfmt
         run: cargo fmt --check
 
+  man-lint:
+    name: Lint (man pages)
+    needs: gate
+    if: ${{ !cancelled() && (needs.gate.result != 'success' || needs.gate.outputs.run == 'true') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Install mandoc
+        run: |
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends mandoc
+      - name: mandoc -T lint
+        run: |
+          # The gate: WARNING and up fail via exit status alone -- no output parsing, so
+          # a change in message wording can never mask a real finding.
+          mandoc -T lint -W warning man/*
+          # The polish layer: STYLE findings, minus the cross-reference notice -- Xr can
+          # only resolve where the pages are installed. Text-matching here risks at most
+          # a missed style nit; the release-time in-VM lint re-checks everything strictly.
+          out=$(mandoc -T lint man/* 2>&1 | grep '^mandoc: man/' | grep -v 'STYLE: referenced manual not found') || true
+          if [ -n "$out" ]; then
+            echo "$out"
+            exit 1
+          fi
+
   # A single aggregate status check: green only when every job above is green (or was legitimately skipped
   # by `gate` because this tree already passed CI). Make THIS the sole required check in branch protection --
   # then adding, renaming, or removing a job never means editing the required-checks list; its `needs` below
@@ -813,7 +843,7 @@ jobs:
   success:
     name: Success
     if: ${{ !cancelled() }}
-    needs: [gate, fmt, lint, test, freebsd-tests, docker-e2e, native-e2e, freebsd-native-e2e, miri, freebsd-port-check, freebsd-port-build, valgrind-test, valgrind-e2e]
+    needs: [gate, fmt, man-lint, lint, test, freebsd-tests, docker-e2e, native-e2e, freebsd-native-e2e, miri, freebsd-port-check, freebsd-port-build, valgrind-test, valgrind-e2e]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ It reflects four link-local protocols and layers an optional DIAL proxy on top o
   clients on one segment can discover responders on the other.
 - **SSDP (UPnP/DLNA)**: discovery traffic is relayed both ways, so a caster on one segment can find
   renderers (TVs, media servers) on the other.
-- **DIAL proxy** *(optional, builds on SSDP)*: a "cast to TV" device serves its REST API only to its
-  own subnet; the proxy bridges that gap so a client on the other segment can launch apps on it. It's
+- **DIAL proxy** *(optional, builds on SSDP)*: a "cast to TV" device's REST API lives on its own
+  segment, often unreachable from the client's (and some TVs refuse off-subnet clients); the proxy
+  bridges that gap so a client on the other segment can launch apps on it. It's
   not a separate reflector; it augments an SSDP entry, enabled with `dial = true`. See [DIAL](#dial).
 - **WS-Discovery (WSD)**: SOAP-over-UDP discovery is relayed both ways, so a client on one segment can
   discover ONVIF cameras or Windows devices (printers, scanners) on the other.
@@ -397,9 +398,11 @@ device/printer discovery across segments.
 ### DIAL
 
 DIAL (DIscovery And Launch, the protocol behind "cast to TV" for YouTube, Netflix, etc.) lets a phone
-or laptop find a smart TV and launch an app on it. The catch: a DIAL device restricts its description
-and REST endpoints to its **own subnet**, so a client on a different segment discovers the device but
-cannot drive it. Setting `dial = true` on an SSDP entry makes netflector bridge that gap.
+or laptop find a smart TV and launch an app on it. The catch: the device's description and REST
+endpoints live at its address on the **other segment**, which the client often cannot reach, and some
+devices refuse off-subnet clients outright (the DIAL spec doesn't require that, but Chromecast and
+some Samsung TVs do it). Either way a client on a different segment discovers the device but cannot
+drive it. Setting `dial = true` on an SSDP entry makes netflector bridge that gap.
 
 It is a **terminating HTTP reverse proxy**. When a DIAL `LOCATION` (in a relayed `NOTIFY` or `M-SEARCH`
 `200 OK`) crosses target→source, netflector mints a per-device ephemeral TCP listener on

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -1,0 +1,162 @@
+.Dd July 18, 2026
+.Dt NETFLECTOR 8
+.Os
+.Sh NAME
+.Nm netflector
+.Nd reflect link-local service-discovery traffic between two interfaces
+.Sh SYNOPSIS
+.Nm
+.Op Fl -check-config
+.Op Fl -
+.Op Ar config
+.Nm
+.Fl V | Fl -version
+.Nm
+.Fl h | Fl -help
+.Sh DESCRIPTION
+.Nm
+relays link-local service-discovery traffic between two network interfaces:
+clients on the source interface discover, wake, and reach devices on the
+target interface, not the other way around.
+It reflects Wake-on-LAN, mDNS, SSDP, WS-Discovery, and DIAL; each is enabled
+per interface pair in the configuration.
+.Pp
+The daemon runs in the foreground and logs to standard error with UTC
+timestamps.
+It opens raw captures on the configured interfaces, so it normally runs as
+root.
+.Pp
+.Nm
+adapts to interface changes at runtime, with no restart needed.
+Reflection for an address family pauses while a required address is missing
+and resumes when it returns; an interface that is destroyed and recreated is
+picked up again under its new kernel identity.
+.Pp
+Configuration comes from a TOML file, from
+.Ev NETFLECTOR_ Ns *
+environment variables, or from both; see
+.Xr netflector.toml 5 .
+Given a
+.Ar config
+file,
+.Nm
+reads it and merges any environment variables on top of it.
+Given no configuration file, the environment is the whole configuration.
+.Ss Options
+.Bl -tag -width Ds
+.It Fl -check-config
+Load and validate the configuration, then exit.
+This parses only: it opens no interface, so it needs no privileges and cannot
+report that an interface is missing or unreachable.
+On success it prints
+.Ql config ok: N reflector(s)
+and exits 0; on a rejected configuration it prints the reason and exits 1.
+.It Fl V , Fl -version
+Print the version and exit.
+.It Fl h , Fl -help
+Print a usage summary and exit.
+.El
+.Pp
+.Fl -help
+and
+.Fl -version
+are answered before anything else on the command line.
+A lone
+.Ql -
+is read as a path, not an option.
+.Fl -
+ends option parsing, so a configuration file whose name begins with a dash
+stays reachable:
+.Ql netflector \-\- \-\-check-config
+reads a file named
+.Pa \-\-check-config .
+.Sh SIGNALS
+.Bl -tag -width "SIGTERM"
+.It Dv SIGINT , Dv SIGTERM
+Shut down gracefully.
+.It Dv SIGUSR1
+Dump diagnostics to the log: the per-interface packet counters
+.Pq see Sx DIAGNOSTICS
+and a memory report (current and peak RSS).
+This works on demand even when the periodic reports are disabled.
+.El
+.Sh ENVIRONMENT
+Every setting has an environment-variable form, named
+.Ev NETFLECTOR_ Ns Ao Ar TAG Ac Ns _ Ns Ao Ar PARAM Ac ,
+plus the globals
+.Ev NETFLECTOR_LOG_LEVEL ,
+.Ev NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS ,
+and
+.Ev NETFLECTOR_COUNTERS_INTERVAL_SECS .
+.Xr netflector.toml 5
+documents the grammar and the file/environment merge.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa /usr/local/etc/netflector.toml
+Configuration file the
+.Xr rc 8
+service reads by default.
+.Nm
+itself has no built-in path; the service supplies one.
+.El
+.Sh EXIT STATUS
+.Ex -std
+The error is reported through the log, so
+.Ql log_level = \&"off\&"
+silences even the failure message.
+.Sh EXAMPLES
+Validate a configuration without starting the daemon:
+.Pp
+.Dl netflector --check-config /usr/local/etc/netflector.toml
+.Pp
+Reflect mDNS between two interfaces, configured from the environment alone:
+.Bd -literal -offset indent
+NETFLECTOR_TV_SOURCE_IF=em0 \e
+NETFLECTOR_TV_TARGET_IF=em1 \e
+NETFLECTOR_TV_MDNS=true \e
+netflector
+.Ed
+.Pp
+Enable and start the service:
+.Bd -literal -offset indent
+sysrc netflector_enable=YES
+service netflector start
+.Ed
+.Pp
+The service reads
+.Va netflector_config
+from
+.Xr rc.conf 5
+for the configuration path.
+.Sh DIAGNOSTICS
+The counter summary, logged periodically when enabled and on
+.Dv SIGUSR1 ,
+tallies per interface what happened to each packet, by message type
+.Pq e.g. Ql mDNS query reflected=42 skipped=10; filtered=2 :
+.Bl -tag -width "recoveries"
+.It Sy reflected
+Re-emitted on the other interface.
+.It Sy skipped
+Recognized, but arrived in a direction the entry does not relay.
+This is normal; it is also what keeps reflected packets from looping.
+.It Sy dropped
+Should have been reflected, but the re-emit failed: a send error or a
+resource cap.
+.It Sy stalled
+Should have been reflected, but the egress interface had no source address
+of the packet's family yet.
+.It Sy filtered
+Not a message
+.Nm
+handles: unrecognized traffic on the group, or an address family the entry
+does not cover.
+.It Sy recoveries
+Times the interface was destroyed and recreated, and its capture re-bound.
+.El
+.Sh SEE ALSO
+.Xr netflector.toml 5 ,
+.Xr rc.conf 5 ,
+.Xr daemon 8 ,
+.Xr service 8
+.Sh AUTHORS
+.An Sergii Bogomolov

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -1,0 +1,225 @@
+.Dd July 18, 2026
+.Dt NETFLECTOR.TOML 5
+.Os
+.Sh NAME
+.Nm netflector.toml
+.Nd configuration file for netflector
+.Sh DESCRIPTION
+The configuration for
+.Xr netflector 8
+is TOML: optional top-level settings and at least one reflector entry.
+Every setting has an environment-variable form as well
+.Pq see Sx ENVIRONMENT ;
+the file is optional when the environment carries the whole configuration.
+.Pp
+A reflector entry is a table under
+.Ic reflectors ,
+keyed by a name used as its label in the log
+.Pq Ic \&[reflectors\&. Ns Ar name Ns Ic \&] .
+Each entry exposes the devices on its
+.Ic target_if
+to the clients on its
+.Ic source_if ,
+for any combination of the protocols; the other direction is not exposed.
+No IP addresses appear anywhere in the configuration; interfaces are named,
+and their addresses are resolved at runtime.
+An unknown key, at the top level or in an entry, is rejected at startup.
+.Ss Top-level settings
+.Bl -tag -width Ds
+.It Ic log_level
+Log verbosity, one of
+.Cm off , error , warning , info , debug ,
+or
+.Cm trace .
+Default
+.Cm info .
+.It Ic debug_memory_interval_secs
+Seconds between memory (RSS and peak) diagnostic reports.
+.Cm 0
+or absent disables them.
+Default
+.Cm 0 .
+.It Ic counters_interval_secs
+Seconds between per-interface packet-counter summaries.
+.Cm 0
+or absent disables them.
+Default
+.Cm 0 .
+.El
+.Pp
+Both intervals are capped at one year; a larger value is rejected at startup.
+.Ss Reflector entry
+Keys under
+.Ic \&[reflectors\&. Ns Ar name Ns Ic \&] :
+.Bl -tag -width Ds
+.It Ic source_if
+The interface the clients are on.
+Required; must differ from
+.Ic target_if .
+.It Ic target_if
+The interface the devices are on.
+Required.
+.It Ic macs
+Optional list of MAC addresses limiting the entry to specific devices on
+.Ic target_if :
+only the listed devices are reflected or woken, across every protocol the
+entry enables.
+Omit it to cover the whole segment.
+An empty list is rejected.
+.It Ic address_family
+.Cm default
+(the default) attempts both families, requires IPv4, and treats IPv6 as
+best-effort;
+.Cm dual
+requires both;
+.Cm ipv4
+and
+.Cm ipv6
+use one family only.
+A required family that cannot be initialized fails startup; a best-effort
+one is skipped and the entry runs on the family it has.
+.It Ic wol
+Enable Wake-on-LAN reflection.
+Boolean, default
+.Cm false .
+.It Ic wol_ports
+UDP ports to match Wake-on-LAN magic packets on.
+A list of unique ports in the range 1 to 65535, default
+.Bq Cm 7 , 9 .
+Valid only when
+.Ic wol
+is enabled.
+.It Ic mdns
+Enable mDNS reflection.
+Boolean, default
+.Cm false .
+.It Ic ssdp
+Enable SSDP reflection.
+Boolean, default
+.Cm false .
+.It Ic dial
+Enable the DIAL application proxy.
+Boolean, default
+.Cm false .
+DIAL (Discovery and Launch, the protocol behind
+.Dq cast to TV )
+lets a client find a smart TV and launch an app on it.
+Reflected discovery alone is often not enough to drive the TV: the follow-up
+HTTP requests go to the TV's address on the other segment, which the client
+may not be able to reach, and some TVs refuse off-subnet clients outright.
+.Ic dial
+closes that gap by proxying those requests between the segments.
+Requires
+.Ic ssdp
+and, because the DIAL protocol itself is IPv4-only, an IPv4-capable
+.Ic address_family :
+an
+.Cm ipv6 Ns -only
+entry with
+.Ic dial
+is rejected at startup.
+.It Ic wsd
+Enable WS-Discovery reflection.
+Boolean, default
+.Cm false .
+.El
+.Pp
+An entry must enable at least one protocol.
+.Sh ENVIRONMENT
+Every setting can come from the environment, which suits containers.
+Variables are named
+.Ev NETFLECTOR_ Ns Ao Ar TAG Ac Ns _ Ns Ao Ar PARAM Ac :
+.Bl -tag -width Ds
+.It Aq Ar TAG
+Ties one entry's parameters together: any alphanumeric string.
+It also becomes the entry's name unless a
+.Ic NAME
+parameter overrides it.
+.It Aq Ar PARAM
+.Ic NAME ,
+or any entry field:
+.Ic SOURCE_IF , TARGET_IF , MACS , WOL , MDNS , SSDP , WSD , DIAL ,
+.Ic WOL_PORTS , ADDRESS_FAMILY .
+Case-insensitive.
+.El
+.Pp
+The globals are
+.Ev NETFLECTOR_LOG_LEVEL ,
+.Ev NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS ,
+and
+.Ev NETFLECTOR_COUNTERS_INTERVAL_SECS ,
+so
+.Cm LOG , DEBUG ,
+and
+.Cm COUNTERS
+are reserved tags.
+Booleans are
+.Cm true Ns / Ns Cm false
+or
+.Cm 1 Ns / Ns Cm 0 ;
+.Ic MACS
+and
+.Ic WOL_PORTS
+are comma-separated.
+An unknown parameter, a non-alphanumeric or reserved tag, and a tag with no
+parameter are all rejected at startup.
+.Pp
+When a file and the environment are both present they merge into one
+configuration.
+Each global variable overrides its file counterpart; entries from each source
+are combined, and
+.Sx DUPLICATE DETECTION
+applies across both.
+.Sh DUPLICATE DETECTION
+Entry names must be unique across the file and the environment; a name that
+appears twice, including the same name from both sources, is rejected at
+startup.
+.Pp
+Beyond names, two entries that enable the same protocol are rejected only when
+they could reflect the same packet twice: same
+.Ic source_if ,
+same
+.Ic target_if ,
+overlapping MAC selection, overlapping address-family handling, and, for
+Wake-on-LAN, at least one shared port.
+MAC selection overlaps when the allow-sets share a device or either entry omits
+its filter.
+Address families overlap when both handle the same IP version:
+.Cm ipv4 Ns -only
+and
+.Cm ipv6 Ns -only
+never overlap, while
+.Cm default
+and
+.Cm dual
+overlap with either.
+Entries that differ in interface, MAC, address family, or Wake-on-LAN ports, or
+that enable different protocols, coexist.
+.Sh EXAMPLES
+One interface pair scoped to a single TV, reflecting several protocols:
+.Bd -literal -offset indent
+log_level = "info"
+
+[reflectors.tv]
+source_if = "em0"
+target_if = "em1"
+macs      = ["B0:37:95:C5:60:BE"]
+wol       = true
+mdns      = true
+ssdp      = true
+dial      = true
+.Ed
+.Pp
+The same entry in the environment:
+.Bd -literal -offset indent
+NETFLECTOR_LOG_LEVEL=info
+NETFLECTOR_TV_SOURCE_IF=em0
+NETFLECTOR_TV_TARGET_IF=em1
+NETFLECTOR_TV_MACS=B0:37:95:C5:60:BE
+NETFLECTOR_TV_WOL=true
+NETFLECTOR_TV_MDNS=true
+NETFLECTOR_TV_SSDP=true
+NETFLECTOR_TV_DIAL=true
+.Ed
+.Sh SEE ALSO
+.Xr netflector 8


### PR DESCRIPTION
netflector(8) and netflector.toml(5), hand-written mdoc under `man/`, shared source for the FreeBSD port and future Linux packages (groff renders mdoc out of the box; macOS man is mandoc). The daemon page covers options, signals, counter semantics, and exit status; the config page covers the keys with their constraints and defaults, the environment grammar, and the merge/rejection rules, sshd_config-style. Also corrects the README's DIAL same-subnet claim (the spec mandates no IP restriction; unreachability plus vendor-specific refusals are the real story) and adds a mandoc lint step to the Format job.

The port installs the pages at the next release re-pin: the port builds the tagged tarball, which gains `man/` only at v0.13.2. That PR also adds a strict in-VM lint of the installed pages (both on the manpath there, so the cross-reference check resolves with no filtering).

## Testing

`mandoc -T lint` clean on both pages (only the sibling-not-installed cross-reference notice, filtered in CI for that reason). Rendered output reviewed via `man ./man/...` and `mandoc -T html`. Every documented flag, key, default, signal, and counter label checked against the source.
