### PR TITLE
opnsense: multi-value fields, and removing the last reflector

### DIFF
--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -277,6 +277,7 @@ jobs:
       - name: Install and exercise the pair
         run: |
           ci/freebsd-vm.sh run 'pkg install -y os-netflector'
+          ci/freebsd-vm.sh run 'php /usr/local/opnsense/scripts/netflector/modelcheck.php'
           ci/freebsd-vm.sh run 'configctl template reload OPNsense/Netflector'
           ci/freebsd-vm.sh run 'test -s /usr/local/etc/netflector.toml'
           ci/freebsd-vm.sh run 'cat /usr/local/etc/netflector.toml'

--- a/dist/opnsense/net/netflector/Makefile
+++ b/dist/opnsense/net/netflector/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		netflector
-PLUGIN_VERSION=		0.1.0
+PLUGIN_VERSION=		0.1.1
 PLUGIN_COMMENT=		Reflect link-local service discovery between interfaces
 PLUGIN_MAINTAINER=	sergii@bogomolov.io
 PLUGIN_DEPENDS=		netflector

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/ServiceController.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/ServiceController.php
@@ -29,7 +29,6 @@
 namespace OPNsense\Netflector\Api;
 
 use OPNsense\Base\ApiMutableServiceControllerBase;
-use OPNsense\Base\UserException;
 use OPNsense\Core\Backend;
 use OPNsense\Netflector\Netflector;
 
@@ -41,38 +40,11 @@ class ServiceController extends ApiMutableServiceControllerBase
     protected static $internalServiceName = 'netflector';
 
     /**
-     * Refuse to apply a configuration that is switched on with nothing to reflect.
-     *
-     * The model rejects that state too, but the grid's toggle reaches around it: OPNsense's
-     * toggleBase() saves with `$disable_validation = true`, on purpose, so a toggle is never blocked by
-     * validation. Unchecking the last reflector therefore lands in the saved model regardless, and
-     * without this the GUI would go on showing "Enabled" over a daemon that is quietly not running,
-     * because the daemon cannot start with no reflector at all. Apply is the last gate that sees every
-     * path, so it is where this has to be caught.
-     */
-    public function reconfigureAction()
-    {
-        if ($this->request->isPost() && !$this->serviceEnabled()) {
-            $model = new Netflector();
-            if ((string)$model->general->enabled === '1') {
-                throw new UserException(
-                    gettext(
-                        'Enable at least one reflector, or switch Netflector off. ' .
-                        'It cannot run with nothing to reflect.'
-                    ),
-                    gettext('Netflector')
-                );
-            }
-        }
-
-        return parent::reconfigureAction();
-    }
-
-    /**
      * The base class reads a single model path, but the daemon refuses to start with no reflector to
      * run. "Enabled" therefore has to mean the same thing here as in netflector_enabled() and in the
-     * rc.conf.d template: the service switch is on AND at least one entry is on. Without this override
-     * Apply would try to start a daemon whose generated configuration has no reflectors at all.
+     * rc.conf.d template: the service switch is on AND at least one entry is on. That makes Apply stop
+     * the daemon once the last reflector goes, rather than starting one on a configuration it would
+     * reject, and the status widget reports "disabled" for the same reason.
      */
     protected function serviceEnabled()
     {

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/SettingsController.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/SettingsController.php
@@ -73,10 +73,9 @@ class SettingsController extends ApiMutableModelControllerBase
     /**
      * Toggle an entry, validating before the save.
      *
-     * toggleBase() saves with validation disabled, which is fine for most models but not for ours: the
-     * daemon will not run with no reflector at all. Toggling the last one off would persist a config
-     * that can never be applied, and at the next boot the service is left unarmed and the daemon quietly
-     * stops while the GUI still says "Enabled".
+     * toggleBase() saves with validation disabled, which is fine for most models but not for ours:
+     * enabling an entry can collide with an already-active one (same interface pair, overlapping
+     * protocols or devices), and that pair rule lives in the model's validation.
      */
     public function toggleReflectorAction($uuid, $enabled = null)
     {

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
@@ -78,17 +78,10 @@ class Netflector extends BaseModel
             }
         }
 
-        // Switched on with nothing to reflect is a contradiction: the daemon refuses to start with no
-        // reflector at all, so the service is left unarmed and the GUI shows "Enabled" over a daemon
-        // that is quietly not running. Rejecting it here is what makes Save, Apply and Validate agree;
-        // without it, Validate calls this state an error while Apply accepts it without a word.
-        if ((string)$this->general->enabled === '1' && empty($active)) {
-            $messages->appendMessage(new Message(
-                gettext('Enable at least one reflector, or switch Netflector off. It cannot run with nothing to reflect.'),
-                'general.enabled'
-            ));
-        }
-
+        // Nothing enabled is a legal configuration, not an error: the rc.conf.d template arms the
+        // service only when the switch is on AND an entry is on, so Apply stops the daemon and the
+        // status widget reads "disabled". Rejecting it here instead would mean the last reflector
+        // could not be removed without switching the whole service off first.
         return $messages;
     }
 

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
@@ -68,14 +68,14 @@
                     <Required>Y</Required>
                 </wsd>
                 <macs type="MacAddressField">
