### PR TITLE
dial: check the route on FreeBSD instead of pinning the interface

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -201,6 +201,21 @@ pub(crate) fn if_index(name: &str) -> Option<u32> {
     (index != 0).then_some(index)
 }
 
+/// The name of interface `index`, or `None` if it names no interface. The reverse of [`if_index`],
+/// so a diagnostic can say `em0` rather than `3`.
+#[cfg(target_os = "freebsd")]
+pub(crate) fn if_name(index: u32) -> Option<String> {
+    let mut buf = [0u8; libc::IF_NAMESIZE];
+    // SAFETY: `buf` is IF_NAMESIZE bytes, the size `if_indextoname` documents it writes into; it
+    // returns NULL on failure without writing.
+    let name = unsafe { libc::if_indextoname(index, buf.as_mut_ptr().cast()) };
+    if name.is_null() {
+        return None;
+    }
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    std::str::from_utf8(&buf[..end]).ok().map(str::to_owned)
+}
+
 /// Log a single source field's transition at `info`, so the address churn is visible to an operator
 /// and the address-change e2e. Returns whether it changed at all, so the caller acts on exactly the
 /// families that moved. Nothing is logged when the field is unchanged.

--- a/src/interface/interface_monitor/route.rs
+++ b/src/interface/interface_monitor/route.rs
@@ -56,29 +56,11 @@ pub(super) fn open() -> io::Result<OwnedFd> {
     let sock = crate::sys::owned_fd_from(unsafe { libc::socket(libc::PF_ROUTE, socktype, 0) })?;
     #[cfg(target_os = "macos")]
     crate::sys::set_cloexec_nonblock(sock.as_raw_fd())?;
-    crate::sys::set_recv_buffer(sock.as_raw_fd(), RECV_BUFFER);
-    // FreeBSD only: without SO_RERROR a receive-buffer overflow is dropped silently, so the drain's
-    // ENOBUFS re-resolve-all recovery never fires and address changes are lost under pressure. Enabling
-    // it surfaces the overflow as ENOBUFS on the next recv; Linux netlink already reports it. macOS has
-    // the same silent drop but no SO_RERROR (a FreeBSD 13.0+ option) or equivalent, so the
-    // overflow-recovery gap is unfixable there.
+    crate::sys::increase_recv_buffer(sock.as_raw_fd(), RECV_BUFFER);
+    // Without it the drain's ENOBUFS re-resolve-all recovery never fires and address changes are lost
+    // under pressure. macOS has the same silent drop and no equivalent, so the gap is unfixable there.
     #[cfg(target_os = "freebsd")]
-    {
-        let on: c_int = 1;
-        // SAFETY: setsockopt reads `on` (a c_int of the given length) on a valid socket fd.
-        let rc = unsafe {
-            libc::setsockopt(
-                sock.as_raw_fd(),
-                libc::SOL_SOCKET,
-                crate::libcex::SO_RERROR,
-                (&raw const on).cast(),
-                libc::socklen_t::try_from(size_of::<c_int>()).expect("c_int fits socklen_t"),
-            )
-        };
-        if rc != 0 {
-            return Err(io::Error::last_os_error());
-        }
-    }
+    crate::sys::set_recv_error_reporting(sock.as_raw_fd())?;
     Ok(sock)
 }
 

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -17,6 +17,8 @@ mod multicast;
 #[cfg(target_os = "linux")]
 mod netlink;
 #[cfg(target_os = "freebsd")]
+mod route;
+#[cfg(target_os = "freebsd")]
 mod sockopt;
 
 pub(crate) use self::bpf::BpfInsn;
@@ -34,5 +36,7 @@ pub(crate) use self::netlink::{
     IfAddrMsg, NETLINK_ROUTE, NLM_F_DUMP, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, NlMsgHdr, RtAttr,
     SockAddrNl, nl_align,
 };
+#[cfg(target_os = "freebsd")]
+pub(crate) use self::route::RtMsgHdr;
 #[cfg(target_os = "freebsd")]
 pub(crate) use self::sockopt::SO_RERROR;

