### PR TITLE
Publish packages to the pkg repository

### DIFF
--- a/.github/workflows/build-daemon-pkgs.yml
+++ b/.github/workflows/build-daemon-pkgs.yml
@@ -1,0 +1,76 @@
+# The heavy half of a daemon publish: build the port's package for every ABI the
+# pkg repository serves. Called by publish-daemon.yml on every port change and by
+# publish-plugin.yml when the tag pins a daemon newer than anything published (a
+# pair publish). One artifact per ABI: daemon-pkg-freebsd-<major>-<arch>.
+name: Build daemon packages
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Package (freebsd${{ matrix.os }}-${{ matrix.arch.name }})
+    runs-on: ubuntu-24.04
+    # KVM lanes take ~7 minutes. The arm64 guests have no KVM on any GitHub
+    # runner, so rustc runs under TCG emulation; the budget is a guess until
+    # the first runs calibrate it.
+    timeout-minutes: ${{ matrix.arch.kvm && 40 || 360 }}
+    env:
+      FREEBSD_VM_ARCH: ${{ matrix.arch.name }}
+      FREEBSD_VM_VERSION: ${{ matrix.os }}
+    strategy:
+      # A publish is all-or-nothing: one failed ABI cancels the rest, and the
+      # deploy tail never runs.
+      fail-fast: true
+      matrix:
+        os: [14, 15]
+        # name is FreeBSD's platform name (MACHINE, what freebsd-vm.sh speaks);
+        # abi is the processor name (MACHINE_ARCH, what pkg ABI strings use).
+        arch:
+          - { name: amd64, abi: amd64, kvm: true, packages: qemu-system-x86 }
+          - { name: arm64, abi: aarch64, kvm: false, packages: qemu-system-arm qemu-efi-aarch64 }
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install QEMU
+        run: |
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends qemu-utils genisoimage ${{ matrix.arch.packages }}
+      # /dev/kvm exists on the runner but is root:kvm 0660; GitHub's documented udev recipe opens it
+      # (a group add wouldn't apply to the already-running session).
+      - name: Enable KVM
+        if: matrix.arch.kvm
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Launch the FreeBSD VM
+        run: ci/freebsd-vm.sh launch
+      - name: Wait for the VM
+        run: ci/freebsd-vm.sh wait
+      - name: Ports tree, pinned to the commit our packages were built from
+        run: ci/freebsd-ports-tree.sh
+      - name: Build the package
+        run: |
+          ci/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
+          ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make package'
+      - name: Fetch the package
+        run: |
+          mkdir out
+          ci/freebsd-vm.sh pull '/usr/ports/net/netflector/work/pkg/*.pkg' out/
+          ls -l out/
+      - name: Upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: daemon-pkg-freebsd-${{ matrix.os }}-${{ matrix.arch.abi }}
+          path: out/*.pkg
+          if-no-files-found: error
+      - name: Console on failure
+        if: failure()
+        run: ci/freebsd-vm.sh console

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,21 +302,7 @@ jobs:
       - name: Wait for the VM
         run: ci/freebsd-vm.sh wait
       - name: Ports tree, pinned to the commit our packages were built from
-        # shellcheck disable=SC2016  # the single quotes are the point: $hash expands in the guest
-        run: |
-          ci/freebsd-vm.sh run 'pkg install -y git rust ports-mgmt/portlint'
-          ci/freebsd-vm.sh run '
-            set -e
-            hash=$(pkg info -A rust | sed -n "s/.*ports_top_git_hash:[[:space:]]*//p")
-            [ -n "$hash" ] || { echo "rust package records no ports_top_git_hash"; exit 1; }
-            echo "ports tree at $hash (the commit our rust package was built from)"
-            mkdir -p /usr/ports && cd /usr/ports
-            git init -q .
-            git remote add origin https://git.FreeBSD.org/ports.git
-            git fetch -q --depth 1 origin "$hash"
-            git checkout -q FETCH_HEAD
-            [ "$(git rev-parse HEAD)" = "$hash" ] || { echo "tree is not at the pinned commit"; exit 1; }
-          '
+        run: ci/freebsd-ports-tree.sh
       - name: Install the port into the tree
         run: |
           ci/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
@@ -324,6 +310,7 @@ jobs:
           ci/freebsd-vm.sh run 'cd /usr/ports/net && awk "/^ *SUBDIR \+= / && !ins && \$3 > \"netflector\" { print \"    SUBDIR += netflector\"; ins = 1 } { print } END { if (!ins) print \"    SUBDIR += netflector\" }" Makefile > Makefile.new && mv Makefile.new Makefile && grep -n "SUBDIR += netflector" Makefile'
       - name: portlint
         run: |
+          ci/freebsd-vm.sh run 'pkg install -y ports-mgmt/portlint'
           ci/freebsd-vm.sh run 'cd /usr/ports && git add -f net/netflector net/Makefile'
           ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && portlint -AC'
       - name: Build, and run the QA a ports committer runs

