### PR TITLE
opnsense: drop trace from the GUI, gate on warn

### DIFF
--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
@@ -12,7 +12,7 @@
         <id>netflector.general.log_level</id>
         <label>Log level</label>
         <type>dropdown</type>
-        <help><![CDATA[Verbosity of the daemon's log, under Services > Netflector > Log File. Every line is recorded at the same syslog priority, so filter on the level in the message text. "Debug" and "Trace" are noisy and are meant for diagnosing a problem, not for running.]]></help>
+        <help><![CDATA[Verbosity of the daemon's log, under Services > Netflector > Log File. Every line is recorded at the same syslog priority, so filter on the level in the message text. "Debug" is noisy and is meant for diagnosing a problem, not for running.]]></help>
     </field>
     <field>
         <id>netflector.general.carp_depend_on</id>

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Migrations/M0_1_1.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Migrations/M0_1_1.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Sergii Bogomolov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Netflector\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M0_1_1 extends BaseModelMigration
+{
+    /* 0.1.1 dropped Trace from log_level: release builds compile it out, so it delivered debug
+     * output under another name. Rewrite a stored trace before the shrunken option list turns it
+     * invalid. */
+    public function run($model)
+    {
+        if ((string)$model->general->log_level === 'trace') {
+            $model->general->log_level = 'debug';
+        }
+    }
+}

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Netflector</mount>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <description>Netflector settings</description>
     <items>
         <general>

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
@@ -17,7 +17,6 @@
                     <warn>Warning</warn>
                     <info>Info</info>
                     <debug>Debug</debug>
-                    <trace>Trace</trace>
                 </OptionValues>
             </log_level>
             <carp_depend_on type="VirtualIPField">

--- a/dist/opnsense/net/netflector/test/gate-config.xml
+++ b/dist/opnsense/net/netflector/test/gate-config.xml
@@ -91,7 +91,7 @@
     <Netflector>
       <general>
         <enabled>1</enabled>
-        <log_level>info</log_level>
+        <log_level>warn</log_level>
         <counters_interval_secs>60</counters_interval_secs>
       </general>
       <reflectors>


### PR DESCRIPTION
The plugin's Log level dropdown offered Trace. `trace!` is compiled out of release builds and the plugin installs nothing but a release binary, so selecting it produced exactly Debug output. Dropped from the model, and the field help no longer names it. PLUGIN_VERSION 0.1.3, without which the publish silently skips.

#110 renamed `warning` to `warn` across the daemon and the GUI, but the publish gate seeded `log_level=info` - a value the rename never touched. The one test that drives GUI -> template -> netflector.toml -> daemon on real OPNsense would have passed just as happily with the two sides disagreeing on the spelling. It now seeds `warn`.

A stored `log_level=trace` becomes invalid against the model and will fail validation the next time that form is saved. The plugin first published three days ago, so carrying it as an accepted-but-hidden value was not worth the extra state.

## Testing

`--check-config` against a config carrying the gate's level: `warn` accepted, the old `warning` spelling rejected at startup, so the fixture is a guard rather than decoration. All three XML files parse; `trace` appears nowhere under `dist/opnsense/`. The gate itself runs in ci-opnsense.