### PR TITLE
ci: let the release tag gate see the tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-tags: true
+          # The gate below needs every tag. fetch-tags on its own leaves the
+          # fetch shallow, so tag auto-follow reaches only the tag being built
+          # and the gate compares that tag against itself.
+          fetch-depth: 0
 
       # Everything else in a release is per-tag, but `latest` and the
       # major.minor image tag are shared state: only the run for the newest

--- a/ci/port-sync.py
+++ b/ci/port-sync.py
@@ -81,7 +81,8 @@ def lockfile_at(tag):
             capture_output=True, text=True, check=True,
         ).stdout
     except subprocess.CalledProcessError:
-        sys.exit(f'no tag {tag}: the port declares a version that was never released')
+        sys.exit(f'no tag {tag} in this clone: either the port declares a version that was never '
+                 f'released, or the checkout is shallow and needs fetch-depth: 0')
 
 
 def crates_from(lock):


### PR DESCRIPTION
`latest` and the `major.minor` image tag are shared state, so release.yml gates them on the tag being the newest one - otherwise an older tag's run drags `:latest`, the `X.Y` image tag and the GitHub Latest marker backwards. The gate reads `git tag --list`, but the manifest job checked out with `fetch-tags: true` and the default depth of 1. On a tag push that fetches `+refs/tags/vX:refs/tags/vX` shallowly, and tag auto-follow only reaches tags pointing into the fetched history - the tip. So exactly one tag is present, the gate compares it against itself, and both outputs are unconditionally true.

`fetch-depth: 0` instead: at depth 0 checkout switches to its all-history refspec, which carries `+refs/tags/*:refs/tags/*`. `fetch-tags` is then redundant and is dropped. Same pattern as ci-port.yml:44, whose port-check job needs tags for `git show <tag>:Cargo.lock`.

Worth knowing: the gate landed in 98f1d92 and is not an ancestor of v0.13.2 or any earlier tag, so it has never executed. The next release is its first run.

The audit that found this also claimed the checkout could die outright on a refspec collision between the pushed tag ref and auto-follow, after per-arch digests were already on GHCR. That did not reproduce on git 2.50.1 - `fetch-depth: 0` with and without `fetch-tags` both exited 0 - so that claim is not carried forward. Dropping `fetch-tags` sidesteps the combination regardless.

The second commit is the same trap one step away. `port-sync.py`'s `lockfile_at` runs `git show <tag>:Cargo.lock` with no fetch and, on failure, blamed the port for declaring an unreleased version - but a shallow checkout produces the identical failure, and the function directly above it already carries a comment about the tag object possibly never having been fetched. The message now names both causes. Message only; `--check` keeps its no-network property.

## Testing

Reproduced all three configurations at git level against a synthetic origin carrying v0.13.0/1/2, using checkout's actual refspecs: current shows only the released tag, `fetch-depth: 0` and `fetch-depth: 0` + `fetch-tags` both show all three. Checked the gate's patterns against the real tag list - `v*` correctly excludes the `os-v*` plugin tags and `v0.13.*` selects the patch line. Swept all 28 checkout steps against every git invocation in the repo's tooling: the release gate and `port-sync.py --check` are the only consumers of local tags or history, and the latter already has `fetch-depth: 0`. `ci/port-sync.py --check` still passes unchanged.