--- a/src/libcex/route.rs
+++ b/src/libcex/route.rs
@@ -1,0 +1,57 @@
+//! `PF_ROUTE` message framing, hand-rolled because `libc` exposes `rt_msghdr` for apple only.
+//!
+//! Transcribed from FreeBSD 14.4 `<net/route.h>`.
+
+use libc::{c_int, c_ulong, pid_t};
+
+#[repr(C)]
+#[derive(Default)]
+pub(crate) struct RtMsgHdr {
+    /// `rtm_msglen`: the whole message, header and trailing sockaddrs.
+    pub(crate) msglen: u16,
+    pub(crate) version: u8,
+    /// `rtm_type`: which `RTM_*` message this is.
+    pub(crate) msg_type: u8,
+    /// `rtm_index`: the interface associated with the route.
+    pub(crate) index: u16,
+    pub(crate) spare1: u16,
+    pub(crate) flags: c_int,
+    /// `rtm_addrs`: which `RTA_*` sockaddrs follow the header.
+    pub(crate) addrs: c_int,
+    pub(crate) pid: pid_t,
+    pub(crate) seq: c_int,
+    pub(crate) errno: c_int,
+    /// `rtm_fmask`: which metrics an `RTM_CHANGE` sets.
+    pub(crate) fmask: c_int,
+    /// `rtm_inits`: which metrics the message initializes.
+    pub(crate) inits: c_ulong,
+    pub(crate) rmx: RtMetrics,
+}
+
+const _: () = assert!(size_of::<RtMsgHdr>() == 152);
+
+#[repr(C)]
+#[derive(Default)]
+pub(crate) struct RtMetrics {
+    /// Metrics the kernel must leave alone.
+    pub(crate) locks: c_ulong,
+    pub(crate) mtu: c_ulong,
+    pub(crate) hopcount: c_ulong,
+    /// Lifetime for the route, e.g. a redirect.
+    pub(crate) expire: c_ulong,
+    /// Inbound delay-bandwidth product.
+    pub(crate) recvpipe: c_ulong,
+    /// Outbound delay-bandwidth product.
+    pub(crate) sendpipe: c_ulong,
+    /// Outbound gateway buffer limit.
+    pub(crate) ssthresh: c_ulong,
+    pub(crate) rtt: c_ulong,
+    pub(crate) rttvar: c_ulong,
+    pub(crate) pksent: c_ulong,
+    pub(crate) weight: c_ulong,
+    pub(crate) nhidx: c_ulong,
+    /// `rmx_filler`: reserved.
+    pub(crate) filler: [c_ulong; 2],
+}
+
+const _: () = assert!(size_of::<RtMetrics>() == 112);

--- a/src/net.rs
+++ b/src/net.rs
@@ -8,6 +8,8 @@ pub(crate) mod mac;
 pub(crate) mod mdns;
 pub(crate) mod packet;
 pub(crate) mod port_reservation;
+#[cfg(target_os = "freebsd")]
+mod route_query;
 pub(crate) mod ssdp;
 pub(crate) mod stream_buffer;
 pub(crate) mod tcp;

