### PR TITLE
build: stop restating pinned versions by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,8 @@ jobs:
         if: contains(matrix.target, 'freebsd')
         env:
           FREEBSD_SYSROOT_ARCH: ${{ matrix.freebsd_arch }}
-          # The shipped static assets link against the oldest supported major, so they run on
-          # every newer release ("14.4 or newer" in the README). This moves when the floor moves.
+          # The oldest supported major, so the static assets reach the widest range of releases.
+          # Which point release that is comes from ci/freebsd14.env.
           FREEBSD_SYSROOT_VERSION: 14
         run: |
           ci/freebsd-sysroot.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,12 @@
 # a layer built on its own arch uses rustc's default toolchain, following upstream defaults
 # where one exists.
 
-# Pin the shared base image by digest: reproducible builds, no drift under the floating tag. Renovate
-# keeps it current. Referenced by both the builder and the valgrind runtime below so they stay in lockstep.
-ARG RUST_IMAGE=docker.io/library/rust:slim@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c
+# Pin the shared base image by digest for reproducible builds, with the rustc version in the tag:
+# Renovate re-pins the digest to whatever the tag resolves to, so an unversioned tag lets the image's
+# compiler drift off rust-toolchain.toml while the diff shows only a new hash. Keep this version equal
+# to rust-toolchain.toml's channel. Referenced by both the builder and the valgrind runtime below so
+# they stay in lockstep.
+ARG RUST_IMAGE=docker.io/library/rust:1.97.1-slim@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c
 FROM --platform=$BUILDPLATFORM ${RUST_IMAGE} AS builder
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ netflector runs on **Linux, macOS, and FreeBSD**.
 router that bridges the two segments.
 
 **FreeBSD** isn't a Docker target (Docker shares the host's Linux kernel), so each release also ships
-a standalone **static** binary for `amd64` and `arm64`, cross-built against a FreeBSD 14.4 base and
-running on 14.4 or newer.
+a standalone **static** binary for `amd64` and `arm64`, cross-built against the FreeBSD 14 base
+pinned in `ci/freebsd14.env` and running on that release or newer.
 
 CI runs the unit suite on Ubuntu 24.04 (amd64 and arm64, both glibc and the shipped static musl),
-macOS 15, FreeBSD 14.4 and 15.1 (amd64 and arm64, cross-compiled on the runner and executed in QEMU VMs), and
+macOS 15, FreeBSD 14 and 15 (amd64 and arm64, cross-compiled on the runner and executed in QEMU VMs), and
 the cross-compiled `linux/arm/v7` and `linux/arm/v5` builds whose suites run under QEMU, each in both
 debug and release. `clippy` and the rustdoc link gate run per target. The e2e suite runs on the
 Docker backend for both image arches (plus a Valgrind memcheck job) and natively on linux amd64/arm64

--- a/docker_test.sh
+++ b/docker_test.sh
@@ -28,8 +28,11 @@ cd "$(dirname "$0")"
 [ "$#" -eq 0 ] && set -- test
 
 IMAGE=netflector-devtest
