### PR TITLE
Unbreak the publish gate on both OPNsense lanes

### DIFF
--- a/.github/workflows/build-daemon-pkgs.yml
+++ b/.github/workflows/build-daemon-pkgs.yml
@@ -31,10 +31,9 @@ jobs:
   package:
     name: Package (freebsd${{ matrix.os }}-${{ matrix.arch.name }})
     runs-on: ubuntu-24.04
-    # KVM lanes take ~7 minutes. The arm64 guests have no KVM on any GitHub
-    # runner, so rustc runs under TCG emulation; the budget is a guess until
-    # the first runs calibrate it.
-    timeout-minutes: ${{ matrix.arch.kvm && 40 || 360 }}
+    # Measured across publish runs: KVM lanes 2-5 minutes, arm64 13-14 (no
+    # GitHub runner offers KVM for aarch64 guests, so rustc runs under TCG).
+    timeout-minutes: ${{ matrix.arch.kvm && 15 || 40 }}
     env:
       FREEBSD_VM_ARCH: ${{ matrix.arch.name }}
       FREEBSD_VM_VERSION: ${{ matrix.os }}-opnsense

--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -26,7 +26,7 @@ jobs:
   sign:
     name: Place and sign
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 15
     environment: pkg-publish
     env:
       FREEBSD_VM_ARCH: amd64
@@ -164,8 +164,9 @@ jobs:
     needs: sign
     runs-on: ubuntu-24.04
     # opnsense-bootstrap downloads OPNsense's packages plus base and kernel
-    # sets from their mirrors and reboots into them.
-    timeout-minutes: 60
+    # sets from their mirrors and reboots into them: measured at ~2 minutes,
+    # and the whole gate at ~3.
+    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -175,7 +175,7 @@ jobs:
           - { opnsense: '26.7', os: 15, abi: 'FreeBSD:15:amd64' }
     env:
       FREEBSD_VM_ARCH: amd64
-      FREEBSD_VM_VERSION: '${{ matrix.os }}'
+      FREEBSD_VM_VERSION: '${{ matrix.os }}-opnsense'
       FREEBSD_VM_EXTRA_NICS: '2'
     steps:
       - name: Check out repository

--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -214,10 +214,43 @@ jobs:
             dist/opnsense/net/netflector/test/gate-config.xml > config.xml
           ci/freebsd-vm.sh run 'mkdir -p /conf'
           ci/freebsd-vm.sh push config.xml /conf/config.xml
-          ci/freebsd-vm.sh run 'fetch -qo /tmp/bootstrap.sh https://raw.githubusercontent.com/opnsense/update/master/src/bootstrap/opnsense-bootstrap.sh.in'
+          # From the series tag, not master: this script is destructive, its
+          # content differs per series, and an unpinned fetch means two runs of
+          # the same tag can convert differently.
+          ci/freebsd-vm.sh run 'fetch -qo /tmp/bootstrap.sh https://raw.githubusercontent.com/opnsense/update/${{ matrix.opnsense }}/src/bootstrap/opnsense-bootstrap.sh.in'
+          # opnsense-bootstrap clears the way with `pkg unlock -ya; pkg delete -fa`,
+          # guarded only by `pkg -N`, and knows nothing about pkgbase. FreeBSD 15
+          # VM images install base as ~500 FreeBSD-* packages, and -f overrides
+          # pkg's vital flag, so on that lane the command deletes the running
+          # userland: FreeBSD-ssh takes /usr/libexec/sshd-session, so the live
+          # sshd accepts TCP and then fatals on every session, and FreeBSD-runtime
+          # takes /bin/rm, so the script dies on its own next line and never
+          # reaches opnsense-update or reboot. FreeBSD 14 images are
+          # installworld-built, base is registered nowhere, and the same command
+          # only reaps the image's couple of ports packages -- which is all this
+          # conversion has ever done on that lane, and the state bootstrap
+          # actually supports. Put a pkgbase guest into it: drop the ports
+          # packages (pkg included, so bootstrap re-bootstraps OPNsense's own),
+          # then remove the database so `pkg -N` fails and the delete is skipped.
+          # Base files stay on disk for OPNsense's base.txz to overwrite.
+          ci/freebsd-vm.sh run '
+            if pkg -N >/dev/null 2>&1 && pkg query %n | grep -qx FreeBSD-runtime; then
+              ports=$(pkg query %n | grep -v "^FreeBSD-") || true
+              if [ -n "$ports" ]; then
+                pkg delete -fy $ports
+              fi
+              rm -rf /var/db/pkg
+              # Upstream guards the delete on `pkg -N` alone; if that ever
+              # changes, fail here rather than losing the base system again.
+              if pkg -N >/dev/null 2>&1; then
+                echo "pkg -N still succeeds; bootstrap would delete the base system" >&2
+                exit 1
+              fi
+            fi
+          '
           # The conversion ends in a reboot that kills the ssh session.
           ci/freebsd-vm.sh run 'sh /tmp/bootstrap.sh -y -r ${{ matrix.opnsense }}' || true
