### PR TITLE
BREAKING: log_level = "warning" is now log_level = "warn"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "netflector"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netflector"
-version = "0.13.3"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.93"
 license = "BSD-2-Clause"

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ describing one `source_if` → `target_if` bridge that enables any combination o
 top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_interval_secs`:
 
 ```toml
-log_level = "info"                 # optional; one of off | error | warning | info | debug | trace (default: info)
+log_level = "info"                 # optional; one of off | error | warn | info | debug | trace (default: info)
 debug_memory_interval_secs = 0     # optional; seconds between memory (RSS/peak) diagnostic reports; 0 disables (default 0)
 counters_interval_secs = 0         # optional; seconds between per-interface packet-counter summaries; 0 disables (default 0)
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_
 
 ```toml
 log_level = "info"                 # optional; one of off | error | warn | info | debug | trace (default: info)
+                                   # release builds compile trace out, where it behaves as debug
 debug_memory_interval_secs = 0     # optional; seconds between memory (RSS/peak) diagnostic reports; 0 disables (default 0)
 counters_interval_secs = 0         # optional; seconds between per-interface packet-counter summaries; 0 disables (default 0)
 

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -28,7 +28,7 @@ An unknown key, at the top level or in an entry, is rejected at startup.
 .Bl -tag -width Ds
 .It Ic log_level
 Log verbosity, one of
-.Cm off , error , warning , info , debug ,
+.Cm off , error , warn , info , debug ,
 or
 .Cm trace .
 Default

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -33,6 +33,9 @@ or
 .Cm trace .
 Default
 .Cm info .
+.Cm trace
+is compiled out of this build and behaves as
+.Cm debug .
 .It Ic debug_memory_interval_secs
 Seconds between memory (RSS and peak) diagnostic reports.
 .Cm 0

--- a/src/config/value.rs
+++ b/src/config/value.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 pub(crate) enum LogLevel {
     Off,
     Error,
-    Warning,
+    Warn,
     #[default]
     Info,
     Debug,
@@ -27,7 +27,7 @@ pub(crate) enum LogLevel {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
-#[error("expected one of: off, error, warning, info, debug, trace")]
+#[error("expected one of: off, error, warn, info, debug, trace")]
 pub(crate) struct ParseLogLevelError;
 
 impl FromStr for LogLevel {
@@ -37,7 +37,7 @@ impl FromStr for LogLevel {
         match s.to_ascii_lowercase().as_str() {
             "off" => Ok(Self::Off),
             "error" => Ok(Self::Error),
-            "warning" => Ok(Self::Warning),
+            "warn" => Ok(Self::Warn),
             "info" => Ok(Self::Info),
             "debug" => Ok(Self::Debug),
             "trace" => Ok(Self::Trace),
@@ -303,7 +303,7 @@ mod tests {
     fn log_level_parses_via_fromstr() {
         assert_eq!("off".parse::<LogLevel>().unwrap(), LogLevel::Off);
         assert_eq!("ERROR".parse::<LogLevel>().unwrap(), LogLevel::Error);
-        assert_eq!("Warning".parse::<LogLevel>().unwrap(), LogLevel::Warning);
+        assert_eq!("Warn".parse::<LogLevel>().unwrap(), LogLevel::Warn);
         assert_eq!("INFO".parse::<LogLevel>().unwrap(), LogLevel::Info);
         assert_eq!("debug".parse::<LogLevel>().unwrap(), LogLevel::Debug);
         assert_eq!("Trace".parse::<LogLevel>().unwrap(), LogLevel::Trace);

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -136,7 +136,7 @@ impl From<LogLevel> for LevelFilter {
         match level {
             LogLevel::Off => LevelFilter::Off,
             LogLevel::Error => LevelFilter::Error,
-            LogLevel::Warning => LevelFilter::Warn,
+            LogLevel::Warn => LevelFilter::Warn,
             LogLevel::Info => LevelFilter::Info,
             LogLevel::Debug => LevelFilter::Debug,
             LogLevel::Trace => LevelFilter::Trace,
@@ -180,7 +180,7 @@ mod tests {
     fn log_levels_map_to_filters() {
         assert_eq!(LevelFilter::from(LogLevel::Off), LevelFilter::Off);
         assert_eq!(LevelFilter::from(LogLevel::Error), LevelFilter::Error);
-        assert_eq!(LevelFilter::from(LogLevel::Warning), LevelFilter::Warn);
+        assert_eq!(LevelFilter::from(LogLevel::Warn), LevelFilter::Warn);
         assert_eq!(LevelFilter::from(LogLevel::Info), LevelFilter::Info);
         assert_eq!(LevelFilter::from(LogLevel::Debug), LevelFilter::Debug);
         assert_eq!(LevelFilter::from(LogLevel::Trace), LevelFilter::Trace);


### PR DESCRIPTION
The OPNsense plugin's dropdown stores `warn`, which the daemon accepted only as `warning`, so picking "Warning" in the GUI left the service refusing to start.

Breaking: `log_level = "warning"` no longer parses. No alias and no migration, hence the minor bump.

Also documents that `trace` behaves as `debug`, since release builds set `release_max_level_debug` and the level has never done anything in a shipped binary.

## Testing

`warn` accepted and `warning` rejected, checked against the built binary. Man page rendered and linted.

Host 452/452, Linux 451/451, clippy, fmt and doc clean on both, Docker e2e 57/57.