### PR TITLE
dial: survive fd pressure instead of spinning on it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ fn reflect(path: Option<&Path>) -> Result<()> {
         log::debug!("loading configuration from NETFLECTOR_* environment only");
     }
 
+    sys::raise_file_limit();
+
     let config = Config::from_sources(toml_text.as_deref(), env)?;
     let count = config.reflectors.len();
     log::info!(

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -112,12 +112,27 @@ impl DialDeviceProxy {
     /// Accept one pending client on `listener` if there is connection capacity, else `None`. An accept
     /// is always taken (draining the readiness) even at the shared connection cap, where the client is
     /// then dropped.
-    fn accept_client(&self, listener: &TcpSocket, what: Listener) -> Option<TcpSocket> {
+    ///
+    /// A failed accept tears the proxy down. `accept` is the only way to drain a pending connection, so
+    /// under `EMFILE` it stays queued and this level-triggered listener re-fires on it without end;
+    /// shedding the proxy stops that and hands its fds back. The device re-mints on its next
+    /// advertisement, as it would after any eviction.
+    fn accept_client(
+        &self,
+        listener: &TcpSocket,
+        what: Listener,
+        reactor: &mut Reactor,
+    ) -> Option<TcpSocket> {
         let client = match listener.accept() {
             Ok(Some(client)) => client,
             Ok(None) => return None, // spurious / already taken
             Err(e) => {
-                log::warn!("dial: accept on the {what} listener failed: {e}");
+                log::error!(
+                    "dial: accept on the {what} listener failed: {e}; tearing the proxy down, \
+                     {} is unproxied until it advertises again",
+                    self.desc_endpoint
+                );
+                reactor.unregister(self.own_key()).ok();
                 return None;
             }
         };
@@ -130,7 +145,7 @@ impl DialDeviceProxy {
 
     /// Accept a client on the description listener and proxy it to the device's description endpoint.
     fn accept_desc(&mut self, reactor: &mut Reactor) {
-        if let Some(client) = self.accept_client(&self.desc, Listener::Description) {
+        if let Some(client) = self.accept_client(&self.desc, Listener::Description, reactor) {
             self.start_connection(client, self.desc_endpoint, self.desc.local_addr(), reactor);
         }
     }
@@ -139,7 +154,7 @@ impl DialDeviceProxy {
     /// description fetch. A client reaching here before that fetch is dropped (the proxy minted the
     /// listener's address into the description's `Application-URL`, so this is unexpected).
     fn accept_rest(&mut self, reactor: &mut Reactor) {
-        let Some(client) = self.accept_client(&self.rest, Listener::Rest) else {
+        let Some(client) = self.accept_client(&self.rest, Listener::Rest, reactor) else {
             return;
         };
         let Some(device) = self.rest_endpoint else {
@@ -384,6 +399,30 @@ mod tests {
             conn.device_endpoint(),
             device_endpoint,
             "the REST connection targets the learned REST endpoint, not the description endpoint"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
+    fn a_failed_accept_sheds_the_proxy() {
+        let mut reactor = Reactor::new().expect("reactor");
+        let (proxy, rest_addr) = watched_proxy(&mut reactor);
+        let key = proxy.own_key();
+        assert!(reactor.is_registered(key));
+
+        // Accepting on a connected socket fails with EINVAL, standing in for the EMFILE the proxy
+        // cannot drain. Either way it must not stay registered and re-firing on a readiness it
+        // will never consume.
+        let connected =
+            TcpSocket::connect(rest_addr, Ipv4Addr::LOCALHOST, None).expect("client connect");
+        assert!(
+            proxy
+                .accept_client(&connected, Listener::Rest, &mut reactor)
+                .is_none()
+        );
+        assert!(
+            !reactor.is_registered(key),
+            "the proxy unregisters itself rather than spin on a listener it cannot drain"
         );
     }
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -128,6 +128,55 @@ pub(crate) fn set_recv_timeout(fd: RawFd, timeout: std::time::Duration) -> io::R
     Ok(())
 }
 
+/// Raise the open-file soft limit to the hard one: a DIAL proxy costs two listener fds plus two per
+/// proxied connection, and each search session holds a port reservation. Best-effort, and only the
+/// soft limit moves, which needs no privilege.
+pub(crate) fn raise_file_limit() {
+    // SAFETY: an all-zero `rlimit` is a valid value for `getrlimit` to overwrite.
+    let mut limit: libc::rlimit = unsafe { std::mem::zeroed() };
+    // SAFETY: `&limit` is a valid out-param for the given resource.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) } != 0 {
+        log::warn!(
+            "could not read the open-file limit: {}",
+            io::Error::last_os_error()
+        );
+        return;
+    }
+    if limit.rlim_cur >= limit.rlim_max {
+        log::debug!("open-file limit already {}", show_limit(limit.rlim_cur));
+        return;
+    }
+    let raised = libc::rlimit {
+        rlim_cur: limit.rlim_max,
+        rlim_max: limit.rlim_max,
+    };
+    // SAFETY: `&raised` is a valid `rlimit` for the given resource.
+    if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raw const raised) } != 0 {
+        log::warn!(
+            "could not raise the open-file limit from {} to {}: {}",
+            limit.rlim_cur,
+            show_limit(limit.rlim_max),
+            io::Error::last_os_error()
+        );
+        return;
+    }
+    log::debug!(
+        "raised the open-file limit from {} to {}",
+        limit.rlim_cur,
+        show_limit(limit.rlim_max)
+    );
+}
+
+/// An open-file limit for the log: macOS reports an infinite hard limit, and the number for that is
+/// noise.
+fn show_limit(limit: libc::rlim_t) -> String {
+    if limit == libc::RLIM_INFINITY {
+        "unlimited".to_owned()
+    } else {
+        limit.to_string()
+    }
+}
+
 /// Ask the kernel to report a receive-queue overflow (`SO_RERROR`) instead of dropping it silently:
 /// the next `recv` then fails with `ENOBUFS`, so a caller can tell "nothing arrived" from "something
 /// was thrown away". A FreeBSD 13.0+ option; macOS has the same silent drop and no equivalent, and
@@ -427,6 +476,29 @@ mod tests {
         assert_eq!(scope_written_for("fd00::1"), 0);
         assert_eq!(scope_written_for("ff05::c"), 0);
         assert_eq!(scope_written_for("::1"), 0);
+    }
+
+    /// The process's current open-file limits.
+    fn file_limit() -> (libc::rlim_t, libc::rlim_t) {
+        // SAFETY: an all-zero `rlimit` is a valid value for `getrlimit` to overwrite.
+        let mut limit: libc::rlimit = unsafe { std::mem::zeroed() };
+        // SAFETY: `&limit` is a valid out-param for the given resource.
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) };
+        assert_eq!(rc, 0, "getrlimit failed");
+        (limit.rlim_cur, limit.rlim_max)
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real getrlimit")]
+    fn raising_the_file_limit_reaches_the_hard_limit() {
+        let (before, hard) = file_limit();
+        raise_file_limit();
+        let (after, _) = file_limit();
+        assert!(
+            after >= before,
+            "the soft limit was lowered: {after} < {before}"
+        );
+        assert_eq!(after, hard, "the soft limit ends at the hard limit");
     }
 
     #[test]


### PR DESCRIPTION
A DIAL proxy costs two listener fds plus two per proxied connection, and each search session holds a port reservation, so the caps multiply well past the 1024 soft limit still common on Linux. Nothing raised it, and nothing coped when it ran out.

**Raise the open-file soft limit to the hard one at startup.** Only the soft limit moves, which needs no privilege. macOS reports an infinite hard limit but refuses anything above `kern.maxfilesperproc`, so the target is clamped there — and the existing soft limit can already be *above* that, which is why it never lowers.

**Shed the proxy when an accept fails.** `accept` is the only way to drain a pending connection, so under `EMFILE` it stays queued and the level-triggered listener re-fires on it without end, burning a core until a connection deadline frees a descriptor. Unregistering hands the fds back and the device re-mints on its next advertisement, as after any eviction. The reactor supports a handler removing itself mid-dispatch.

No new caps. A global connection budget was considered and dropped: the per-proxy cap can't come down without crippling the one-device-many-clients case, and raising the limit removes the self-inflicted exhaustion that motivated it.

## Testing

`raising_the_file_limit_never_lowers_it` pins the clamp hazard — on a host where the soft limit (1048576) already exceeds `kern.maxfilesperproc` (92160), removing the guard fails it. It deliberately doesn't lower the limit to force the raise path, since that is process-global and the suite opens sockets in parallel.

`a_failed_accept_sheds_the_proxy` fails if the `unregister` is removed, and nothing else does.

Verified on Linux with the soft limit forced to 1024: `raised the open-file limit from 1024 to 1048576 (hard 1048576)`.

Host 452/452, Linux 451/451, clippy clean on host, Linux and `x86_64-unknown-freebsd`, fmt and doc clean, Docker e2e 57/57.