### PR TITLE
netlink: bound the address dump's blocking reads

### DIFF
--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -7,6 +7,7 @@ use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::ptr;
+use std::time::{Duration, Instant};
 
 use libc::{c_int, socklen_t};
 
@@ -16,9 +17,17 @@ use crate::libcex::{
     SockAddrNl, nl_align,
 };
 use crate::net::mac::MacAddr;
+use crate::sys::IoStatus;
 
 /// `IFA_F_*` bits that disqualify an address as a source.
 const IFA_F_UNUSABLE: u32 = libc::IFA_F_TENTATIVE | libc::IFA_F_DEPRECATED | libc::IFA_F_DADFAILED;
+
+/// Bound on one blocking read, and on a whole dump. The kernel builds every chunk inside our own
+/// `sendmsg`/`recvmsg`, so neither is a normal wait: they cap the cases where a reply is dropped
+/// (the socket's `ENOBUFS` state) or another local process feeds us datagrams we discard, either of
+/// which would otherwise park the single-threaded reactor for good.
+const READ_TIMEOUT: Duration = Duration::from_secs(1);
+const DUMP_DEADLINE: Duration = Duration::from_secs(5);
 
 /// Iterator over the `rtattr` TLVs of a message: yields `(attr_type, value)`, stopping at the
 /// first malformed length (as the kernel's own walk does).
@@ -101,13 +110,15 @@ pub(super) fn resolve(if_name: &str, ifindex: u32) -> io::Result<InterfaceAddres
 
 fn netlink_socket() -> io::Result<OwnedFd> {
     // SAFETY: `socket` returns a fresh fd or -1.
-    crate::sys::owned_fd_from(unsafe {
+    let sock = crate::sys::owned_fd_from(unsafe {
         libc::socket(
             libc::AF_NETLINK,
             libc::SOCK_RAW | libc::SOCK_CLOEXEC,
             NETLINK_ROUTE,
         )
-    })
+    })?;
+    crate::sys::set_recv_timeout(sock.as_raw_fd(), READ_TIMEOUT)?;
+    Ok(sock)
 }
 
 /// Send a dump request (`request_type` + `body`) and feed every reply of `reply_type` to
@@ -150,7 +161,13 @@ fn dump<B>(
     // Grows to whatever the largest datagram needs (see the peek below); reused across
     // datagrams, so it reallocates at most a few times over a dump.
     let mut buf: Vec<u8> = Vec::new();
+    let deadline = Instant::now() + DUMP_DEADLINE;
     loop {
+        if Instant::now() >= deadline {
+            return Err(io::Error::other(
+                "the netlink dump did not finish within its deadline",
+            ));
+        }
         // Size the next datagram before reading it: MSG_PEEK leaves it queued while MSG_TRUNC
         // reports its true length. Reading into a zero-length buffer learns the size; an
         // oversized message then grows `buf` rather than being silently truncated.
@@ -163,12 +180,10 @@ fn dump<B>(
                 libc::MSG_PEEK | libc::MSG_TRUNC,
             )
         };
-        if size < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        // Infallible: the negative (error) case returned above, and a non-negative `isize`
-        // always fits `usize`.
-        let size = usize::try_from(size).expect("recv count is non-negative");
+        // A blocking read only reports would-block once READ_TIMEOUT expires.
+        let IoStatus::Ready(size) = IoStatus::from_syscall(size)? else {
+            return Err(io::Error::other("the netlink dump went unanswered"));
+        };
         buf.resize(size, 0);
 
         let mut src = SockAddrNl::default();
@@ -186,9 +201,9 @@ fn dump<B>(
                 &raw mut addrlen,
             )
         };
-        if received < 0 {
-            return Err(io::Error::last_os_error());
-        }
+        let IoStatus::Ready(received) = IoStatus::from_syscall(received)? else {
+            return Err(io::Error::other("the netlink dump went unanswered"));
+        };
         // Only the kernel (nl_pid == 0) may answer the dump; a local process could unicast a spoofed
         // reply to inject a bogus address. Discard anything else and read the next datagram.
         if src.pid != 0 {
@@ -198,7 +213,6 @@ fn dump<B>(
             );
             continue;
         }
-        let received = usize::try_from(received).expect("recv count is non-negative");
 
         match walk_dump(&buf[..received], reply_type, &mut on_msg) {
             DumpStep::Done => return Ok(()),

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -89,6 +89,45 @@ pub(crate) fn so_error(fd: RawFd) -> io::Result<c_int> {
     Ok(err)
 }
 
+/// Bound a blocking socket's reads with `SO_RCVTIMEO`: an answer that never arrives then surfaces as
+/// would-block instead of parking the single-threaded reactor forever. Only the synchronous
+/// request/reply sockets need it; everything the reactor polls is non-blocking already.
+///
+/// # Errors
+/// Returns the OS error if the option can't be set.
+#[cfg(target_os = "linux")]
+pub(crate) fn set_recv_timeout(fd: RawFd, timeout: std::time::Duration) -> io::Result<()> {
+    // `tv_usec` is a `suseconds_t`, whose width varies by target: musl deprecates the name and
+    // widens it to 64-bit, so the conversion has to be fallible to compile where it is still 32-bit.
+    // Where it is already 64-bit the conversion can't fail, which is what clippy objects to.
+    #[allow(clippy::unnecessary_fallible_conversions)]
+    let tv_usec = timeout
+        .subsec_micros()
+        .try_into()
+        .expect("a sub-second microsecond count fits tv_usec");
+    let tv = libc::timeval {
+        tv_sec: timeout
+            .as_secs()
+            .try_into()
+            .expect("the timeout's seconds fit tv_sec"),
+        tv_usec,
+    };
+    // SAFETY: setsockopt reads `tv` (a timeval of the given length) on a valid socket fd.
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            (&raw const tv).cast(),
+            socklen_of::<libc::timeval>(),
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 /// Best-effort: request a larger `SO_RCVBUF` so a burst can't overflow the kernel receive queue as
 /// easily. The kernel clamps it to its own maximum, and a failure is logged and ignored (the default
 /// buffer still works), so this never fails the caller. Only the BSD route socket needs it (Linux


### PR DESCRIPTION
The netlink dump socket blocks with no timeout, and the loop that skips datagrams from a non-kernel sender never gives up. Any local process can unicast to a netlink socket, so it can keep that loop fed; and once a reply is dropped, which the socket's `ENOBUFS` state does with nothing arriving afterwards, the next read never returns. `resolve()` runs at startup and on every address change, so that parks the single-threaded reactor for good.

The socket now gets `SO_RCVTIMEO` and the dump as a whole a deadline. Neither is a normal wait: the kernel builds every chunk inside our own `sendmsg`/`recvmsg`, so a read that blocks for a second already means something is wrong.

`set_recv_timeout` lands in `sys.rs` beside `set_recv_buffer`. It is Linux-only for now; the FreeBSD DIAL egress work needs it too and will widen the `cfg` where its caller appears.

## Testing

Docker e2e 57/57. Linux clippy, tests and doc clean; host and `armv5te`/`armv7-unknown-linux-musleabihf` clippy clean.

`tv_usec` is a `suseconds_t`, which is 32-bit on 32-bit musl and deprecated there because it widens to 64-bit. `.into()` fails to compile on armv7 (`i32: From<u32>` does not exist) — verified — while `try_into()` trips `unnecessary_fallible_conversions` where it is already 64-bit, hence the narrow `allow`.