-          FREEBSD_VM_SSH_WAIT_SECS=900 ci/freebsd-vm.sh wait
+          ci/freebsd-vm.sh wait
           ci/freebsd-vm.sh run 'opnsense-version'
       - name: Configure the netflector repository
         run: |

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [guard, verify-ci, build-daemon]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 15
     env:
       FREEBSD_VM_ARCH: amd64
       FREEBSD_VM_VERSION: ${{ matrix.os }}

--- a/dist/freebsd/net/netflector/files/netflector.in
+++ b/dist/freebsd/net/netflector/files/netflector.in
@@ -28,9 +28,11 @@ pidfile="/var/run/${name}.pid"
 procname="%%PREFIX%%/bin/${name}"
 
 # The daemon runs in the foreground and logs to stderr, so daemon(8) backgrounds it and -S routes that
-# stderr into syslog under our own tag rather than /dev/null.
+# stderr into syslog under our own tag rather than /dev/null. -f closes the descriptors daemon(8)
+# inherited: without it the supervisor holds the caller's stdout open for the service's lifetime, so
+# `ssh host service netflector start` never returns. It does not affect -S, which redirects the child.
 command="/usr/sbin/daemon"
-command_args="-S -T ${name} -p ${pidfile} ${procname} ${netflector_config}"
+command_args="-f -S -T ${name} -p ${pidfile} ${procname} ${netflector_config}"
 
 start_precmd="${name}_precmd"
 


### PR DESCRIPTION
Attempt five of the first publish reached the OPNsense gate and both lanes failed, for two unrelated reasons. This fixes both, plus the timeouts now that we have measurements.

**26.1 hung after starting the service.** `daemon(8)` passes `-f` straight to `daemon(3)`'s `noclose`, so without it the supervisor keeps whatever stdout and stderr the caller had for the service's lifetime. The gate's `service netflector start && sleep 2 && service netflector status` printed `netflector is running as pid 52875`, then sat there until fail-fast killed it 13 minutes later: the command had exited but the ssh channel never saw EOF. This also hits users - `ssh firewall service netflector start` never returns - so the fix is in the port's rc script, not the workflow. `-S` is unaffected; it redirects the child, not the supervisor.

**26.7 never came back from the conversion.** `opnsense-bootstrap` clears the way with `pkg unlock -ya; pkg delete -fa`, guarded only by `pkg -N`, and knows nothing about pkgbase. FreeBSD 15 VM images install base as ~500 `FreeBSD-*` packages and `-f` overrides pkg's `vital` flag, so on that lane it deleted the running userland: `FreeBSD-ssh` took `/usr/libexec/sshd-session`, which is why the live sshd accepted TCP and then fatal'd on every session, and `FreeBSD-runtime` took `/bin/rm`, so the script died on its own next line (`rm -rf /var/db/pkg/*`) and never reached `opnsense-update` or the reboot. FreeBSD 14 images are installworld-built, base is registered nowhere, and the same command reaps only the image's couple of ports packages - which is the state bootstrap actually supports. The gate now puts a pkgbase guest into that state before converting, and asserts that upstream's `pkg -N` guard still does what we think.

Also here: the bootstrap fetch is pinned to the series tag instead of `master` (a destructive script whose content differs per series), the gate boots the `-opnsense` base pins like the daemon builds already do, and the post-conversion ssh wait drops its 900s override - the arch default of 300 is ten times the 28s the reboot measured, and the console dump that follows a timeout is what diagnosed this failure anyway.

Timeouts, replacing budgets written before anything had run: amd64 KVM lanes 40 -> 15 (measured 2-5), arm64 TCG 360 -> 40 (13-14), plugin and sign 20 -> 15 (1), gate 60 -> 30 (~3).

Testing: the diagnosis is from the failing run's own logs, and the mechanisms were verified against primary sources (daemon.c, rc.subr, the bootstrap script at each series tag, releng vmimage.subr, the pkgbase catalogue). One assumption is untested by construction: nobody has converted a 15.1 guest with base present on disk but unregistered in pkg. Attempt six is that test - the tell is the delete reporting a handful of ports packages instead of 501, and a second kernel banner on the console.