### PR TITLE
Give the FreeBSD VMs 8 GB of RAM

### DIFF
--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -119,7 +119,9 @@ launch() {
     # in ipxe-qemu, which qemu-system-arm does not pull in, and these guests
     # only ever boot from disk anyway.
     common=(
-        -smp "$(nproc)" -m 6144
+        # 8 GB: pkg's catalogue processing OOM-killed twice at 6 (the cloud
+        # images carry no swap, so any memory spike kills); runners have 16.
+        -smp "$(nproc)" -m 8192
         # cache=unsafe: flushes become no-ops (UFS journal commits, pkg's per-package
         # fsyncs). The failure mode is a stale image after a HOST crash, and these VMs
         # do not outlive the job.


### PR DESCRIPTION
Both attempts of the os-v0.1.0 publish died the same way: the freebsd14-amd64 daemon build's `pkg update` was OOM-killed during catalogue processing (`swap_pager: out of swap space`, pkg exit 137) about a minute in. The cloud images carry no swap, so the 6 GB ceiling is a hard one; the freebsd15 leg with its split pkgbase catalogues and newer stock pkg processed the same step in seconds. Runners have 16 GB, so 8 for the guest is comfortable everywhere freebsd-vm.sh is used, KVM and TCG alike.

Testing: CI's FreeBSD lanes boot the resized VMs on this PR. The real proof is re-tagging the release after the merge.