-docker build -q -t "$IMAGE" - >/dev/null <<'DOCKERFILE'
-FROM rust:slim
+rust_version=$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)
+[ -n "$rust_version" ] || { echo "rust-toolchain.toml has no channel" >&2; exit 1; }
+docker build -q -t "$IMAGE" --build-arg RUST_VERSION="$rust_version" - >/dev/null <<'DOCKERFILE'
+ARG RUST_VERSION
+FROM rust:${RUST_VERSION}-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends iproute2 \
     && rm -rf /var/lib/apt/lists/*

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,9 @@
 [toolchain]
-# Pinned (not "stable") so every environment -- host, the rust:slim Docker builds, and the rustup CI
-# lanes -- compiles with one known rustc, and a new stable can't silently change codegen or fail a
-# release build on a fresh warn-by-default lint. Renovate's rust-toolchain manager bumps this via a
-# CI-gated PR. (The freebsd-arm64 lanes build with the pinned nightly from ci/freebsd-nightly.env instead,
-# until stable 1.98 ships aarch64-unknown-freebsd std.)
+# Pinned (not "stable") so every environment -- host, the Docker builds, and the rustup CI lanes --
+# compiles with one known rustc, and a new stable can't silently change codegen or fail a release
+# build on a fresh warn-by-default lint. Renovate's rust-toolchain manager bumps this via a CI-gated
+# PR; the Dockerfile's RUST_IMAGE tag names the same version and has to move with it. (The
+# freebsd-arm64 lanes build with the pinned nightly from ci/freebsd-nightly.env instead, until stable
+# 1.98 ships aarch64-unknown-freebsd std.)
 channel = "1.97.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Two versions were written out by hand next to a pin that moves on its own, with nothing checking that they still agree.

## The base image

The Dockerfile pinned `rust:slim@sha256:...`. The digest makes each build reproducible, but Renovate re-pins it to whatever the tag currently resolves to, and `rust:slim` is unversioned - so the image's rustc tracked the latest release while `rust-toolchain.toml` pinned 1.97.1, and `.dockerignore` keeps that file out of the build context so nothing inside the image corrected it.

The two agreed only by coincidence, and they have already come apart: the 2026-07-14 digest carried rustc 1.97.0, `rust-toolchain.toml` moved to 1.97.1 on 07-17, and the image caught up on 07-18. No release tag fell in that window, so nothing shipped with a mismatched compiler, but the window reopens at every rustc release and lasts as long as the two Renovate PRs sit unmerged relative to each other.

The tag now carries the version. `rust:1.97.1-slim` and `rust:slim` resolve to the same digest today, so the image rebuilds byte-identically; what changes is that moving to a new rustc requires editing a version rather than a hash, which Renovate does automatically for `<version>-<suffix>` tags and which is legible in review.

`docker_test.sh` reads the version out of `rust-toolchain.toml` instead, so it needs no edit when the pin moves.

Two alternatives rejected. Copying `rust-toolchain.toml` into the build and letting rustup install the pin is not the no-op it looks like - measured on a base image already at the pinned version, rustup still syncs the channel and downloads clippy, because the toolchain file requests components the slim image does not ship. That is a network dependency and a linter install per arch, in images that only run `cargo build`. Leaving the tag floating and deleting the claim in `rust-toolchain.toml` is honest but makes the shipped binaries the one artifact not built with the compiler everything else is tested with.

## The FreeBSD release

`RELEASE=14.4` in `ci/freebsd14.env` is Renovate-bumped on every 14.x point release. It was restated in the README's compatibility promise ("cross-built against a FreeBSD 14.4 base and running on 14.4 or newer"), in the README's CI-coverage line, and in a release.yml comment quoting the README back at it. A bump touches only the `.env`, leaving the README promising a floor the binaries no longer have.

The README now points at the pin and says "that release or newer"; the CI line says "FreeBSD 14 and 15", where the point release told the reader nothing; the workflow comment explains why the major is 14 and defers the rest to the pin.

Left alone deliberately: the install section's `(14.3+ and 15.1+)` comes from a different pin pair (`ci/freebsd14-opnsense.env`), and there the number is what someone deciding whether to install is looking for.

Worth revisiting separately: the assets are `+crt-static`, so at runtime the floor is the syscall ABI rather than the base they linked against, and `ci/freebsd14.env` says the intent is "the oldest supported major gives static binaries the widest reach". If that is the goal, the sysroot should come from 14.0 rather than whatever point release CI pins, and the promise becomes a stable "FreeBSD 14 or newer". That is a build change, not a comment change.

## Testing

`./docker_test.sh` rebuilt from the derived tag runs `test --lib` (453), `clippy --all-targets -- -D warnings` and `fmt --check` clean - the last exercising the rustfmt component the toolchain file requires. The missing-channel guard exits 1 with its message instead of building `rust:-slim`. Verified `rust:1.97.1-slim` and `rust:slim` currently resolve to the same digest, and that the digest carries rustc 1.97.1. release.yml parses.