--- a/src/net/route_query.rs
+++ b/src/net/route_query.rs
@@ -1,0 +1,254 @@
+//! Which interface would the kernel route a destination through? A `PF_ROUTE` `RTM_GET` query.
+//!
+//! FreeBSD has no `SO_BINDTODEVICE`/`IP_BOUND_IF`, so the DIAL proxy checks the route instead of
+//! pinning the connect. Weaker than a pin: it can't hold an established connection in place, and
+//! under multipath the kernel reports the first nexthop while the connect hashes independently.
+
+use std::io;
+use std::net::Ipv4Addr;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::time::{Duration, Instant};
+
+use libc::{c_int, c_void};
+
+use crate::libcex::RtMsgHdr;
+use crate::sys::IoStatus;
+
+/// One routing message: a fixed header plus a few small sockaddrs.
+const READ_BUF: usize = 2048;
+
+/// Bound on one blocking read, and on the whole exchange. The kernel hands the reply to a software
+/// interrupt rather than queueing it inline, so some wait is normal; these only cap the cases where
+/// it was dropped (the netisr queue and the receive buffer both discard silently) or where the
+/// socket's own broadcasts keep arriving faster than we step over them.
+const READ_TIMEOUT: Duration = Duration::from_secs(1);
+const REPLY_DEADLINE: Duration = Duration::from_secs(5);
+
+/// The default `rts_recvspace` is 8 KiB, small enough that a burst of the kernel's routing
+/// broadcasts can crowd out the reply we are waiting for.
+const RECV_BUFFER: c_int = 256 * 1024;
+
+/// Marks our request in the reply; the kernel's broadcasts carry 0.
+const REQUEST_SEQ: c_int = 1;
+
+/// An `RTM_GET` request: the header followed by the one sockaddr it names. A routing message carries
+/// a variable set of sockaddrs, so `<net/route.h>` declares no struct for one; `route(8)` appends
+/// them to a byte blob through a cursor. Asking for a single `RTA_DST` needs only this.
+#[repr(C)]
+struct RouteRequest {
+    hdr: RtMsgHdr,
+    dst: libc::sockaddr_in,
+}
+
+// A trailing sockaddr occupies `SA_SIZE` bytes: `sa_len` rounded up to a multiple of `sizeof(long)`.
+// A 16-byte `sockaddr_in` is already a multiple, so a plain field lands where the cursor would.
+const _: () = assert!(size_of::<RouteRequest>() == size_of::<RtMsgHdr>() + 16);
+
+/// The index of the interface the kernel would route `dst` through.
+///
+/// # Errors
+/// No route, a route that discards traffic, or a routing-socket failure. Anything that leaves the
+/// answer unknown is an error: the caller refuses the connect on one.
+pub(crate) fn egress_ifindex(dst: Ipv4Addr) -> io::Result<u32> {
+    let sock = open_route_socket()?;
+    let request = build_request(dst);
+    // SAFETY: `request` is a live, fully initialized `RouteRequest` of exactly this size.
+    let written = unsafe {
+        libc::write(
+            sock.as_raw_fd(),
+            (&raw const request).cast::<c_void>(),
+            size_of::<RouteRequest>(),
+        )
+    };
+    if written < 0 {
+        let err = io::Error::last_os_error();
+        // The kernel reports an unroutable destination by failing the write, not by replying.
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            return Err(io::Error::other(format!("no route to {dst}")));
+        }
+        return Err(err);
+    }
+    read_reply(sock.as_raw_fd(), dst)
+}
+
+/// A socket for one query: blocking, like the netlink dump's, since this is a synchronous exchange
+/// rather than something the reactor polls. `AF_INET` narrows the broadcasts it also receives.
+fn open_route_socket() -> io::Result<OwnedFd> {
+    // SAFETY: `socket` returns a fresh fd or -1.
+    let sock = crate::sys::owned_fd_from(unsafe {
+        libc::socket(
+            libc::PF_ROUTE,
+            libc::SOCK_RAW | libc::SOCK_CLOEXEC,
+            libc::AF_INET,
+        )
+    })?;
+    crate::sys::set_recv_timeout(sock.as_raw_fd(), READ_TIMEOUT)?;
+    crate::sys::increase_recv_buffer(sock.as_raw_fd(), RECV_BUFFER);
+    // A reply the buffer had no room for then reports ENOBUFS rather than looking like silence.
+    crate::sys::set_recv_error_reporting(sock.as_raw_fd())?;
+    Ok(sock)
+}
+
+/// `RTA_DST` alone, without `RTA_NETMASK`, selects the longest-prefix match: the lookup a forwarded
+/// packet gets rather than an exact-match one.
+fn build_request(dst: Ipv4Addr) -> RouteRequest {
+    RouteRequest {
+        hdr: RtMsgHdr {
+            msglen: u16::try_from(size_of::<RouteRequest>())
+                .expect("the request fits a u16 length"),
+            version: u8::try_from(libc::RTM_VERSION).expect("RTM_VERSION fits a u8"),
+            msg_type: u8::try_from(libc::RTM_GET).expect("RTM_GET fits a u8"),
+            addrs: libc::RTA_DST,
+            pid: our_pid(),
+            seq: REQUEST_SEQ,
+            ..RtMsgHdr::default()
+        },
+        dst: libc::sockaddr_in {
+            sin_len: u8::try_from(size_of::<libc::sockaddr_in>())
+                .expect("sockaddr_in fits a u8 length"),
+            sin_family: u8::try_from(libc::AF_INET).expect("AF_INET fits a u8 family"),
+            sin_port: 0, // a route has no port
+            sin_addr: libc::in_addr {
+                s_addr: u32::from_ne_bytes(dst.octets()),
+            },
+            sin_zero: [0; 8],
+        },
+    }
+}
+
+/// Read past the kernel's broadcasts to our own reply. An unanswered query is an error, so the
+/// caller refuses the connect rather than allowing it.
+fn read_reply(fd: RawFd, dst: Ipv4Addr) -> io::Result<u32> {
+    let mut buf = [0u8; READ_BUF];
+    let deadline = Instant::now() + REPLY_DEADLINE;
+    // Counted so the deadline message can tell a flooded socket from a silent one.
+    let mut skipped = 0_u32;
+    loop {
+        if Instant::now() >= deadline {
+            return Err(io::Error::other(format!(
+                "no answer for {dst} in {REPLY_DEADLINE:?}, after {skipped} other messages"
+            )));
+        }
+        // SAFETY: `buf` is a valid writable buffer of its own length.
+        let read = unsafe { libc::read(fd, buf.as_mut_ptr().cast::<c_void>(), buf.len()) };
+        // A blocking read only reports would-block once READ_TIMEOUT expires.
+        let IoStatus::Ready(n) = IoStatus::from_syscall(read)? else {
+            return Err(io::Error::other(format!(
+                "the routing socket did not answer which interface reaches {dst}"
+            )));
+        };
+        if n < size_of::<RtMsgHdr>() {
+            skipped += 1;
+            continue;
+        }
+        // SAFETY: `buf` holds at least a whole header, checked above. Unaligned because the read
+        // landed in a byte buffer, and `RtMsgHdr` is plain data with no invalid bit patterns.
+        let hdr = unsafe { buf.as_ptr().cast::<RtMsgHdr>().read_unaligned() };
+        if !is_our_reply(&hdr) {
+            skipped += 1;
+            continue;
+        }
+        if hdr.errno != 0 {
+            return Err(io::Error::from_raw_os_error(hdr.errno));
+        }
+        if hdr.flags & (libc::RTF_REJECT | libc::RTF_BLACKHOLE) != 0 {
+            return Err(io::Error::other(format!(
+                "the route to {dst} discards traffic"
+            )));
+        }
+        return Ok(u32::from(hdr.index));
+    }
+}
+
+/// Whether `hdr` answers our own request rather than being one of the kernel's broadcasts.
+fn is_our_reply(hdr: &RtMsgHdr) -> bool {
+    hdr.version == u8::try_from(libc::RTM_VERSION).expect("RTM_VERSION fits a u8")
+        && hdr.msg_type == u8::try_from(libc::RTM_GET).expect("RTM_GET fits a u8")
+        && hdr.pid == our_pid()
+        && hdr.seq == REQUEST_SEQ
+}
+
+fn our_pid() -> c_int {
+    // SAFETY: `getpid` takes no arguments and cannot fail.
+    unsafe { libc::getpid() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real routing socket")]
+    fn loopback_routes_via_lo0() {
+        // A live exchange: the header layout and size have to be right or the kernel rejects the
+        // request or the reply is read from the wrong place.
+        let want = crate::interface::if_index("lo0").expect("lo0 exists");
+        assert_eq!(egress_ifindex(Ipv4Addr::LOCALHOST).expect("a route"), want);
+    }
+
+    /// A header matching every field [`is_our_reply`] keys on. Each rejection test below changes
+    /// exactly one of them, so it exercises its own clause rather than tripping an earlier one.
+    fn our_reply() -> RtMsgHdr {
+        RtMsgHdr {
+            version: u8::try_from(libc::RTM_VERSION).unwrap(),
+            msg_type: u8::try_from(libc::RTM_GET).unwrap(),
+            pid: our_pid(),
+            seq: REQUEST_SEQ,
+            ..RtMsgHdr::default()
+        }
+    }
+
+    #[test]
+    fn recognises_our_own_reply() {
+        assert!(is_our_reply(&our_reply()));
+    }
+
+    #[test]
+    fn skips_another_process_reply() {
+        // Every routing socket sees every reply, including other processes' RTM_GETs.
+        let hdr = RtMsgHdr {
+            pid: our_pid() + 1,
+            ..our_reply()
+        };
+        assert!(!is_our_reply(&hdr));
+    }
+
+    #[test]
+    fn skips_a_kernel_broadcast() {
+        // What actually shares the socket with us: an unsolicited announcement, carrying its own
+        // message type and seq 0.
+        let hdr = RtMsgHdr {
+            msg_type: u8::try_from(libc::RTM_NEWADDR).unwrap(),
+            seq: 0,
+            ..our_reply()
+        };
+        assert!(!is_our_reply(&hdr));
+    }
+
+    #[test]
+    fn skips_another_message_type() {
+        let hdr = RtMsgHdr {
+            msg_type: u8::try_from(libc::RTM_DELADDR).unwrap(),
+            ..our_reply()
+        };
+        assert!(!is_our_reply(&hdr));
+    }
+
+    #[test]
+    fn skips_a_foreign_sequence() {
+        let hdr = RtMsgHdr {
+            seq: REQUEST_SEQ + 1,
+            ..our_reply()
+        };
+        assert!(!is_our_reply(&hdr));
+    }
+
+    #[test]
+    fn skips_another_protocol_version() {
+        let hdr = RtMsgHdr {
+            version: u8::try_from(libc::RTM_VERSION).unwrap() - 1,
+            ..our_reply()
+        };
+        assert!(!is_our_reply(&hdr));
+    }
+}

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,6 +1,7 @@
 //! A non-blocking IPv4 TCP socket for the DIAL application proxy: listen on the source interface,
-//! accept, egress-pinned connect to a device on the target interface, and stream bytes. The reactor
-//! watches its fd; all operations are non-blocking and the socket is close-on-exec.
+//! accept, connect to a device on the target interface, and stream bytes. The reactor watches its
+//! fd; all operations are non-blocking and the socket is close-on-exec. Outbound connections are
+//! confined to the target interface: see [`TcpSocket::connect`].
 
 use std::io;
 use std::mem::MaybeUninit;
@@ -69,25 +70,28 @@ impl TcpSocket {
         }))
     }
 