--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -1,0 +1,308 @@
+# The shared publish logic: take whatever package artifacts the caller built
+# (daemon set, plugin, or both), advance netflector/pkg by exactly one commit,
+# and let Pages serve it. Trees keep every version ever published -- filenames
+# carry versions, `pkg install netflector` resolves the newest, an explicit
+# netflector-X.Y.Z pins -- so placing packages is add-only. Signing is at the
+# catalogue level: `pkg repo` signs packagesite, which carries every package's
+# SHA256, so one signature per tree covers daemon and plugin alike.
+#
+# The gate runs on real OPNsense, one VM per supported release, each consuming
+# its own ABI tree: opnsense-bootstrap converts the stock FreeBSD VM of the
+# matching major, then the plugin installs from the freshly signed tree and
+# configd renders the config the way a user's firewall would.
+#
+# Serialization note: the pkg-publish concurrency group lives at the TOP level
+# of both caller workflows, not here -- job-level groups cannot stop the
+# stages of two publishes from interleaving.
+name: Publish to the pkg repository
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  sign:
+    name: Place and sign
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: pkg-publish
+    env:
+      FREEBSD_VM_ARCH: amd64
+      FREEBSD_VM_VERSION: '14'
+    outputs:
+      message: ${{ steps.place.outputs.message }}
+      snapshot: ${{ steps.snapshot.outputs.sha }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Check out netflector/pkg
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: netflector/pkg
+          path: pkg-repo
+          persist-credentials: false
+      - name: Record the tree snapshot
+        id: snapshot
+        run: echo "sha=$(git -C pkg-repo rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Download the built packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: incoming
+      - name: Place packages into the ABI trees
+        id: place
+        run: |
+          shopt -s nullglob
+          # Every artifact must hold exactly one package, and all ABIs must
+          # agree on its version: the builds ran from one ref, so a mismatch
+          # means something went badly wrong upstream.
+          one_pkg() {
+            local pkgs=("$1"/*.pkg)
+            if [ ${#pkgs[@]} -ne 1 ]; then
+              echo "expected exactly one package in $1, found ${#pkgs[@]}" >&2
+              return 1
+            fi
+            printf '%s\n' "${pkgs[0]}"
+          }
+          daemon_version=''
+          plugin_version=''
+          for dir in incoming/daemon-pkg-freebsd-*; do
+            pkg=$(one_pkg "$dir")
+            base=${dir##*/daemon-pkg-freebsd-}
+            os=${base%%-*}
+            arch=${base#*-}
+            tree="pkg-repo/opnsense/FreeBSD:${os}:${arch}/latest"
+            mkdir -p "$tree"
+            cp "$pkg" "$tree/"
+            version=$(basename "$pkg" .pkg)
+            version=${version#netflector-}
+            if [ -n "$daemon_version" ] && [ "$version" != "$daemon_version" ]; then
+              echo "daemon version mismatch across ABIs: ${daemon_version} vs ${version}" >&2
+              exit 1
+            fi
+            daemon_version=$version
+          done
+          for dir in incoming/plugin-pkg-freebsd-*; do
+            pkg=$(one_pkg "$dir")
+            os=${dir##*-}
+            for arch in amd64 aarch64; do
+              tree="pkg-repo/opnsense/FreeBSD:${os}:${arch}/latest"
+              mkdir -p "$tree"
+              cp "$pkg" "$tree/"
+            done
+            version=$(basename "$pkg" .pkg)
+            version=${version#os-netflector-}
+            if [ -n "$plugin_version" ] && [ "$version" != "$plugin_version" ]; then
+              echo "plugin version mismatch across majors: ${plugin_version} vs ${version}" >&2
+              exit 1
+            fi
+            plugin_version=$version
+          done
+          if [ -z "${daemon_version}${plugin_version}" ]; then
+            echo "no package artifacts to publish" >&2
+            exit 1
+          fi
+          message=''
+          [ -n "$daemon_version" ] && message="daemon ${daemon_version}"
+          [ -n "$plugin_version" ] && message="${message:+${message} + }plugin ${plugin_version}"
+          echo "message=$message" >> "$GITHUB_OUTPUT"
+      - name: Install QEMU
+        run: |
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86 genisoimage
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Launch the FreeBSD VM
+        run: ci/freebsd-vm.sh launch
+      - name: Wait for the VM
+        run: ci/freebsd-vm.sh wait
+      - name: Sign the catalogues
+        env:
+          PKG_REPO_SIGNING_KEY: ${{ secrets.PKG_REPO_SIGNING_KEY }}
+        run: |
+          umask 077
+          printf '%s\n' "$PKG_REPO_SIGNING_KEY" > repo.key
+          ci/freebsd-vm.sh push repo.key /tmp/repo.key
+          rm repo.key
+          ci/freebsd-vm.sh push pkg-repo/opnsense /repo
+          ci/freebsd-vm.sh run '
+            set -e
+            chmod 400 /tmp/repo.key
+            openssl rsa -in /tmp/repo.key -pubout -out /tmp/repo.pub 2>/dev/null
+            for tree in /repo/FreeBSD:*/latest; do
+              pkg repo "$tree" /tmp/repo.key
+            done
+          '
+      - name: Collect the signed trees
+        run: |
+          mkdir signed
+          ci/freebsd-vm.sh pull /repo signed/opnsense
+          ci/freebsd-vm.sh pull /tmp/repo.pub signed/netflector-pkg.pub
+          # upload-artifact rejects ':' in any file path inside the artifact,
+          # and the tree directories are ABI-named (FreeBSD:14:amd64); a tar
+          # crosses the boundary intact.
+          tar -cf signed-trees.tar -C signed .
+      - name: Upload the signed trees
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signed-trees
+          path: signed-trees.tar
+          if-no-files-found: error
+      - name: Console on failure
+        if: failure()
+        run: ci/freebsd-vm.sh console
+
+  gate:
+    name: Gate on OPNsense ${{ matrix.opnsense }}
+    needs: sign
+    runs-on: ubuntu-24.04
+    # opnsense-bootstrap downloads OPNsense's packages plus base and kernel
+    # sets from their mirrors and reboots into them.
+    timeout-minutes: 60
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - { opnsense: '26.1', os: 14, abi: 'FreeBSD:14:amd64' }
+          - { opnsense: '26.7', os: 15, abi: 'FreeBSD:15:amd64' }
+    env:
+      FREEBSD_VM_ARCH: amd64
+      FREEBSD_VM_VERSION: '${{ matrix.os }}'
+      FREEBSD_VM_EXTRA_NICS: '2'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Download the signed trees
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-trees
+      - name: Unpack the signed trees
+        run: |
+          mkdir signed
+          tar -xf signed-trees.tar -C signed
+      - name: Install QEMU
+        run: |
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86 genisoimage
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Launch the FreeBSD VM
+        run: ci/freebsd-vm.sh launch
+      - name: Wait for the VM
+        run: ci/freebsd-vm.sh wait
+      - name: Convert the VM to OPNsense ${{ matrix.opnsense }}
+        run: |
+          # Seed /conf/config.xml before the conversion reboot: OPNsense
+          # regenerates root's authorized_keys from it on every boot, so
+          # without this the reboot locks us out.
+          b64=$(base64 < "${FREEBSD_VM_DIR:-$HOME/.freebsd-vm}/id_ed25519.pub" | tr -d '\n')
+          sed "s|__SSH_PUBKEY_B64__|$b64|" \
+            dist/opnsense/net/netflector/test/gate-config.xml > config.xml
+          ci/freebsd-vm.sh run 'mkdir -p /conf'
+          ci/freebsd-vm.sh push config.xml /conf/config.xml
+          ci/freebsd-vm.sh run 'fetch -qo /tmp/bootstrap.sh https://raw.githubusercontent.com/opnsense/update/master/src/bootstrap/opnsense-bootstrap.sh.in'
+          # The conversion ends in a reboot that kills the ssh session.
+          ci/freebsd-vm.sh run 'sh /tmp/bootstrap.sh -y -r ${{ matrix.opnsense }}' || true
+          FREEBSD_VM_SSH_WAIT_SECS=900 ci/freebsd-vm.sh wait
+          ci/freebsd-vm.sh run 'opnsense-version'
+      - name: Configure the netflector repository
+        run: |
+          # Only after the conversion: opnsense-bootstrap wipes /usr/local/etc/pkg.
+          ci/freebsd-vm.sh push 'signed/opnsense/${{ matrix.abi }}/latest' /repo
+          ci/freebsd-vm.sh run 'mkdir -p /usr/local/etc/pkg/repos /usr/local/etc/pkg/keys'
+          ci/freebsd-vm.sh push signed/netflector-pkg.pub /usr/local/etc/pkg/keys/netflector-pkg.pub
+          ci/freebsd-vm.sh run '
+            set -e
+            cat > /usr/local/etc/pkg/repos/netflector.conf <<EOF
+          netflector: {
+            url: "file:///repo",
+            signature_type: "pubkey",
+            pubkey: "/usr/local/etc/pkg/keys/netflector-pkg.pub",
+            enabled: yes
+          }
+          EOF
+            pkg update -r netflector
+          '
+      # The full user journey against the exact pair the tree offers: install
+      # the plugin (its OPNsense dependencies come from their mirrors, the
+      # daemon from ours), let real configd render the configuration, have the
+      # daemon validate it, and start the service on the dummy interfaces.
+      - name: Install and exercise the pair
+        run: |
+          ci/freebsd-vm.sh run 'pkg install -y os-netflector'
+          ci/freebsd-vm.sh run 'configctl template reload OPNsense/Netflector'
+          ci/freebsd-vm.sh run 'test -s /usr/local/etc/netflector.toml'
+          ci/freebsd-vm.sh run 'cat /usr/local/etc/netflector.toml'
+          ci/freebsd-vm.sh run 'netflector --check-config /usr/local/etc/netflector.toml'
+          # No sysrc here: the seeded config.xml arms the service through the
+          # plugin's rc.conf.d template, the same path a user's firewall takes
+          # (and /etc/rc.conf.d overrides rc.conf anyway).
+          ci/freebsd-vm.sh run 'service netflector start && sleep 2 && service netflector status'
+      - name: Console on failure
+        if: failure()
+        run: ci/freebsd-vm.sh console
+
+  push:
+    name: Push the snapshot
+    needs: [sign, gate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: pkg-publish
+    steps:
+      # Pinned to the commit sign snapshotted: if anything else lands on
+      # netflector/pkg while the gate runs, the push below is a rejected
+      # non-fast-forward instead of a silent clobber of that commit.
+      - name: Check out netflector/pkg
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: netflector/pkg
+          ref: ${{ needs.sign.outputs.snapshot }}
+          path: pkg-repo
+          ssh-key: ${{ secrets.PKG_REPO_DEPLOY_KEY }}
+      - name: Download the signed trees
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-trees
+      - name: Unpack the signed trees
+        run: |
+          mkdir signed
+          tar -xf signed-trees.tar -C signed
+      # Client bootstrap files at the site root, regenerated every publish so
+      # there is no hand-maintained copy: the public key (derived from the
+      # signing key) and a ready-made repo configuration.
+      - name: Advance the tree
+        run: |
+          rm -rf pkg-repo/opnsense
+          cp -R signed/opnsense pkg-repo/opnsense
+          cp signed/netflector-pkg.pub pkg-repo/netflector-pkg.pub
+          cat > pkg-repo/netflector.conf <<'EOF'
+          netflector: {
+            url: "https://netflector.github.io/pkg/opnsense/${ABI}/latest",
+            signature_type: "pubkey",
+            pubkey: "/usr/local/etc/pkg/keys/netflector-pkg.pub",
+            enabled: yes
+          }
+          EOF
+      - name: Commit and push
+        env:
+          MESSAGE: ${{ needs.sign.outputs.message }}
+        run: |
+          cd pkg-repo
+          git add -A
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "$MESSAGE"
+          git push origin HEAD:main

--- a/.github/workflows/publish-daemon.yml
+++ b/.github/workflows/publish-daemon.yml
@@ -1,0 +1,76 @@
+# Publish the daemon package when the port changes. That is the moment the
+# package definition moves: at release-tag time main's port still pins the
+# previous version (the re-pin PR lands after the tag), and PORTREVISION-only
+# bumps must republish too. The paths: filter is safe here because publish is
+# not a required check; the no-path-filters rule guards ci.yml's Success only.
+name: Publish daemon
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dist/freebsd/net/netflector/**'
+
+# Whole publishes serialize, never partially interleave: with the tail split
+# into sign/gate/push jobs, a job-level group could let two publishes overlap
+# stage-wise and the later push would drop the earlier one's packages.
+# GitHub holds at most ONE pending run per group: a third publish queuing up
+# displaces the pending one, which is cancelled with no failure signal. A
+# displaced run needs a manual "Re-run all jobs" (re-runs keep their original
+# snapshot); nothing re-triggers it, so watch for cancelled runs here.
+concurrency:
+  group: pkg-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ci.yml runs on this same push; wait for it. Nothing broken can publish
+  # without this (the port build and the OPNsense gate fail first), but a red
+  # main should not spend hours of VM time finding that out.
+  verify-ci:
+    permissions:
+      actions: read
+    uses: ./.github/workflows/verify-ci.yml
+
+  guard:
+    name: Skip if this port version is already published
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      publish: ${{ steps.decide.outputs.publish }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Compare the port against the published trees
+        id: decide
+        run: |
+          version=$(sed -n 's/^DISTVERSION=[[:space:]]*//p' dist/freebsd/net/netflector/Makefile)
+          revision=$(sed -n 's/^PORTREVISION=[[:space:]]*//p' dist/freebsd/net/netflector/Makefile)
+          if [ -n "$revision" ] && [ "$revision" != 0 ]; then
+            version="${version}_${revision}"
+          fi
+          git clone -q --depth 1 https://github.com/netflector/pkg pkg-repo
+          if [ -e "pkg-repo/opnsense/FreeBSD:14:amd64/latest/netflector-${version}.pkg" ]; then
+            echo "netflector-${version} is already published; nothing to do."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publishing netflector-${version}"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: [guard, verify-ci]
+    if: needs.guard.outputs.publish == 'true'
+    uses: ./.github/workflows/build-daemon-pkgs.yml
+
+  # If the gate in the tail fails here, the new daemon is incompatible with the
+  # published plugin. That is a signal, not an incident: release a bridge plugin
+  # first when the config change allows one, or tag the new plugin release --
+  # publish-plugin.yml detects the unpublished daemon and carries both out
+  # atomically.
+  deploy:
+    needs: build
+    uses: ./.github/workflows/pkg-deploy.yml
+    secrets: inherit

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -1,0 +1,165 @@
+# Publish the plugin on its release tag. The guard also decides pairing: when
+# the port at the tag pins a daemon that is not yet published (it could not
+# pass its own publish gate against the previous plugin -- a breaking pair --
+# or the repository is empty), this run builds and publishes both from the one
+# tree snapshot the tag names. Whatever lands, the gate validates the newest
+# pair in the tree: the resolution users actually get.
+name: Publish plugin
+
+on:
+  push:
+    tags: ['os-v*']
+
+# Whole publishes serialize, never partially interleave: with the tail split
+# into sign/gate/push jobs, a job-level group could let two publishes overlap
+# stage-wise and the later push would drop the earlier one's packages.
+# GitHub holds at most ONE pending run per group: a third publish queuing up
+# displaces the pending one, which is cancelled with no failure signal. A
+# displaced run needs a manual "Re-run all jobs" (re-runs keep their original
+# snapshot); nothing re-triggers it, so watch for cancelled runs here.
+concurrency:
+  group: pkg-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # os-release.sh waits for CI before pushing the tag; this is the
+  # authoritative re-check, and it covers tags pushed by hand.
+  verify-ci:
+    permissions:
+      actions: read
+    uses: ./.github/workflows/verify-ci.yml
+
+  guard:
+    name: Check the tag and decide pairing
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      pair: ${{ steps.decide.outputs.pair }}
+      port: ${{ steps.decide.outputs.port }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Verify the tag and compare daemon versions
+        id: decide
+        run: |
+          tag='${{ github.ref_name }}'
+          plugin=$(sed -n 's/^PLUGIN_VERSION=[[:space:]]*//p' dist/opnsense/net/netflector/Makefile)
+          if [ "$tag" != "os-v${plugin}" ]; then
+            echo "tag ${tag} does not match PLUGIN_VERSION ${plugin}" >&2
+            exit 1
+          fi
+          port=$(sed -n 's/^DISTVERSION=[[:space:]]*//p' dist/freebsd/net/netflector/Makefile)
+          revision=$(sed -n 's/^PORTREVISION=[[:space:]]*//p' dist/freebsd/net/netflector/Makefile)
+          if [ -n "$revision" ] && [ "$revision" != 0 ]; then
+            port="${port}_${revision}"
+          fi
+          git clone -q --depth 1 https://github.com/netflector/pkg pkg-repo
+          echo "port=${port}" >> "$GITHUB_OUTPUT"
+          if [ -e "pkg-repo/opnsense/FreeBSD:14:amd64/latest/netflector-${port}.pkg" ]; then
+            echo "daemon ${port} is already published; plugin-only publish"
+            echo "pair=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "daemon ${port} is not published; publishing daemon and plugin together"
+            echo "pair=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-plugin:
+    name: Package plugin (freebsd${{ matrix.os }})
+    # On a pair publish the freshly built daemon package satisfies the
+    # plugin's dependency below; build-daemon is skipped on plugin-only
+    # publishes, so run unless something actually failed or was cancelled.
+    needs: [guard, verify-ci, build-daemon]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      FREEBSD_VM_ARCH: amd64
+      FREEBSD_VM_VERSION: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        # One build per FreeBSD major on the matching OPNsense plugins branch;
+        # the package is no-arch (PHP/XML), so it serves every arch tree of
+        # its major.
+        include:
+          - { os: 14, plugins_branch: stable/26.1 }
+          - { os: 15, plugins_branch: stable/26.7 }
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install QEMU
+        run: |
+          # A failing third-party repo (packages.microsoft.com flakes) must not kill the step:
+          # the packages come from the Ubuntu archive, and a broken archive still fails the
+          # install below loudly.
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86 genisoimage
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Launch the FreeBSD VM
+        run: ci/freebsd-vm.sh launch
+      - name: Wait for the VM
+        run: ci/freebsd-vm.sh wait
+      - name: Download the paired daemon package
+        if: needs.guard.outputs.pair == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: daemon-pkg-freebsd-${{ matrix.os }}-amd64
+          path: daemon-pkg
+      # plugins.mk resolves PLUGIN_DEPENDS with `pkg install`, and no repo the
+      # VM knows carries netflector: the daemon must already be installed when
+      # `make package` runs. pkg add, not our published repo: on a pair
+      # publish the pinned daemon is not published yet (publishing it is this
+      # run's job), and on a plugin-only publish `pkg install` would take the
+      # tree's newest, which the port's pin may trail.
+      - name: Install the daemon the plugin depends on
+        run: |
+          if [ '${{ needs.guard.outputs.pair }}' = 'true' ]; then
+            ci/freebsd-vm.sh push daemon-pkg/*.pkg /tmp/netflector.pkg
+            ci/freebsd-vm.sh run 'pkg add /tmp/netflector.pkg'
+          else
+            ci/freebsd-vm.sh run 'pkg add https://netflector.github.io/pkg/opnsense/FreeBSD:${{ matrix.os }}:amd64/latest/netflector-${{ needs.guard.outputs.port }}.pkg'
+          fi
+      - name: Build the plugin package
+        run: |
+          ci/freebsd-vm.sh run 'pkg install -y git'
+          ci/freebsd-vm.sh run 'git clone -q --depth 1 -b ${{ matrix.plugins_branch }} https://github.com/opnsense/plugins /plugins'
+          ci/freebsd-vm.sh push dist/opnsense/net/netflector /plugins/net/netflector
+          ci/freebsd-vm.sh run 'cd /plugins/net/netflector && make package'
+      - name: Fetch the package
+        run: |
+          mkdir out
+          ci/freebsd-vm.sh run 'find /plugins/net/netflector/work -name "*.pkg"'
+          # The package lands in every arch tree of its major, so it must
+          # carry the wildcard ABI (PLUGIN_NO_ABI), not the build host's amd64.
+          ci/freebsd-vm.sh run 'pkg query -F /plugins/net/netflector/work/pkg/*.pkg %q | grep -Fx "FreeBSD:*:*"'
+          ci/freebsd-vm.sh pull '/plugins/net/netflector/work/pkg/*.pkg' out/
+          ls -l out/
+      - name: Upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: plugin-pkg-freebsd-${{ matrix.os }}
+          path: out/*.pkg
+          if-no-files-found: error
+      - name: Console on failure
+        if: failure()
+        run: ci/freebsd-vm.sh console
+
+  build-daemon:
+    needs: [guard, verify-ci]
+    if: needs.guard.outputs.pair == 'true'
+    uses: ./.github/workflows/build-daemon-pkgs.yml
+
+  deploy:
+    needs: [build-plugin, build-daemon]
+    # build-daemon is skipped on plugin-only publishes; run unless something
+    # actually failed or was cancelled.
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/pkg-deploy.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - variant: linux-amd64
@@ -192,7 +192,7 @@ jobs:
       contents: read
       packages: write
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - arch: amd64
@@ -253,10 +253,31 @@ jobs:
     needs: image
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    outputs:
+      latest: ${{ steps.ord.outputs.latest }}
     permissions:
       contents: read
       packages: write
     steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-tags: true
+
+      # Everything else in a release is per-tag, but `latest` and the
+      # major.minor image tag are shared state: only the run for the newest
+      # tag (of the repo, and of its patch line) may move them, or an older
+      # run finishing late drags them backwards. A concurrency group would
+      # not do: it holds one pending run at most, so a third tag pushed
+      # while one builds silently cancels the second's release.
+      - name: Which shared tags may move
+        id: ord
+        run: |
+          newest=$(git tag --list 'v*' --sort=-v:refname | head -1)
+          line=$(git tag --list "${GITHUB_REF_NAME%.*}.*" --sort=-v:refname | head -1)
+          echo "latest=$([ "$GITHUB_REF_NAME" = "$newest" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "minor=$([ "$GITHUB_REF_NAME" = "$line" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -281,8 +302,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=semver,pattern={{major}}.{{minor}},enable=${{ steps.ord.outputs.minor }}
+            type=raw,value=latest,enable=${{ steps.ord.outputs.latest }}
+          # The default latest=auto emits :latest from the {{version}} entry,
+          # bypassing the gate on the raw entry above.
+          flavor: |
+            latest=false
 
       - name: Create and push the manifest list
         working-directory: /tmp/digests
@@ -330,3 +355,6 @@ jobs:
             dist/SHA256SUMS
           generate_release_notes: true
           fail_on_unmatched_files: true
+          # The API default (true for new releases) would let an old tag's run
+          # finishing late steal the Latest marker; same predicate as :latest.
+          make_latest: ${{ needs.manifest.outputs.latest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,21 +11,15 @@ permissions:
   contents: read
 
 jobs:
-  # Fail fast on a version mismatch before the (possibly long) CI wait: check the tag matches the project
-  # version first, then gate the release on ci.yml being green for this commit (poll it, waiting if the tag
-  # was pushed before CI finished).
-  verify-ci:
-    name: Verify CI + tag check
+  # A version tag must match the [package] version in Cargo.toml, so the git tag, the published image,
+  # and the GitHub release name can never disagree. Fails within a minute while verify-ci still waits.
+  tag-check:
+    name: Tag matches Cargo.toml
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    permissions:
-      actions: read
+    timeout-minutes: 5
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      # A version tag must match the [package] version in Cargo.toml, so the git tag, the published image,
-      # and the GitHub release name can never disagree.
       - name: Verify tag matches Cargo.toml version
         run: |
           version="$(./version.sh)"
@@ -36,27 +30,12 @@ jobs:
           fi
           echo "Tag ${GITHUB_REF_NAME} matches Cargo.toml version ${version}."
 
-      - name: Wait for CI to pass on this commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sha='${{ github.sha }}'
-          wf=ci.yml
-          ok=
-          for _ in $(seq 1 90); do  # job timeout-minutes is the real ceiling
-            run=$(gh api "repos/${{ github.repository }}/actions/workflows/$wf/runs?head_sha=$sha&per_page=1" \
-              --jq '.workflow_runs[0] | "\(.status)|\(.conclusion // "")"')
-            case "${run%%|*}" in
-              completed)
-                if [ "${run##*|}" = success ]; then ok=1; break; fi
-                echo "::error::$wf concluded '${run##*|}' on $sha"; exit 1 ;;
-              "") echo "No $wf run for $sha yet; waiting..." ;;
-              *)  echo "$wf is '${run%%|*}'; waiting..." ;;
-            esac
-            sleep 20
-          done
-          [ -n "$ok" ] || { echo "::error::Timed out waiting for $wf on $sha"; exit 1; }
-          echo "$wf passed on $sha."
+  # Gate the release on ci.yml being green for this commit (poll it, waiting if the tag was pushed
+  # before CI finished).
+  verify-ci:
+    permissions:
+      actions: read
+    uses: ./.github/workflows/verify-ci.yml
 
   # Downloadable binaries, built with rustc's default toolchain wherever one exists: amd64 and
   # arm64 are static musl on their native runners (the self-contained default, gcc-driven link),
@@ -66,7 +45,7 @@ jobs:
   # freebsd-arm64 on the pinned nightly from ci/freebsd-nightly.env until stable 1.98 ships its std).
   binaries:
     name: Binary (${{ matrix.variant }})
-    needs: verify-ci
+    needs: [tag-check, verify-ci]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -206,7 +185,7 @@ jobs:
   # the arm32 pair, which have no native runner and cross-compile on the amd64 host (no QEMU).
   image:
     name: Image (${{ matrix.arch }})
-    needs: verify-ci
+    needs: [tag-check, verify-ci]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/verify-ci.yml
+++ b/.github/workflows/verify-ci.yml
@@ -1,0 +1,40 @@
+# Wait for ci.yml to succeed on the commit the caller runs for. The release
+# scripts gate on CI locally before pushing their tag; this is the
+# authoritative re-check, and it also covers tags pushed by hand.
+name: Verify CI
+
+on:
+  workflow_call:
+
+permissions:
+  actions: read
+
+jobs:
+  verify:
+    name: Wait for CI on this commit
+    runs-on: ubuntu-24.04
+    # A publish triggered by a push waits out the full CI run, not just the
+    # usually-short tail release tags see.
+    timeout-minutes: 45
+    steps:
+      - name: Wait for CI to pass on this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha='${{ github.sha }}'
+          wf=ci.yml
+          ok=
+          for _ in $(seq 1 135); do  # job timeout-minutes is the real ceiling
+            run=$(gh api "repos/${{ github.repository }}/actions/workflows/$wf/runs?head_sha=$sha&per_page=1" \
+              --jq '.workflow_runs[0] | "\(.status)|\(.conclusion // "")"')
+            case "${run%%|*}" in
+              completed)
+                if [ "${run##*|}" = success ]; then ok=1; break; fi
+                echo "::error::$wf concluded '${run##*|}' on $sha"; exit 1 ;;
+              "") echo "No $wf run for $sha yet; waiting..." ;;
+              *)  echo "$wf is '${run%%|*}'; waiting..." ;;
+            esac
+            sleep 20
+          done
+          [ -n "$ok" ] || { echo "::error::Timed out waiting for $wf on $sha"; exit 1; }
+          echo "$wf passed on $sha."

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ these. The same shape serves one or a few specific devices (`macs`) or a whole n
 
 - [Platform support](#platform-support)
 - [Build](#build)
-- [Run](#run): [privileges](#runtime-privileges), [Docker](#run-in-docker), [MikroTik](#on-mikrotik-routeros)
+- [Run](#run): [privileges](#runtime-privileges), [Docker](#run-in-docker), [MikroTik](#on-mikrotik-routeros), [FreeBSD/OPNsense packages](#install-on-freebsd-and-opnsense)
 - [Configuration](#configuration): [env vars](#environment-variables), [`macs`](#the-macs-field), [`address_family`](#address_family), [per-protocol behavior](#per-protocol-behavior), [DIAL](#dial), [duplicate detection](#duplicate-detection)
 - [Tests](#tests)
 - [Release](#release)
@@ -239,6 +239,34 @@ entry above becomes `NETFLECTOR_TV_SOURCE_IF=veth-lan`, `NETFLECTOR_TV_TARGET_IF
 `/etc/netflector/config.toml` and set that path as the container's command argument. For the RouterOS
 side (enabling container mode, creating the `veth`s, and attaching each to its VLAN), see MikroTik's
 [Container documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/84901929/Container).
+
+### Install on FreeBSD and OPNsense
+
+Signed packages for FreeBSD 14 and 15 (amd64 and aarch64) are served from a
+[package repository](https://github.com/netflector/pkg) built for OPNsense and usable on any FreeBSD.
+Two fetches enable it; the catalogue is signed, and pkg verifies it against the public key on every update:
+
+```sh
+mkdir -p /usr/local/etc/pkg/keys /usr/local/etc/pkg/repos
+fetch -o /usr/local/etc/pkg/keys/netflector-pkg.pub https://netflector.github.io/pkg/netflector-pkg.pub
+fetch -o /usr/local/etc/pkg/repos/netflector.conf https://netflector.github.io/pkg/netflector.conf
+```
+
+On plain FreeBSD, install `netflector` (man pages and the rc service included), write
+`/usr/local/etc/netflector.toml` (netflector.toml(5) documents it), and start:
+
+```sh
+pkg install netflector
+sysrc netflector_enable=YES
+service netflector start
+```
+
+On OPNsense, install the plugin instead. It pulls in the daemon and owns the configuration and the
+service from its GUI page under Services > Netflector:
+
+```sh
+pkg install os-netflector
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -526,6 +526,12 @@ into one manifest), and creates the GitHub release
 with the binaries and their `SHA256SUMS` attached and generated notes. `release.sh` needs only the GitHub
 CLI (`gh`, authenticated) for its CI check; nothing else runs locally.
 
+The OPNsense plugin releases separately: bump `PLUGIN_VERSION` in
+`dist/opnsense/net/netflector/Makefile`, merge, then run `./os-release.sh` from a clean synced `main`.
+It does the same local half and tags `os-v<version>`; the tag hands off to `publish-plugin.yml`, which
+packages the plugin for each supported FreeBSD major (plus the daemon when the version the port pins is
+not yet published) and publishes everything to the [package repository](https://github.com/netflector/pkg).
+
 ## License
 
 Copyright 2026 Sergii Bogomolov.

--- a/ci/freebsd-ports-tree.sh
+++ b/ci/freebsd-ports-tree.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Check out /usr/ports inside the running FreeBSD VM (ci/freebsd-vm.sh env
+# applies), pinned to the commit the VM's binary packages were built from:
+# every official package records it in the ports_top_git_hash annotation, and
+# rust is queried because the port needs it installed anyway. Building against
+# that exact tree matches the framework the packages themselves saw.
+set -euo pipefail
+
+VM="$(dirname "$0")/freebsd-vm.sh"
+
+"$VM" run 'pkg install -y git rust'
+# shellcheck disable=SC2016  # the single quotes are the point: $hash expands in the guest
+"$VM" run '
+    set -e
+    hash=$(pkg info -A rust | sed -n "s/.*ports_top_git_hash:[[:space:]]*//p")
+    [ -n "$hash" ] || { echo "rust package records no ports_top_git_hash"; exit 1; }
+    echo "ports tree at $hash (the commit our rust package was built from)"
+    mkdir -p /usr/ports && cd /usr/ports
+    git init -q .
+    git remote add origin https://git.FreeBSD.org/ports.git
+    git fetch -q --depth 1 origin "$hash"
+    git checkout -q FETCH_HEAD
+    [ "$(git rev-parse HEAD)" = "$hash" ] || { echo "tree is not at the pinned commit"; exit 1; }
+'

--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -11,6 +11,7 @@
 #   ci/freebsd-vm.sh wait      block until root ssh answers
 #   ci/freebsd-vm.sh run CMD   run CMD in the VM as root
 #   ci/freebsd-vm.sh push SRC... DEST   copy files/dirs to DEST in the VM
+#   ci/freebsd-vm.sh pull SRC DEST      copy a file/dir from the VM to DEST
 #   ci/freebsd-vm.sh console   dump the serial console (boot diagnostics)
 #
 # State (disk, seed, per-run ssh key, console log) lives in $FREEBSD_VM_DIR,
@@ -128,6 +129,16 @@ launch() {
         -display none -serial "file:$VM_DIR/console.log"
         -pidfile "$VM_DIR/qemu.pid" -daemonize
     )
+    # FREEBSD_VM_EXTRA_NICS isolated dummy NICs (vtnet1..vtnetN) for tests
+    # that need real capture devices beyond the ssh NIC. restrict=on cuts
+    # them off from the host and each other.
+    nics=${FREEBSD_VM_EXTRA_NICS:-0}
+    i=1
+    while [ "$i" -le "$nics" ]; do
+        common+=(-netdev "user,id=extra$i,restrict=on"
+            -device "virtio-net-pci,netdev=extra$i,romfile=")
+        i=$((i + 1))
+    done
     if [ "$ARCH" = amd64 ]; then
         qemu-system-x86_64 \
             -machine q35 -accel kvm -cpu host \
@@ -190,6 +201,10 @@ push() {
     scp -qr "${SSH_OPTS[@]}" -P "$SSH_PORT" "${@:1:$#-1}" "root@127.0.0.1:${!#}"
 }
 
+pull() {
+    scp -qr "${SSH_OPTS[@]}" -P "$SSH_PORT" "root@127.0.0.1:$1" "$2"
+}
+
 case "${1:-}" in
 launch) launch ;;
 wait) wait_ssh ;;
@@ -201,9 +216,13 @@ push)
     shift
     push "$@"
     ;;
+pull)
+    shift
+    pull "$@"
+    ;;
 console) cat "$VM_DIR/console.log" ;;
 *)
-    echo "usage: $0 launch|wait|run CMD|push SRC... DEST|console" >&2
+    echo "usage: $0 launch|wait|run CMD|push SRC... DEST|pull SRC DEST|console" >&2
     exit 64
     ;;
 esac

--- a/dist/opnsense/net/netflector/Makefile
+++ b/dist/opnsense/net/netflector/Makefile
@@ -4,4 +4,9 @@ PLUGIN_COMMENT=		Reflect link-local service discovery between interfaces
 PLUGIN_MAINTAINER=	sergii@bogomolov.io
 PLUGIN_DEPENDS=		netflector
 
+# One package serves every arch tree (PHP/XML only); without this the
+# build host stamps its own ABI and pkg on any other arch rejects the
+# whole catalogue.
+PLUGIN_NO_ABI=		yes
+
 .include "../../Mk/plugins.mk"

--- a/dist/opnsense/net/netflector/test/gate-config.xml
+++ b/dist/opnsense/net/netflector/test/gate-config.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<!--
+  Seed configuration for the publish gate's OPNsense VM, derived from
+  OPNsense's factory config.xml.sample. Written to /conf/config.xml before
+  opnsense-bootstrap reboots the FreeBSD VM into OPNsense, so the first
+  OPNsense boot comes up with ssh reachable (OPNsense regenerates root's
+  authorized_keys from <authorizedkeys> on every boot; a key written to the
+  filesystem is discarded) and with the Netflector model populated for the
+  template-render and service checks. The packet filter is off: the VM's only
+  ingress is QEMU's ssh port forward, and pf would block it on WAN.
+
+  __SSH_PUBKEY_B64__ is replaced with the base64 of the VM's per-run ssh
+  public key. opt1/opt2 sit on the FREEBSD_VM_EXTRA_NICS dummy devices with
+  static addresses, giving the daemon real capture interfaces with IPv4.
+-->
+<opnsense>
+  <theme>opnsense</theme>
+  <system>
+    <optimization>normal</optimization>
+    <hostname>netflector-gate</hostname>
+    <domain>internal</domain>
+    <dnsallowoverride>1</dnsallowoverride>
+    <disablefilter>1</disablefilter>
+    <group>
+      <name>admins</name>
+      <description>System Administrators</description>
+      <scope>system</scope>
+      <gid>1999</gid>
+      <member>0</member>
+      <priv>page-all</priv>
+    </group>
+    <user>
+      <name>root</name>
+      <descr>System Administrator</descr>
+      <scope>system</scope>
+      <groupname>admins</groupname>
+      <password>$2y$10$YRVoF4SgskIsrXOvOQjGieB9XqHPRra9R7d80B3BZdbY/j21TwBfS</password>
+      <uid>0</uid>
+      <authorizedkeys>__SSH_PUBKEY_B64__</authorizedkeys>
+    </user>
+    <timezone>Etc/UTC</timezone>
+    <webgui>
+      <protocol>https</protocol>
+    </webgui>
+    <usevirtualterminal>1</usevirtualterminal>
+    <disableconsolemenu/>
+    <ipv6allow>1</ipv6allow>
+    <ssh>
+      <enabled>enabled</enabled>
+      <permitrootlogin>1</permitrootlogin>
+      <group>admins</group>
+    </ssh>
+  </system>
+  <interfaces>
+    <wan>
+      <enable>1</enable>
+      <if>vtnet0</if>
+      <ipaddr>dhcp</ipaddr>
+      <subnet/>
+      <gateway/>
+      <dhcphostname/>
+      <media/>
+      <mediaopt/>
+    </wan>
+    <opt1>
+      <enable>1</enable>
+      <descr>SOURCE</descr>
+      <if>vtnet1</if>
+      <ipaddr>10.10.1.1</ipaddr>
+      <subnet>24</subnet>
+      <media/>
+      <mediaopt/>
+    </opt1>
+    <opt2>
+      <enable>1</enable>
+      <descr>TARGET</descr>
+      <if>vtnet2</if>
+      <ipaddr>10.10.2.1</ipaddr>
+      <subnet>24</subnet>
+      <media/>
+      <mediaopt/>
+    </opt2>
+  </interfaces>
+  <nat>
+    <outbound>
+      <mode>automatic</mode>
+    </outbound>
+  </nat>
+  <filter/>
+  <OPNsense>
+    <Netflector>
+      <general>
+        <enabled>1</enabled>
+        <log_level>info</log_level>
+        <counters_interval_secs>60</counters_interval_secs>
+      </general>
+      <reflectors>
+        <reflector uuid="9a1b0c62-4c58-4b2e-9a41-6f2f5d7a0001">
+          <enabled>1</enabled>
+          <name>tv</name>
+          <source_if>opt1</source_if>
+          <target_if>opt2</target_if>
+          <wol>1</wol>
+          <wol_ports>7,9</wol_ports>
+          <mdns>1</mdns>
+          <ssdp>1</ssdp>
+          <dial>1</dial>
+          <wsd>0</wsd>
+          <macs>B0:37:95:C5:60:BE,C4:9D:8F:11:22:33</macs>
+          <address_family>ipv4</address_family>
+        </reflector>
+        <reflector uuid="9a1b0c62-4c58-4b2e-9a41-6f2f5d7a0002">
+          <enabled>1</enabled>
+          <name>cameras</name>
+          <source_if>opt2</source_if>
+          <target_if>opt1</target_if>
+          <wol>0</wol>
+          <wol_ports/>
+          <mdns>0</mdns>
+          <ssdp>0</ssdp>
+          <dial>0</dial>
+          <wsd>1</wsd>
+          <macs/>
+          <address_family>default</address_family>
+        </reflector>
+        <reflector uuid="9a1b0c62-4c58-4b2e-9a41-6f2f5d7a0003">
+          <enabled>0</enabled>
+          <name>off</name>
+          <source_if>opt1</source_if>
+          <target_if>opt2</target_if>
+          <wol>0</wol>
+          <wol_ports/>
+          <mdns>1</mdns>
+          <ssdp>0</ssdp>
+          <dial>0</dial>
+          <wsd>0</wsd>
+          <macs/>
+          <address_family>default</address_family>
+        </reflector>
+      </reflectors>
+    </Netflector>
+  </OPNsense>
+</opnsense>

--- a/os-release.sh
+++ b/os-release.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+# Cut a plugin release. From a clean main in sync with origin/main, this confirms the plugin version,
+# waits for CI (ci.yml) to pass on HEAD, then tags os-v<version> (from PLUGIN_VERSION in the plugin
+# Makefile) and pushes it. Pushing the tag triggers .github/workflows/publish-plugin.yml, which
+# re-checks CI and the tag against PLUGIN_VERSION, packages the plugin for each supported FreeBSD
+# major (and the daemon for all ABIs when the version the port pins is not yet published), signs the
+# trees, gates on real OPNsense, and pushes to netflector/pkg. Requires the gh CLI (authenticated)
+# for the CI check.
+
+cd "$(dirname "$0")"
+. ./release-lib.sh
+
+version=$(sed -n 's/^PLUGIN_VERSION=[[:space:]]*//p' dist/opnsense/net/netflector/Makefile)
+if [ -z "$version" ]; then
+    echo "Could not read PLUGIN_VERSION from dist/opnsense/net/netflector/Makefile." >&2
+    exit 1
+fi
+tag="os-v${version}"
+
+ensure_releasable
+ensure_tag_absent "$tag" "bump PLUGIN_VERSION in the plugin Makefile first"
+wait_for_ci
+confirm_and_push_tag "$tag"
+
+echo "Pushed ${tag}. The publish workflow takes over from here -- it packages the plugin (and the"
+echo "daemon if the pinned version is unpublished), signs, gates on OPNsense, and publishes:"
+echo "  https://github.com/${slug}/actions/workflows/publish-plugin.yml"

--- a/release-lib.sh
+++ b/release-lib.sh
@@ -1,0 +1,81 @@
+# shellcheck shell=sh
+# Shared checks for release.sh and os-release.sh. Sourced, not executed; the
+# callers run `set -eu` and cd to the repo root first.
+
+# Refuse to release from a dirty tree, off main, or out of sync with origin.
+ensure_releasable() {
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Working tree is not clean; commit or stash before releasing." >&2
+        exit 1
+    fi
+
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$branch" != "main" ]; then
+        echo "Releases are cut from main; current branch is \"$branch\"." >&2
+        exit 1
+    fi
+
+    git fetch --quiet origin main
+    if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+        echo "Local main is not in sync with origin/main; push or pull first." >&2
+        exit 1
+    fi
+}
+
+# ensure_tag_absent <tag> <bump hint>: fail if the tag exists locally or on origin.
+ensure_tag_absent() {
+    if git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1 \
+            || git ls-remote --exit-code --tags origin "refs/tags/$1" >/dev/null 2>&1; then
+        echo "Tag $1 already exists; $2." >&2
+        exit 1
+    fi
+}
+
+# Gate on CI being green for HEAD before the irreversible tag push -- the tag-triggered workflows
+# re-check this, but only after the tag is pushed, so bring the check forward. ci.yml runs on the
+# push to main; we poll its run for this commit (~30 min ceiling, matching verify-ci.yml). Sets
+# $slug (owner/repo) for the caller's hand-off message.
+wait_for_ci() {
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "gh CLI is required to verify CI before releasing (install it, or push the tag manually)." >&2
+        exit 1
+    fi
+
+    slug=$(git config --get remote.origin.url | sed -e 's#^.*github\.com[:/]##' -e 's#\.git$##')
+    sha=$(git rev-parse HEAD)
+    echo "Waiting for CI (ci.yml) to pass on ${sha}..."
+    ci_ok=
+    i=0
+    while [ "$i" -lt 90 ]; do
+        i=$((i + 1))
+        run=$(gh api "repos/${slug}/actions/workflows/ci.yml/runs?head_sha=${sha}&per_page=1" \
+            --jq '.workflow_runs[0] | "\(.status)|\(.conclusion // "")"' 2>/dev/null || true)
+        case "${run%%|*}" in
+            completed)
+                if [ "${run##*|}" = success ]; then ci_ok=1; break; fi
+                echo "CI concluded '${run##*|}' on ${sha}; not releasing." >&2
+                exit 1
+                ;;
+            "" | null) echo "  no CI run for ${sha} yet; waiting..." ;;
+            *) echo "  CI is '${run%%|*}'; waiting..." ;;
+        esac
+        sleep 20
+    done
+    [ -n "$ci_ok" ] || { echo "Timed out waiting for CI on ${sha}; not releasing." >&2; exit 1; }
+    echo "CI passed on ${sha}."
+}
+
+# confirm_and_push_tag <tag>: ask, then tag and push. A non-interactive run (no stdin) reads EOF
+# and aborts.
+confirm_and_push_tag() {
+    printf 'Release %s at %s? [y/N] ' "$1" "$(git rev-parse --short HEAD)"
+    if ! read -r answer; then answer=""; fi
+    case "$answer" in
+        y | Y | yes | Yes | YES) ;;
+        *) echo "Aborted." >&2; exit 1 ;;
+    esac
+
+    echo "Tagging and pushing $1..."
+    git tag -a "$1" -m "Release $1"
+    git push origin "$1"
+}

