### PR TITLE
ci: close four gaps in what the pipelines actually exercise

### DIFF
--- a/.github/workflows/build-daemon-pkgs.yml
+++ b/.github/workflows/build-daemon-pkgs.yml
@@ -16,7 +16,11 @@
 # When a new series lands (~Jan/Jul), add its knobs: the pin here (repin via
 # `ci/freebsd-pin.sh <base> opnsense`), the plugins_branch matrix in
 # publish-plugin.yml, the gate matrix in pkg-deploy.yml, the exercise matrix
-# and pin paths in ci-opnsense.yml, and the ABI trees.
+# and pin paths in ci-opnsense.yml together with the matching paths-ignore
+# entries in ci.yml (the two lists are one partition), and the ABI trees. A
+# series on a FreeBSD major we do not build yet needs ci/freebsd<major>.env
+# and its renovate.json manager and packageRule as well, plus the os matrix
+# in ci.yml, ci-port.yml and here.
 # Retire a series' knobs when upstream ends it; keep-all retention leaves its
 # published packages downloadable. A stale pin cannot ship: the gate installs
 # from the signed tree on real OPNsense and rejects the mismatch.

--- a/.github/workflows/ci-opnsense.yml
+++ b/.github/workflows/ci-opnsense.yml
@@ -21,6 +21,10 @@ on:
       - 'ci/freebsd-plugin-package.sh'
       - 'ci/freebsd-to-opnsense.sh'
       - 'ci/opnsense-exercise.sh'
+      # Shared with ci.yml rather than exclusive to this pipeline, so both fire
+      # on it: the 14.3 cloud-init seed and the extra-NIC setup are reached
+      # only under the OPNsense pins, which ci.yml's lanes never use.
+      - 'ci/freebsd-vm.sh'
   workflow_call:
     inputs:
       # For publish-plugin: pkg-deploy's gate runs the same journey against

--- a/.github/workflows/ci-opnsense.yml
+++ b/.github/workflows/ci-opnsense.yml
@@ -109,10 +109,13 @@ jobs:
             version="${version}_${revision}"
           fi
           url="https://netflector.github.io/pkg/opnsense/${{ matrix.abi }}/latest/netflector-${version}.pkg"
-          if ! ci/freebsd-vm.sh run "fetch -qo /root/netflector.pkg '$url'"; then
-            # Pair state: the pinned version is not published yet. Build it
-            # from the port, the same way build-daemon-pkgs.yml will.
-            echo "daemon ${version} not published; building it from the port"
+          # PRs always build from the port: this pipeline is the only one that fires on
+          # ci/freebsd-port-package.sh, and once the pinned version is published the fetch
+          # succeeds and the script never runs. A publish prefers the published package and
+          # falls back to the port only in the pair state, as build-daemon-pkgs.yml does.
+          if [ '${{ github.event_name }}' = pull_request ] \
+              || ! ci/freebsd-vm.sh run "fetch -qo /root/netflector.pkg '$url'"; then
+            echo "building the daemon ${version} from the port"
             ci/freebsd-port-package.sh
             ci/freebsd-vm.sh run 'cp /usr/ports/net/netflector/work/pkg/netflector-*.pkg /root/netflector.pkg'
           fi

--- a/ci/opnsense-exercise.sh
+++ b/ci/opnsense-exercise.sh
@@ -2,7 +2,8 @@
 # Exercise the installed plugin on the converted OPNsense VM (ci/freebsd-vm.sh
 # env applies), the way a user's firewall runs it: the model checked against
 # this core, the configuration rendered by real configd, validated by the
-# daemon, the service started. No sysrc: the seeded config.xml arms the
+# daemon and through the GUI's own check action, the service started. No sysrc:
+# the seeded config.xml arms the
 # service through the plugin's rc.conf.d template, the same path a user's
 # firewall takes (and /etc/rc.conf.d overrides rc.conf anyway).
 set -euo pipefail
@@ -14,4 +15,16 @@ HERE="$(dirname "$0")"
 "$HERE"/freebsd-vm.sh run 'test -s /usr/local/etc/netflector.toml'
 "$HERE"/freebsd-vm.sh run 'cat /usr/local/etc/netflector.toml'
 "$HERE"/freebsd-vm.sh run 'netflector --check-config /usr/local/etc/netflector.toml'
