### PR TITLE
dial: don't shed the proxy when a client dies before the accept

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -51,12 +51,13 @@ impl TcpSocket {
         self.local_addr
     }
 
-    /// Accept one pending connection, or `None` if none is pending (the listener is non-blocking, and a
-    /// level-triggered reactor re-fires while more wait). The accepted socket is connected,
+    /// Accept one pending connection, or `None` if there is none to take: either nothing is pending
+    /// (the listener is non-blocking, and a level-triggered reactor re-fires while more wait) or the
+    /// connection that was pending died before we reached it. The accepted socket is connected,
     /// non-blocking, close-on-exec, and `TCP_NODELAY`.
     ///
     /// # Errors
-    /// Propagates a non-`WouldBlock` `accept` failure, or the `setsockopt` failure.
+    /// Propagates an `accept` failure that leaves the connection queued, or the `setsockopt` failure.
     pub(crate) fn accept(&self) -> io::Result<Option<Self>> {
         let Some(fd) = accept_fd(self.fd.as_raw_fd())? else {
             return Ok(None);
@@ -260,7 +261,7 @@ fn accept_fd(fd: RawFd) -> io::Result<Option<OwnedFd>> {
     let raw = unsafe { libc::accept(fd, std::ptr::null_mut(), std::ptr::null_mut()) };
     if raw < 0 {
         let err = io::Error::last_os_error();
-        if would_block(&err) {
+        if nothing_to_accept(&err) {
             return Ok(None);
         }
         return Err(err);
@@ -270,6 +271,32 @@ fn accept_fd(fd: RawFd) -> io::Result<Option<OwnedFd>> {
     #[cfg(target_os = "macos")]
     crate::sys::set_cloexec_nonblock(fd.as_raw_fd())?;
     Ok(Some(fd))
+}
+
+/// Whether a failed `accept` leaves nothing to take rather than reporting a failure to take one.
+/// Either nothing was pending (`EAGAIN`), or the connection that was pending is already gone: the
+/// peer aborted after the handshake (`ECONNABORTED`), or an error queued against that one connection
+/// surfaced here. The kernel drops it either way, so there is nothing to retry and the readiness
+/// clears without us; `accept(2)` says to treat these like `EAGAIN`.
+///
+/// Not a catch-all, and the distinction is the point: `EMFILE`/`ENFILE` and friends fail before a
+/// descriptor exists, leaving the connection queued for a level-triggered listener to re-fire on
+/// without end. Those must reach the caller so it can shed the listener instead of spinning on it.
+fn nothing_to_accept(err: &io::Error) -> bool {
+    would_block(err)
+        || matches!(
+            err.raw_os_error(),
+            Some(
+                libc::ECONNABORTED
+                    | libc::EPROTO
+                    | libc::ENETDOWN
+                    | libc::ENETUNREACH
+                    | libc::EHOSTDOWN
+                    | libc::EHOSTUNREACH
+                    | libc::ENOPROTOOPT
+                    | libc::EOPNOTSUPP
+            )
+        )
 }
 
 /// Start a non-blocking connect to `dst`. `true` if it is still in progress (`EINPROGRESS`), `false` if
@@ -504,6 +531,40 @@ mod tests {
         let server = spin(|| listener.accept());
         assert!(nodelay(&client), "the outbound socket sets TCP_NODELAY");
         assert!(nodelay(&server), "the accepted socket sets TCP_NODELAY");
+    }
+
+    #[test]
+    fn nothing_pending_and_a_client_that_died_first_both_read_as_no_connection() {
+        for errno in [
+            libc::EAGAIN,
+            libc::EWOULDBLOCK,
+            libc::ECONNABORTED,
+            libc::EPROTO,
+            libc::ENETDOWN,
+            libc::ENETUNREACH,
+            libc::EHOSTDOWN,
+            libc::EHOSTUNREACH,
+            libc::ENOPROTOOPT,
+            libc::EOPNOTSUPP,
+        ] {
+            assert!(
+                nothing_to_accept(&io::Error::from_raw_os_error(errno)),
+                "errno {errno} leaves no connection to take, so accept reports None"
+            );
+        }
+    }
+
+    #[test]
+    fn an_accept_that_leaves_the_connection_queued_reaches_the_caller() {
+        // Nothing drained the connection on these, so a level-triggered readiness re-fires on it
+        // forever; the caller has to see the error and shed the listener.
+        for errno in [libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::EINVAL] {
+            assert!(
+                !nothing_to_accept(&io::Error::from_raw_os_error(errno)),
+                "errno {errno} leaves the connection queued and must not be swallowed"
+            );
+        }
+        assert!(!nothing_to_accept(&io::Error::other("not an errno")));
     }
 
     #[test]

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -113,10 +113,11 @@ impl DialDeviceProxy {
     /// is always taken (draining the readiness) even at the shared connection cap, where the client is
     /// then dropped.
     ///
-    /// A failed accept tears the proxy down. `accept` is the only way to drain a pending connection, so
-    /// under `EMFILE` it stays queued and this level-triggered listener re-fires on it without end;
-    /// shedding the proxy stops that and hands its fds back. The device re-mints on its next
-    /// advertisement, as it would after any eviction.
+    /// A failed accept tears the proxy down. `accept` fails only once the connection is stuck in the
+    /// queue -- a client that dies before we reach it arrives as `None` instead -- so under `EMFILE` it
+    /// stays queued and this level-triggered listener re-fires on it without end; shedding the proxy
+    /// stops that and hands its fds back. The device re-mints on its next advertisement, as it would
+    /// after any eviction.
     fn accept_client(
         &self,
         listener: &TcpSocket,
@@ -125,7 +126,7 @@ impl DialDeviceProxy {
     ) -> Option<TcpSocket> {
         let client = match listener.accept() {
             Ok(Some(client)) => client,
-            Ok(None) => return None, // spurious / already taken
+            Ok(None) => return None, // the client died before we reached it, or a spurious readiness
             Err(e) => {
                 log::error!(
                     "dial: accept on the {what} listener failed: {e}; tearing the proxy down, \


### PR DESCRIPTION
Fixes a regression from #108, which is on main and would otherwise ship in the next release.

#108 made a failed `accept` tear the DIAL device proxy down. That is right for `EMFILE`/`ENFILE`: the connection stays queued because no descriptor was ever handed out, and `accept` is the only way to drain it, so a level-triggered listener re-fires on it forever. But `accept_fd` mapped only `EAGAIN`/`EWOULDBLOCK` to `Ok(None)`, so every other errno reached the teardown arm - including `ECONNABORTED`, which is what `accept` returns when the peer aborts between the handshake and the accept.

That made a device proxy evictable by any host on the source segment with one connect followed by an RST: no spoofing, no privilege, and the device stays unproxied until it advertises again. It also fired by accident whenever a client gave up mid-connect. Linux's `accept(2)` says the pending-network-error set should be treated like `EAGAIN` and retried; we shed instead.

The classification belongs to `accept`, not to the DIAL call site - it is `accept(2)` semantics, and putting it there makes every accept caller correct rather than just this one. `nothing_to_accept` folds those errnos in with `EAGAIN`, so `accept` reports `Ok(None)` and the proxy's existing "nothing pending" arm handles it with no new branch.

Two choices worth recording:

**The whitelist runs the other way on purpose.** Only "the connection is already gone" is enumerated; everything else, unknown errnos included, still reaches the caller and still sheds. Enumerating the fatal set instead would leave an unforeseen persistent error to spin, and on a single-threaded reactor a spin wedges the whole daemon, while a spurious teardown is a recoverable blip. The existing `a_failed_accept_sheds_the_proxy` test (which induces `EINVAL`) is unchanged and still passes.

**No new caps.** A daemon-wide connection budget and a lower `MAX_CONNECTIONS` were both considered and rejected in #108, and nothing here revisits that.

Also removes a stale comment on the `Ok(None)` arm claiming the connection could have been "already taken". There is no fd duplication anywhere in `src/`, one production `accept()` call site, and a single-threaded loop, so there is no second consumer that could take it.

## Testing

454 tests on macOS, 453 on Linux via docker_test.sh; Miri clean; `clippy --all-targets -D warnings` clean on the host, armv7, armv5te, `x86_64-unknown-freebsd` and Linux; fmt and `cargo doc` clean. Verified all eight errno constants exist and are mutually distinct on linux/freebsd/apple, so the or-pattern cannot trip `unreachable_patterns` on one target only (the reason `would_block` next door needs a guard instead).

Mutation-tested both directions: dropping `ECONNABORTED` from the set fails exactly the first test, and making the classifier a catch-all fails exactly the second.

The single line in `accept_fd` that calls the classifier is not itself covered - inducing a real `ECONNABORTED` requires an RST to win a race against `accept`, and the suite already carries three known flakes.