--- a/release.sh
+++ b/release.sh
@@ -10,75 +10,15 @@ set -eu
 # (authenticated) for the CI check.
 
 cd "$(dirname "$0")"
+. ./release-lib.sh
 
 version=$(./version.sh)
 tag="v${version}"
 
-if [ -n "$(git status --porcelain)" ]; then
-    echo "Working tree is not clean; commit or stash before releasing." >&2
-    exit 1
-fi
-
-branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$branch" != "main" ]; then
-    echo "Releases are cut from main; current branch is \"$branch\"." >&2
-    exit 1
-fi
-
-git fetch --quiet origin main
-if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
-    echo "Local main is not in sync with origin/main; push or pull first." >&2
-    exit 1
-fi
-
-if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1 \
-        || git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-    echo "Tag ${tag} already exists; bump the version in Cargo.toml first." >&2
-    exit 1
-fi
-
-# Gate on CI being green for HEAD before the irreversible tag push -- release.yml re-checks this, but only
-# after the tag is pushed, so bring the check forward. ci.yml runs on the push to main; we poll its run for
-# this commit (~30 min ceiling, matching release.yml's verify-ci).
-if ! command -v gh >/dev/null 2>&1; then
-    echo "gh CLI is required to verify CI before releasing (install it, or push ${tag} manually)." >&2
-    exit 1
-fi
-
-slug=$(git config --get remote.origin.url | sed -e 's#^.*github\.com[:/]##' -e 's#\.git$##')
-sha=$(git rev-parse HEAD)
-echo "Waiting for CI (ci.yml) to pass on ${sha}..."
-ci_ok=
-i=0
-while [ "$i" -lt 90 ]; do
-    i=$((i + 1))
-    run=$(gh api "repos/${slug}/actions/workflows/ci.yml/runs?head_sha=${sha}&per_page=1" \
-        --jq '.workflow_runs[0] | "\(.status)|\(.conclusion // "")"' 2>/dev/null || true)
-    case "${run%%|*}" in
-        completed)
-            if [ "${run##*|}" = success ]; then ci_ok=1; break; fi
-            echo "CI concluded '${run##*|}' on ${sha}; not releasing." >&2
-            exit 1
-            ;;
-        "" | null) echo "  no CI run for ${sha} yet; waiting..." ;;
-        *) echo "  CI is '${run%%|*}'; waiting..." ;;
-    esac
-    sleep 20
-done
-[ -n "$ci_ok" ] || { echo "Timed out waiting for CI on ${sha}; not releasing." >&2; exit 1; }
-echo "CI passed on ${sha}."
-
-# Confirm before the irreversible tag push. A non-interactive run (no stdin) reads EOF and aborts.
-printf 'Release %s at %s? [y/N] ' "$tag" "$(git rev-parse --short HEAD)"
-if ! read -r answer; then answer=""; fi
-case "$answer" in
-    y | Y | yes | Yes | YES) ;;
-    *) echo "Aborted." >&2; exit 1 ;;
-esac
-
-echo "Tagging and pushing ${tag}..."
-git tag -a "${tag}" -m "Release ${tag}"
-git push origin "${tag}"
+ensure_releasable
+ensure_tag_absent "$tag" "bump the version in Cargo.toml first"
+wait_for_ci
+confirm_and_push_tag "$tag"
 
 echo "Pushed ${tag}. The release workflow takes over from here -- it re-checks CI, builds the"
 echo "binaries, publishes the image to GHCR, and creates the GitHub release:"


