### PR TITLE
e2e: fail fast on a hung command, and always capture the console

### DIFF
--- a/.github/workflows/build-daemon-pkgs.yml
+++ b/.github/workflows/build-daemon-pkgs.yml
@@ -86,6 +86,6 @@ jobs:
           name: daemon-pkg-freebsd-${{ matrix.os }}-${{ matrix.arch.abi }}
           path: out/*.pkg
           if-no-files-found: error
-      - name: Console on failure
-        if: failure()
+      - name: VM console log
+        if: always()
         run: ci/freebsd-vm.sh console

--- a/.github/workflows/ci-opnsense.yml
+++ b/.github/workflows/ci-opnsense.yml
@@ -122,8 +122,8 @@ jobs:
           ci/freebsd-vm.sh run 'pkg add /root/netflector.pkg'
           ci/freebsd-vm.sh run 'pkg add /root/os-netflector-*.pkg'
           ci/opnsense-exercise.sh
-      - name: Console on failure
-        if: failure()
+      - name: VM console log
+        if: always()
         run: ci/freebsd-vm.sh console
 
   # The aggregate the ruleset requires: green only when every job above is.

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -126,8 +126,8 @@ jobs:
       - name: Deinstall
         run: |
           ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make deinstall'
-      - name: Console on failure
-        if: failure()
+      - name: VM console log
+        if: always()
         run: ci/freebsd-vm.sh console
 
   # The aggregate the ruleset requires: green only when every job above is.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           export "${prefix}_RUSTFLAGS=${{ matrix.profile.rustflags }}"
           cargo ${FREEBSD_TOOLCHAIN:-} test --locked --target "$triple" ${{ matrix.profile.flags }}
       - name: VM console log
-        if: failure()
+        if: always()
         run: ci/freebsd-vm.sh console
 
   # The native e2e suite on a real FreeBSD kernel: epair segments, every participant in its own
@@ -222,7 +222,7 @@ jobs:
           ci/freebsd-vm.sh push e2e target/${{ matrix.arch.triple }}/release/netflector /root/netflector/
           ci/freebsd-vm.sh run 'cd /root/netflector && python3 e2e/run.py --backend native --binary ./netflector'
       - name: VM console log
-        if: failure()
+        if: always()
         run: ci/freebsd-vm.sh console
 
   # The port built from this commit's source instead of the pinned release
@@ -292,8 +292,8 @@ jobs:
           ci/freebsd-vm.sh run 'sysrc netflector_enable=YES'
           ci/freebsd-vm.sh run 'printf "[reflectors.bad]\nsource_if = \"em0\"\ntarget_if = \"em0\"\nmdns = true\n" > /usr/local/etc/netflector.toml'
           ci/freebsd-vm.sh run 'service netflector start 2>&1 | grep -q "refusing to start" && echo "rc refused an invalid configuration"'
-      - name: Console on failure
-        if: failure()
+      - name: VM console log
+        if: always()
         run: ci/freebsd-vm.sh console
 
   # The e2e suite with netflector under Valgrind memcheck (the runtime-valgrind image: a glibc release

--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -155,8 +155,8 @@ jobs:
           name: signed-trees
           path: signed-trees.tar
           if-no-files-found: error
-      - name: Console on failure
-        if: failure()
+      - name: VM console log
+        if: always()
         run: ci/freebsd-vm.sh console
 
   gate:
@@ -231,8 +231,8 @@ jobs:
         run: |
           ci/freebsd-vm.sh run 'pkg install -y os-netflector'
           ci/opnsense-exercise.sh
-      - name: Console on failure
-        if: failure()
+      - name: VM console log
+        if: always()
         run: ci/freebsd-vm.sh console
 
   push:

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -141,8 +141,8 @@ jobs:
           name: plugin-pkg-freebsd-${{ matrix.os }}
           path: out/*.pkg
           if-no-files-found: error
-      - name: Console on failure
-        if: failure()
+      - name: VM console log
+        if: always()
         run: ci/freebsd-vm.sh console
 
   build-daemon:

--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -259,7 +259,11 @@ pull)
     shift
     pull "$@"
     ;;
-console) cat "$VM_DIR/console.log" ;;
+console)
+    # Dumped unconditionally by the workflows, including on a job the runner cancels, so a run that
+    # never got as far as launching the VM must not fail the step.
+    cat "$VM_DIR/console.log" 2>/dev/null || echo "no console log: the VM was never launched"
+    ;;
 *)
     echo "usage: $0 launch|wait|run CMD|push SRC... DEST|pull SRC DEST|console" >&2
     exit 64

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -236,6 +236,11 @@ CONTAINER_READY_TIMEOUT_SECONDS = 15.0
 # A clean SIGTERM exit triggers valgrind's leak analysis; give `docker stop` this much grace before it
 # SIGKILLs, so the analysis (which can take tens of seconds) finishes and its exit code is read.
 VALGRIND_STOP_GRACE_SECONDS = 60
+
+# Ceiling on one setup or teardown command. Well above the slowest of them (a probe run waits at most
+# ~8s), so it only ever fires on a wedge; the emulated arm64 lanes are the slow case to clear.
+COMMAND_TIMEOUT_SECONDS = 120.0
+
 NETFLECTOR_SOURCE_IFNAME = "wol_src"
 NETFLECTOR_TARGET_IFNAME = "wol_dst"
 RECEIVER_IFNAME = "probe0"
@@ -250,6 +255,12 @@ class CommandError(RuntimeError):
         self.command = command
         self.result = result
         super().__init__(f"command failed with exit code {result.returncode}: {format_command(command)}")
+
+
+class CommandTimeout(RuntimeError):
+    def __init__(self, command: list[str], timeout: float) -> None:
+        self.command = command
+        super().__init__(f"command hung for {timeout:g}s: {format_command(command)}")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -929,15 +940,51 @@ def run_command(
     check: bool = True,
     capture: bool = True,
     echo: bool = True,
+    timeout: float = COMMAND_TIMEOUT_SECONDS,
 ) -> subprocess.CompletedProcess[str]:
     if echo:
         print(f"+ {format_command(command)}", flush=True)
     stdout = subprocess.PIPE if capture else None
     stderr = subprocess.PIPE if capture else None
-    result = subprocess.run(command, cwd=cwd, text=True, stdout=stdout, stderr=stderr, check=False)
+    proc = subprocess.Popen(command, cwd=cwd, text=True, stdout=stdout, stderr=stderr)
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        dump_stack(proc.pid)
+        proc.kill()
+        proc.communicate()
+        raise CommandTimeout(command, timeout) from None
+    result = subprocess.CompletedProcess(command, proc.returncode, out, err)
     if check and result.returncode != 0:
         raise CommandError(command, result)
     return result
+
+
+def dump_stack(pid: int) -> None:
+    """Print what `pid` is blocked on, best-effort.
+
+    Linux exposes the wait channel through /proc, readable without root and untruncated, unlike the
+    six characters `ps` prints (`hrtime` vs `hrtimer_nanosleep`). FreeBSD has no such procfs but does
+    have procstat, whose kernel stack is better still. `ps` covers whatever is left; its `wchan:32`
+    spelling would fix the truncation but BSD ps rejects it.
+    """
+    wchan = Path(f"/proc/{pid}/wchan")
+    if wchan.exists():
+        state = ""
+        for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+            if line.startswith("State:"):
+                state = line
+        print(f"--- hung pid {pid} ---\n{state}\nwchan: {wchan.read_text()}", flush=True)
+        return
+    for probe in (["procstat", "-kk", str(pid)], ["ps", "-o", "pid,stat,wchan,args", "-p", str(pid)]):
+        try:
+            out = subprocess.run(probe, text=True, capture_output=True, timeout=15, check=False)
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        if out.returncode == 0 and out.stdout.strip():
+            print(f"--- {probe[0]} for the hung pid {pid} ---\n{out.stdout}", flush=True)
+            return
+    print(f"--- no stack available for the hung pid {pid} ---", flush=True)
 
 
 def docker(


### PR DESCRIPTION
The freebsd14-arm64 e2e lane wedged on `ifconfig <epair> destroy` in an interface-recreate case and sat there until the 40-minute job timeout. Two things made that worse than it needed to be.

`run_command` waited without a timeout, so one stuck guest command spent the entire job budget. It now fails after 120s, well clear of the slowest synchronous command (a probe waits ~8s), and dumps where the process is blocked before killing it: `/proc/<pid>/wchan` plus `State:` on Linux, `procstat -kk` on FreeBSD, `ps` elsewhere. `/proc` rather than `ps` on Linux because `ps` truncates the wait channel to six characters (`hrtime` for `hrtimer_nanosleep`), and `-o wchan:32` fixes that on procps but is rejected by BSD ps.

All nine console dumps were `if: failure()`. A GitHub timeout *cancels* the job, which is not a failure, so the guest state was skipped precisely when it was wanted - this incident produced none. They are now `if: always()`, six of them renamed from "Console on failure" accordingly, and `freebsd-vm.sh console` tolerates a VM that never launched so an unconditional dump cannot fail a step on its own.

The hang itself is not addressed here, and the recreate cases stay deliberately racy: destroying an interface under a live daemon is the scenario under test. This is about failing in seconds with evidence instead of in 40 minutes without.

## Testing

`dump_stack` exercised on non-root Linux (`/proc` path) and macOS (`ps` path); timeout, success and failure paths of `run_command` all checked directly. Docker e2e 57/57 on the rewritten runner, which every case goes through. All eight workflow files parse; `sh -n` on the script.