-                    <Multiple>Y</Multiple>
+                    <AsList>Y</AsList>
                     <ValidationMessage>Enter one or more MAC addresses to scope this reflector to specific devices. Leave empty to reflect for the whole network.</ValidationMessage>
                 </macs>
                 <!-- Not a PortField: that one enumerates all 65535 ports as selectable options, which is
                      right for a firewall rule and absurd here. It made the edit dialog fetch 2.5 MB and
                      hang. CSVListField validates each item against the mask and stores a plain list. -->
                 <wol_ports type="CSVListField">
-                    <Multiple>Y</Multiple>
+                    <MaskPerItem>Y</MaskPerItem>
                     <Mask>/^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/u</Mask>
                     <ValidationMessage>Enter the UDP ports magic packets arrive on, as numbers between 1 and 65535. The daemon defaults to 7 and 9.</ValidationMessage>
                 </wol_ports>

--- a/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/check.py
+++ b/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/check.py
@@ -55,15 +55,6 @@ def report(status, message):
     print(json.dumps({'status': status, 'message': message}))
 
 
-def service_enabled(cnf):
-    node = cnf
-    for key in ('OPNsense', 'Netflector', 'general', 'enabled'):
-        if not isinstance(node, dict) or key not in node:
-            return False
-        node = node[key]
-    return str(node) == '1'
-
-
 def main():
     with tempfile.TemporaryDirectory() as root:
         conf = config.Config(CONFIG_XML)
@@ -81,12 +72,12 @@ def main():
         with open(candidate) as handle:
             generated = handle.read()
 