### PR DESCRIPTION
Publish pipeline for [netflector/pkg](https://github.com/netflector/pkg) (served via GitHub Pages):

- **publish-daemon.yml**: a port change on main builds the port for FreeBSD 14/15 x amd64/aarch64 and hands off to the shared tail. Skips when the version is already published.
- **publish-plugin.yml**: an os-v* tag builds the plugin per major (no-arch package, wildcard ABI). When the daemon the port pins is not published yet, it builds and publishes both from the tag's snapshot.
- **pkg-deploy.yml**, the shared tail: place packages into the ABI trees, sign the catalogues in a FreeBSD VM, gate on real OPNsense 26.1 and 26.7 (opnsense-bootstrap converts the FreeBSD VMs; `pkg install os-netflector` from the signed tree, configd renders the config, `netflector --check-config`, service start on dummy NICs), then push one commit to netflector/pkg, pinned to the tree snapshot signing saw.
- **verify-ci.yml**: the CI wait extracted from release.yml; both publish triggers gate on it too, so nothing publishes from a commit whose CI is red (a tag pushed by hand skips the scripts' local wait).
- `os-release.sh` cuts plugin releases (tags `os-v<PLUGIN_VERSION>`); the checks shared with `release.sh` live in `release-lib.sh`.
- release.yml: fail-fast matrices; the latest/major.minor image tags and the GitHub Latest marker move only when the run's tag is the newest of the repo / of its line.
- README: FreeBSD and OPNsense install instructions.

Merging publishes nothing: the publish workflows trigger only on port changes and os-v* tags. The first publish is `./os-release.sh` at plugin 0.1.0, which bootstraps the repository with the daemon+plugin pair.

Testing: the publish workflows cannot run before merge. Two adversarial audit rounds checked them against primary sources (pinned action sources, plugins.mk, pkg and rc.subr behavior, opnsense-bootstrap) with local reproductions where possible (tar artifact round-trip, tag ordering on shallow fetches, the metadata-action bundle executed with gated inputs). ci/freebsd-ports-tree.sh is exercised by this PR's own CI; the release scripts' shared guards were smoke-tested locally. actionlint clean.