+
+# The GUI's validate button, end to end: the configd action wiring plus check.py,
+# which nothing else runs. configd reads actions.d at startup and the plugin was
+# pkg-added into a running system, so its actions appear only after a restart.
+"$HERE"/freebsd-vm.sh run 'service configd restart'
+verdict=$("$HERE"/freebsd-vm.sh run 'configctl netflector check')
+echo "$verdict"
+case "$verdict" in
+*'"status": "ok"'*) ;;
+*) echo "the configd check action did not report ok" >&2; exit 1 ;;
+esac
+
 "$HERE"/freebsd-vm.sh run 'service netflector start && sleep 2 && service netflector status'


### PR DESCRIPTION
Four places where a pipeline reported green without running the thing it owns.

**ci/freebsd-vm.sh fired only ci.yml.** It is in no pipeline's `paths` and reaches CI only by falling through ci.yml's `paths-ignore`. Two of its branches are unreachable from there: the `RELEASE = 14.3` cloud-init seed (14.3 comes from ci/freebsd14-opnsense.env, while ci.yml runs the 14.4/15.1 pins) and the `FREEBSD_VM_EXTRA_NICS` setup, which only ci-opnsense.yml and pkg-deploy.yml set. Adding it to ci-opnsense.yml's `paths` makes both fire, the same dual-fire arrangement ci/port-sync.py already has. The three-way partition invariant still holds.

**ci/freebsd-port-package.sh merged unexecuted.** ci-opnsense.yml is the only pipeline that fires on it, and it ran the script solely in the `if !` fallback taken when the pinned daemon is not yet published. In the steady state the fetch succeeds and not a line of it runs. The port build is now unconditional on `pull_request`; publish-plugin.yml triggers on `push`, so under `workflow_call` a publish still prefers the published package and falls back to the port only in the pair state. Costs a few minutes inside a job whose 45-minute budget was already sized for that branch.

**The add-a-series checklist was incomplete.** build-daemon-pkgs.yml carries the enumerated knob list for a new OPNsense series. It named ci-opnsense.yml's pin paths but not the matching `paths-ignore` in ci.yml - the two are one partition - and said nothing about a series landing on a FreeBSD major we do not build yet, which also needs ci/freebsd<major>.env, its renovate manager and packageRule, and the `os` matrix in ci.yml, ci-port.yml and build-daemon-pkgs.yml itself. All six workflows carry that matrix. A checklist that is silently incomplete is worse than none, because whoever adds a series stops when they have done everything it names.

**check.py and the configd actions were never executed.** check.py backs the GUI's validate button and was only fed to `py_compile`; the plugin's configd actions (check/start/stop/restart/status) were never invoked through `configctl` at all - the existing `configctl template reload` is a core action. Both reach `/usr/local/opnsense/service/modules`, the internal API that differs between the 26.1 and 26.7 cores this job already boots, so a break there ships silently to the one button users press before applying. The exercise now restarts configd (it reads actions.d at startup, and the plugin arrives by `pkg add` into a live system), runs `configctl netflector check`, and fails unless the verdict is `ok`.

Two findings from the same audit were dropped rather than fixed, recorded here so they are not re-raised:

- *CI does not run on push to main.* The premise is false: the repo's ruleset is active with `required_status_checks strict:true` plus a pull_request rule, so a PR cannot merge onto a moved main and the post-merge state is the tested one. release.yml runs the full ci.yml on every tag. The only direct pushes are version bumps via the admin bypass, which need no CI.
- *Partition hole for >300-file PRs, plus workflow_dispatch on the siblings.* The real GitHub limit is 3,000, not 300, and with 142 tracked files and a largest-ever PR of 18 it is unreachable. Nothing fires only when a sibling workflow is deleted, and the pipeline to dispatch then is ci.yml, which already can be.

## Testing

Verified the trigger change makes ci-opnsense.yml fire on ci/freebsd-vm.sh while ci.yml still does, and that every ci.yml ignore entry is still claimed by a sibling's `paths`. Confirmed publish-plugin.yml triggers on `push` so the event-name guard distinguishes PR from publish, and checked the generated step is valid shell with a PR event substituted in. Checked the extended checklist now names all seven per-major knobs that exist. Asserted the configd verdict against all three shapes check.py can emit (`ok` passes; `failed` and `idle` fail). `bash -n` and shellcheck clean; all workflow files parse.

This PR touches ci/opnsense-exercise.sh and ci-opnsense.yml, so its own run exercises both new steps on each series.