-    /// Open a connection to `dst`, egress-pinned to the target interface (`source` address + the
-    /// `iface` name) so the route can't leak onto the wrong segment. Non-blocking: the socket is
+    /// Open a connection to `dst`, confined to the target interface (`source` address + the `iface`
+    /// name) so the route can't leak onto the wrong segment. Non-blocking: the socket is
     /// [`is_connecting`](Self::is_connecting) until a writable edge and [`finish_connect`](Self::finish_connect).
+    ///
+    /// Linux and macOS pin the interface; FreeBSD has no such primitive and checks the route
+    /// instead. The `source` bind confines nothing on its own: `ip_output` picks the interface from
+    /// the destination alone.
     ///
     /// # Errors
     /// Propagates the socket / `setsockopt` / pin / `bind` / `connect` failure (other than the
-    /// in-progress sentinel).
+    /// in-progress sentinel), or, on FreeBSD, a destination that does not route via `iface`.
     pub(crate) fn connect(
         dst: SocketAddrV4,
         source: Ipv4Addr,
         iface: Option<&str>,
     ) -> io::Result<Self> {
+        #[cfg(target_os = "freebsd")]
+        verify_egress(dst, iface)?;
         let fd = open_socket(libc::AF_INET, libc::SOCK_STREAM)?;
         set_nodelay(fd.as_raw_fd())?;
-        // FreeBSD has no egress-pin primitive; the source-address bind below steers egress.
         #[cfg(not(target_os = "freebsd"))]
         pin_egress(fd.as_raw_fd(), iface)?;
-        #[cfg(target_os = "freebsd")]
-        let _ = iface;
         bind_v4(fd.as_raw_fd(), source, 0)?;
         let local_addr = local_addr_v4(fd.as_raw_fd())?;
         let connecting = connect_v4(fd.as_raw_fd(), dst)?;
@@ -309,8 +313,8 @@ fn set_nodelay(fd: RawFd) -> io::Result<()> {
 /// Constrain `fd`'s egress to the interface named `iface` so a route lookup can't leak the connect
 /// onto the wrong segment; `None` skips the pin. Linux uses `SO_BINDTODEVICE` (needs `CAP_NET_RAW`),
 /// which takes the name directly; macOS resolves the name to its current ifindex for `IP_BOUND_IF`,
-/// so the pin follows the name across an interface recreation. FreeBSD has no pin primitive, so the
-/// caller skips it and relies on the source-address bind.
+/// so the pin follows the name across an interface recreation. FreeBSD has no equivalent and checks
+/// the route instead.
 #[cfg(not(target_os = "freebsd"))]
 fn pin_egress(fd: RawFd, iface: Option<&str>) -> io::Result<()> {
     let Some(name) = iface else {
@@ -363,6 +367,31 @@ fn pin_egress(fd: RawFd, iface: Option<&str>) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Refuse a connect whose route would leave by an interface other than `iface`; `None` skips the
+/// check.
+#[cfg(target_os = "freebsd")]
+fn verify_egress(dst: SocketAddrV4, iface: Option<&str>) -> io::Result<()> {
+    let Some(name) = iface else {
+        return Ok(());
+    };
+    let want = crate::interface::if_index(name).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("interface {name} not found"),
+        )
+    })?;
+    let got = super::route_query::egress_ifindex(*dst.ip())?;
+    if got == want {
+        log::trace!("{} is reachable via {name}", dst.ip());
+        return Ok(());
+    }
+    let via = crate::interface::if_name(got).unwrap_or_else(|| format!("interface {got}"));
+    let ip = dst.ip();
+    Err(io::Error::other(format!(
+        "{ip} routes via {via}, not {name}"
+    )))
 }
 
 #[cfg(test)]

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -60,10 +60,11 @@ pub(super) struct DialDeviceProxy {
     /// opens.
     key: Option<HandlerKey>,
     /// The target-interface address device connections bind, so the device sees a same-segment peer
-    /// and replies via the target interface (on the BSDs the bind is the only egress steer).
+    /// and replies via the target interface. The bind picks the source address only; what keeps the
+    /// connection on that segment is `target_iface`.
     target: Ipv4Addr,
-    /// The target interface's name, egress-pinning device connections to that segment (`None` skips
-    /// the pin). The name, not an ifindex: `SO_BINDTODEVICE` wants it directly, and a name stays
+    /// The target interface's name, confining device connections to that segment (`None` skips the
+    /// confinement). The name, not an ifindex: `SO_BINDTODEVICE` wants it directly, and a name stays
     /// valid across an interface recreation where a cached index would not.
     target_iface: Option<String>,
     /// The description listener (source side); its connections proxy to `desc_endpoint`.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -95,7 +95,7 @@ pub(crate) fn so_error(fd: RawFd) -> io::Result<c_int> {
 ///
 /// # Errors
 /// Returns the OS error if the option can't be set.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub(crate) fn set_recv_timeout(fd: RawFd, timeout: std::time::Duration) -> io::Result<()> {
     // `tv_usec` is a `suseconds_t`, whose width varies by target: musl deprecates the name and
     // widens it to 64-bit, so the conversion has to be fallible to compile where it is still 32-bit.
@@ -128,12 +128,68 @@ pub(crate) fn set_recv_timeout(fd: RawFd, timeout: std::time::Duration) -> io::R
     Ok(())
 }
 
-/// Best-effort: request a larger `SO_RCVBUF` so a burst can't overflow the kernel receive queue as
-/// easily. The kernel clamps it to its own maximum, and a failure is logged and ignored (the default
-/// buffer still works), so this never fails the caller. Only the BSD route socket needs it (Linux
+/// Ask the kernel to report a receive-queue overflow (`SO_RERROR`) instead of dropping it silently:
+/// the next `recv` then fails with `ENOBUFS`, so a caller can tell "nothing arrived" from "something
+/// was thrown away". A FreeBSD 13.0+ option; macOS has the same silent drop and no equivalent, and
+/// Linux netlink reports overflow already.
+///
+/// # Errors
+/// Returns the OS error if the option can't be set.
+#[cfg(target_os = "freebsd")]
+pub(crate) fn set_recv_error_reporting(fd: RawFd) -> io::Result<()> {
+    let on: c_int = 1;
+    // SAFETY: setsockopt reads `on` (a c_int of the given length) on a valid socket fd.
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            crate::libcex::SO_RERROR,
+            (&raw const on).cast(),
+            socklen_of::<c_int>(),
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Best-effort: grow the kernel receive queue to `bytes` so a burst can't overflow it as easily,
+/// leaving an already-larger one alone. `SO_RCVBUF` sets an absolute size, so an operator who raised
+/// the default would otherwise have it silently cut back. Only the BSD route sockets need this (Linux
 /// netlink already defaults to the system max).
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-pub(crate) fn set_recv_buffer(fd: RawFd, bytes: c_int) {
+pub(crate) fn increase_recv_buffer(fd: RawFd, bytes: c_int) {
+    let mut current: c_int = 0;
+    let mut len = socklen_of::<c_int>();
+    // SAFETY: `&current`/`&len` are a valid (value, length) out-pair of `c_int` size for `fd`.
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            (&raw mut current).cast::<c_void>(),
+            &raw mut len,
+        )
+    };
+    if rc != 0 {
+        log::warn!(
+            "could not read the socket receive buffer size, requesting {bytes} bytes anyway: {}",
+            io::Error::last_os_error()
+        );
+    } else if current >= bytes {
+        log::trace!(
+            "socket receive buffer already {current} bytes, at or above the {bytes} wanted; leaving it"
+        );
+        return;
+    }
+    set_recv_buffer(fd, bytes);
+}
+
+/// Request `bytes` of receive queue. The kernel clamps it to its own maximum, and a failure is
+/// logged and ignored (the default buffer still works), so this never fails the caller.
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn set_recv_buffer(fd: RawFd, bytes: c_int) {
     // SAFETY: setsockopt reads `bytes` (a c_int of the given length) on a valid socket fd.
     let rc = unsafe {
         libc::setsockopt(


### PR DESCRIPTION
FreeBSD has no `SO_BINDTODEVICE`/`IP_BOUND_IF`, so the DIAL proxy's connect went out unconfined and a device endpoint taken from a captured SSDP `LOCATION` could leave by any interface, the source segment and the WAN included. The comment claiming the source-address bind steered it was wrong: `ip_output` routes on the destination alone. That is the OPNsense platform.

An `RTM_GET` on a `PF_ROUTE` socket now reports which interface a destination would leave by, and a mismatch refuses the connect. Linux and macOS keep their pins, which are stronger. The check gives "reachable on that interface" rather than same-subnet, so a device behind a router on the target segment still works.

Weaker than a pin in two ways, both documented in the module: it can't hold an established connection in place, and under multipath the kernel reports the first nexthop while the connect hashes independently.

`rt_msghdr` goes in `libcex` (libc declares it for apple only), and the first commit shares the two route sockets' setup.

## Testing

Run on a FreeBSD 15.1 arm64 VM: 451/451 unit tests, and the full e2e 57/57 in vnet jails. Sabotaging `verify_egress` fails `dial_launch_roundtrip`, so the DIAL cases do exercise it rather than passing vacuously.

`rt_msghdr`'s layout is pinned by a `size_of` assert and was cross-checked with C `_Static_assert`s against 15.1's `<net/route.h>` for amd64 and arm64.

Host, Linux, `x86_64-unknown-freebsd` and both 32-bit musl targets: clippy, tests, fmt and doc clean. Docker e2e 57/57.