-        # Switched off with nothing enabled is not a broken configuration, it is an off one, and the
-        # daemon's "must define at least one reflector" is an alarming way to say so. With the service on
-        # it is a real problem, and worth the daemon's own words, though the model refuses to save that
-        # state so it only arrives here from a restored or hand-edited config.
-        if '[reflectors.' not in generated and not service_enabled(cnf):
-            report('idle', 'Nothing to validate (service is switched off, no enabled reflectors)')
+        # Nothing enabled is an off configuration, not a broken one, whichever way the service switch
+        # points: the template arms the daemon only when both are on, so this state stops it rather
+        # than starting it. Handing the file to the daemon anyway would answer with its "must define
+        # at least one reflector", which reads as a fault when nothing is wrong.
+        if '[reflectors.' not in generated:
+            report('idle', 'Nothing to validate (no enabled reflectors, the service will not run)')
             return
 
         proc = subprocess.run(

--- a/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/modelcheck.php
+++ b/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/modelcheck.php
@@ -1,0 +1,128 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Sergii Bogomolov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Two checks against this core's field types, exit 1 on any finding. Nothing
+ * is written: the model instances live in memory only.
+ *
+ * Structural: every tag in the model XML must map to a set<Tag>() method on
+ * its field type. BaseModel drops unknown tags without a word (hasMethod()
+ * filter), so a typo or a guessed name silently disables the option it was
+ * meant to set.
+ *
+ * Behavioural: the multi-value fields must accept lists and still reject bad
+ * items. The structural check cannot see an OMITTED tag (a CSVListField
+ * without MaskPerItem validates "7,9" against the whole-string mask), so the
+ * list handling is exercised for real.
+ */
+
+use OPNsense\Netflector\Netflector;
+
+require_once 'script/load_phalcon.php';
+
+$failures = 0;
+
+function fail(string $message): void
+{
+    global $failures;
+    $failures++;
+    echo 'FAIL: ' . $message . PHP_EOL;
+}
+
+/* structural: no silently ignored model tags */
+$model_xml = '/usr/local/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml';
+$walk = function ($node) use (&$walk) {
+    foreach ($node->children() as $field) {
+        $type = (string)($field->attributes()['type'] ?? '');
+        if ($type === '') {
+            $walk($field);
+            continue;
+        }
+        $cls = str_contains($type, '\\') ? $type : 'OPNsense\\Base\\FieldTypes\\' . $type;
+        if (!class_exists($cls)) {
+            fail(sprintf('%s: field type %s does not exist in this core', $field->getName(), $type));
+            continue;
+        }
+        $rf = new ReflectionClass($cls);
+        foreach ($field->children() as $tag) {
+            $name = $tag->getName();
+            if (($tag->attributes()['type'] ?? null) !== null || $name === 'OptionValues') {
+                continue;
+            }
+            if (!$rf->hasMethod('set' . $name)) {
+                fail(sprintf('%s (%s): <%s> has no set%s(), BaseModel ignores it', $field->getName(), $type, $name, $name));
+            }
+        }
+        $walk($field);
+    }
+};
+$walk(simplexml_load_file($model_xml)->items);
+
+/* behavioural: list fields take lists, bad items still fail */
+function validation_messages(string $macs, string $wol_ports): array
+{
+    $model = new Netflector();
+    $entry = $model->reflectors->reflector->Add();
+    $entry->enabled = '1';
+    $entry->name = 'modelcheck';
+    $entry->wol = '1';
+    $entry->macs = $macs;
+    $entry->wol_ports = $wol_ports;
+    $messages = [];
+    foreach ($model->performValidation() as $message) {
+        $field = $message->getField();
+        /* only the fields under test: the synthetic entry has no interfaces */
+        if (str_ends_with($field, '.macs') || str_ends_with($field, '.wol_ports')) {
+            $messages[] = $field . ': ' . $message->getMessage();
+        }
+    }
+    return $messages;
+}
+
+foreach (
+    [
+        ['aa:bb:cc:dd:ee:ff,11:22:33:44:55:66', '7,9', true],
+        ['aa:bb:cc:dd:ee:ff', '7', true],
+        ['aa:bb:cc:dd:ee:ff,nonsense', '7', false],
+        ['aa:bb:cc:dd:ee:ff', '7,70000', false],
+    ] as [$macs, $wol_ports, $expect_valid]
+) {
+    $messages = validation_messages($macs, $wol_ports);
+    if ($expect_valid && $messages !== []) {
+        fail(sprintf('macs=%s wol_ports=%s rejected: %s', $macs, $wol_ports, implode(' | ', $messages)));
+    } elseif (!$expect_valid && $messages === []) {
+        fail(sprintf('macs=%s wol_ports=%s accepted, expected a validation error', $macs, $wol_ports));
+    }
+}
+
+if ($failures === 0) {
+    echo 'model check ok' . PHP_EOL;
+    exit(0);
+}
+exit(1);

--- a/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/netflector.toml
+++ b/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/netflector.toml
@@ -7,33 +7,25 @@ counters_interval_secs = {{ OPNsense.Netflector.general.counters_interval_secs|d
 {%     if entry.enabled|default('0') == '1' %}
 
 {#     The GUI stores OPNsense's logical names (lan, opt1); the daemon needs the device (vtnet0). #}
+{#     Every switch is written out, false and "default" included: the file states what the GUI
+       showed, so a later change to a daemon default cannot silently flip a plugin user. Only
+       wol_ports and macs may be absent -- there absence is itself the setting (the daemon's
+       default ports; all devices). #}
 [reflectors.{{ entry.name }}]
 source_if = "{{ physical_interface(entry.source_if) }}"
 target_if = "{{ physical_interface(entry.target_if) }}"
-{%       if entry.wol|default('0') == '1' %}
-wol = true
-{%         if entry.wol_ports %}
+wol = {{ 'true' if entry.wol|default('0') == '1' else 'false' }}
+{%       if entry.wol|default('0') == '1' and entry.wol_ports %}
 wol_ports = [{{ entry.wol_ports.split(',') | join(', ') }}]
-{%         endif %}
 {%       endif %}
-{%       if entry.mdns|default('0') == '1' %}
-mdns = true
-{%       endif %}
-{%       if entry.ssdp|default('0') == '1' %}
-ssdp = true
-{%       endif %}
-{%       if entry.dial|default('0') == '1' %}
-dial = true
-{%       endif %}
-{%       if entry.wsd|default('0') == '1' %}
-wsd = true
-{%       endif %}
+mdns = {{ 'true' if entry.mdns|default('0') == '1' else 'false' }}
+ssdp = {{ 'true' if entry.ssdp|default('0') == '1' else 'false' }}
+dial = {{ 'true' if entry.dial|default('0') == '1' else 'false' }}
+wsd = {{ 'true' if entry.wsd|default('0') == '1' else 'false' }}
 {%       if entry.macs %}
 macs = [{% for mac in entry.macs.split(',') %}"{{ mac }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 {%       endif %}
-{%       if entry.address_family and entry.address_family != 'default' %}
-address_family = "{{ entry.address_family }}"
-{%       endif %}
+address_family = "{{ entry.address_family|default('default') }}"
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
The GUI rejected more than one MAC or WoL port per reflector: `<Multiple>` is not a model tag, and BaseModel drops unknown tags silently. `macs` needs `<AsList>`, `wol_ports` needs `<MaskPerItem>`. Stored format unchanged; PLUGIN_VERSION 0.1.1.

New `modelcheck.php`, run by the gate on each series: fails on model tags the core has no setter for, and exercises multi-value validation.

Zero enabled reflectors is now a legal off state instead of an error: Apply stops the daemon, the status widget shows disabled, Validate reports idle. The master checkbox keeps recording intent, so re-enabling a reflector brings the service back. Drops the model rule, the reconfigure override (it threw after delete had already saved, stranding Apply), and check.py's switch-sensitive idle case.

The generated configuration now writes every switch explicitly, false and "default" included, so a later change to a daemon default cannot silently flip a plugin user. Only wol_ports and macs may be absent: there absence is the setting.

Verified on a live OPNsense 26.1 aarch64 install; publishing this exercises the plugin-only path.