### PR TITLE
ci: harden the publish and packaging scripts

### DIFF
--- a/.github/workflows/ci-opnsense.yml
+++ b/.github/workflows/ci-opnsense.yml
@@ -25,6 +25,7 @@ on:
       # on it: the 14.3 cloud-init seed and the extra-NIC setup are reached
       # only under the OPNsense pins, which ci.yml's lanes never use.
       - 'ci/freebsd-vm.sh'
+      - 'ci/pkg-published.sh'
   workflow_call:
     inputs:
       # For publish-plugin: pkg-deploy's gate runs the same journey against
@@ -56,6 +57,31 @@ jobs:
           rm -rf dist/opnsense/net/netflector/src/opnsense/scripts/netflector/__pycache__
       - name: XML well-formed
         run: find dist/opnsense -name '*.xml' -exec xmllint --noout {} +
+      # The publish guards read this; nothing else would run it before a publish does.
+      - name: Published-probe answers both ways
+        run: |
+          abis=$(ci/pkg-published.sh --abis)
+          echo "probes:"; echo "$abis" | sed 's/^/  /'
+          # Rebuilt a second way, so a wrong sort or a dropped arch is caught.
+          expected=$(for m in $(ls ci/freebsd*-opnsense.env \
+                                | sed 's|.*freebsd\([0-9]*\)-opnsense\.env|\1|' | sort -n); do
+                       printf 'FreeBSD:%s:amd64\nFreeBSD:%s:aarch64\n' "$m" "$m"
+                     done)
+          [ "$abis" = "$expected" ] \
+            || { echo "::error::probed trees do not match the served pins"; exit 1; }
+
+          probe=$(mktemp -d)
+          [ "$(ci/pkg-published.sh "$probe" 9.9.9)" = false ] \
+            || { echo "::error::empty catalogue reported as published"; exit 1; }
+          while read -r abi; do
+            mkdir -p "$probe/opnsense/$abi/latest"
+            touch "$probe/opnsense/$abi/latest/netflector-9.9.9.pkg"
+          done <<< "$abis"
+          [ "$(ci/pkg-published.sh "$probe" 9.9.9)" = true ] \
+            || { echo "::error::complete catalogue not reported as published"; exit 1; }
+          rm "$probe/opnsense/$(echo "$abis" | tail -1)/latest/netflector-9.9.9.pkg"
+          [ "$(ci/pkg-published.sh "$probe" 9.9.9)" = false ] \
+            || { echo "::error::half-finished publish reported as published"; exit 1; }
 
   # One VM per series: build the plugin package on stock FreeBSD, then convert
   # the VM to OPNsense and put the package through the whole user journey. The

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -81,6 +81,8 @@ jobs:
         run: ci/freebsd-ports-tree.sh
       - name: Install the port into the tree
         run: |
+          # scp -r nests into an existing directory; see ci/freebsd-port-package.sh.
+          ci/freebsd-vm.sh run 'rm -rf /usr/ports/net/netflector'
           ci/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
           # net/Makefile's SUBDIR list is a deliverable of the submission, and portlint checks it.
           ci/freebsd-vm.sh run 'cd /usr/ports/net && awk "/^ *SUBDIR \+= / && !ins && \$3 > \"netflector\" { print \"    SUBDIR += netflector\"; ins = 1 } { print } END { if (!ins) print \"    SUBDIR += netflector\" }" Makefile > Makefile.new && mv Makefile.new Makefile && grep -n "SUBDIR += netflector" Makefile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,8 @@ jobs:
         run: ci/freebsd-ports-tree.sh
       - name: Build and install from this commit
         run: |
+          # scp -r nests into an existing directory; see ci/freebsd-port-package.sh.
+          ci/freebsd-vm.sh run 'rm -rf /usr/ports/net/netflector'
           ci/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
           # DISTFILES lists the cargo crates first and the GH tarball last;
           # provide this commit under the tarball and WRKSRC names the port expects.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
       - 'ci/freebsd-plugin-package.sh'
       - 'ci/freebsd-to-opnsense.sh'
       - 'ci/opnsense-exercise.sh'
+      - 'ci/pkg-published.sh'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/publish-daemon.yml
+++ b/.github/workflows/publish-daemon.yml
@@ -44,7 +44,7 @@ jobs:
             version="${version}_${revision}"
           fi
           git clone -q --depth 1 https://github.com/netflector/pkg pkg-repo
-          if [ -e "pkg-repo/opnsense/FreeBSD:14:amd64/latest/netflector-${version}.pkg" ]; then
+          if [ "$(ci/pkg-published.sh pkg-repo "$version")" = true ]; then
             echo "netflector-${version} is already published; nothing to do."
             echo "publish=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -51,7 +51,7 @@ jobs:
           fi
           git clone -q --depth 1 https://github.com/netflector/pkg pkg-repo
           echo "port=${port}" >> "$GITHUB_OUTPUT"
-          if [ -e "pkg-repo/opnsense/FreeBSD:14:amd64/latest/netflector-${port}.pkg" ]; then
+          if [ "$(ci/pkg-published.sh pkg-repo "$port")" = true ]; then
             echo "daemon ${port} is already published; plugin-only publish"
             echo "pair=false" >> "$GITHUB_OUTPUT"
           else

--- a/ci/freebsd-pin.sh
+++ b/ci/freebsd-pin.sh
@@ -16,16 +16,17 @@ cd "$(dirname "$0")"
 
 [ $# -le 2 ] || { echo "usage: freebsd-pin.sh [release [opnsense]]" >&2; exit 64; }
 
-# The CI pins track current releases and stay on the download CDN. The
-# OPNsense-base pins freeze a release for a whole series and outlive its EOL,
-# when download.freebsd.org drops it; the archive keeps every release forever,
-# byte-identical, so they prefer it (falling back only while a base is too
-# young to have been archived).
+# The CI pins track current releases and stay on the download CDN, which is
+# geo-distributed where the archive is a single US host. The OPNsense-base pins freeze
+# a release for a whole series and outlive its EOL, when download.freebsd.org drops it,
+# so they take the archive unconditionally: it carries every release byte-identical,
+# current ones included, and nothing on the CDN is missing from it (checked 2026-07-28:
+# 27 releases against the CDN's 4, no gaps). There is no fallback to make -- a base too
+# new to be archived fails the checksum fetch below, rather than pinning a CDN URL that
+# expires with the release.
 mirror_for() { # $1 = release, $2 = variant; prints the mirror root
-    local archive="https://archive.freebsd.org/old-releases"
-    if [ "${2:-}" = opnsense ] &&
-            curl -fsIL -o /dev/null "$archive/VM-IMAGES/${1}-RELEASE/amd64/Latest/CHECKSUM.SHA512"; then
-        echo "$archive"
+    if [ "${2:-}" = opnsense ]; then
+        echo "https://archive.freebsd.org/old-releases"
     else
         echo "https://download.freebsd.org/releases"
     fi

--- a/ci/freebsd-plugin-package.sh
+++ b/ci/freebsd-plugin-package.sh
@@ -13,6 +13,10 @@ HERE="$(dirname "$0")"
 
 "$HERE"/freebsd-vm.sh run 'pkg install -y git'
 "$HERE"/freebsd-vm.sh run "git clone -q --depth 1 -b $branch https://github.com/opnsense/plugins /plugins"
+# scp -r copies INTO an existing directory, so the day net/netflector lands in
+# opnsense/plugins this push starts nesting ours a level down and make below builds
+# the branch's plugin instead: green, and testing nothing of the change.
+"$HERE"/freebsd-vm.sh run 'rm -rf /plugins/net/netflector'
 "$HERE"/freebsd-vm.sh push dist/opnsense/net/netflector /plugins/net/netflector
 "$HERE"/freebsd-vm.sh run 'cd /plugins/net/netflector && make package'
 "$HERE"/freebsd-vm.sh run 'find /plugins/net/netflector/work -name "*.pkg"'

--- a/ci/freebsd-port-package.sh
+++ b/ci/freebsd-port-package.sh
@@ -10,5 +10,9 @@ set -euo pipefail
 HERE="$(dirname "$0")"
 
 "$HERE"/freebsd-ports-tree.sh
+# scp -r copies INTO an existing directory, so the day net/netflector lands upstream this
+# push starts nesting ours at net/netflector/netflector and every make below builds the
+# tree's port instead: green, and testing nothing of the change.
+"$HERE"/freebsd-vm.sh run 'rm -rf /usr/ports/net/netflector'
 "$HERE"/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
 "$HERE"/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make ALLOW_UNSUPPORTED_SYSTEM=yes package'

--- a/ci/freebsd-ssh-runner.sh
+++ b/ci/freebsd-ssh-runner.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# cargo target runner for x86_64-unknown-freebsd: cargo hands it the host path
-# of each cross-built test executable plus libtest args; copy the binary into
-# the VM ci/freebsd-vm.sh booted and run it there as root (the privileged
-# tests -- interface pairs, BPF captures, joins -- run instead of skipping).
-# The remote exit status is the runner's, which cargo treats as the test
-# result. cargo runs test binaries serially, so one ssh session at a time.
+# cargo target runner for the <arch>-unknown-freebsd targets: cargo hands it
+# the host path of each cross-built test executable plus libtest args; copy the
+# binary into the VM ci/freebsd-vm.sh booted and run it there as root (the
+# privileged tests -- interface pairs, BPF captures, joins -- run instead of
+# skipping). The remote exit status is the runner's, which cargo treats as the
+# test result. cargo runs test binaries serially, so one ssh session at a time.
 set -euo pipefail
 
 VM_DIR=${FREEBSD_VM_DIR:-$HOME/.freebsd-vm}

--- a/ci/freebsd-to-opnsense.sh
+++ b/ci/freebsd-to-opnsense.sh
@@ -52,7 +52,17 @@ sed "s|__SSH_PUBKEY_B64__|$b64|" \
     fi
 '
 
-# The conversion ends in a reboot that kills the ssh session.
+# The conversion ends in a reboot that kills the ssh session, so the exit status says
+# nothing and has to be discarded. opnsense-version is no post-condition either:
+# bootstrap pkg-installs it before the base swap, so it answers happily on a VM that
+# never rebooted. The kernel string is what the swap actually replaces.
+kernel_before=$("$HERE"/freebsd-vm.sh run 'uname -v')
 "$HERE"/freebsd-vm.sh run "sh /tmp/bootstrap.sh -y -r $series" || true
 "$HERE"/freebsd-vm.sh wait
+kernel_after=$("$HERE"/freebsd-vm.sh run 'uname -v')
+if [ "$kernel_after" = "$kernel_before" ]; then
+    echo "opnsense-bootstrap left the kernel at: $kernel_after" >&2
+    echo "it died before the base swap and reboot" >&2
+    exit 1
+fi
 "$HERE"/freebsd-vm.sh run 'opnsense-version'

--- a/ci/pkg-published.sh
+++ b/ci/pkg-published.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Is a daemon version already in the published catalogue? Prints true or false on
+# stdout, and a found/missing line per tree on stderr.
+#
+#   ci/pkg-published.sh <pkg-repo-clone> <version>   # e.g. ... pkg-repo 0.13.2_1
+#   ci/pkg-published.sh --abis                       # the trees it would probe
+#
+# true only when EVERY served tree has it. One publish writes them all, so a partial
+# result means a publish died midway, and calling that published would freeze the gap:
+# both callers skip a version once, and nothing ever revisits it.
+#
+# The majors are derived, never written down. ci/freebsd<major>-opnsense.env exists for
+# exactly the ones we serve, so adding or retiring a series moves this probe with no
+# edit here -- which matters because keep-all retention leaves a retired tree in place
+# but unwritten, and a probe pinned to it would never match again.
+set -euo pipefail
+
+# Every served major is built for both of these; matches build-daemon-pkgs.yml's arch
+# matrix. pkg's ABI string spells arm64 as the processor name, aarch64.
+ARCHES=(amd64 aarch64)
+
+here=$(dirname "$0")
+
+served_abis() {
+    local majors=() pin
+    for pin in "$here"/freebsd*-opnsense.env; do
+        [ -e "$pin" ] || continue
+        pin=${pin##*/}
+        pin=${pin#freebsd}
+        majors+=("${pin%-opnsense.env}")
+    done
+    # Stop rather than guess: an invented ABI would answer "not published" and
+    # republish over a released package.
+    [ ${#majors[@]} -gt 0 ] || {
+        echo "no ci/freebsd<major>-opnsense.env: cannot tell which trees to probe" >&2
+        return 1
+    }
+    local major arch
+    for major in $(printf '%s\n' "${majors[@]}" | sort -n); do
+        for arch in "${ARCHES[@]}"; do
+            echo "FreeBSD:${major}:${arch}"
+        done
+    done
+}
+
+if [ "${1:-}" = --abis ]; then
+    served_abis
+    exit 0
+fi
+
+repo=${1:?usage: pkg-published.sh <pkg-repo-clone> <version> | --abis}
+version=${2:?usage: pkg-published.sh <pkg-repo-clone> <version> | --abis}
+
+# Assigned before the loop so a failure to resolve the trees exits here, rather than
+# feeding an empty list into a loop that would then report everything present.
+abis=$(served_abis)
+
+found=0
+missing=0
+while read -r abi; do
+    if [ -e "$repo/opnsense/$abi/latest/netflector-${version}.pkg" ]; then
+        printf '  %-24s found\n' "$abi" >&2
+        found=$((found + 1))
+    else
+        printf '  %-24s missing\n' "$abi" >&2
+        missing=$((missing + 1))
+    fi
+done <<< "$abis"
+
+if [ "$missing" -eq 0 ]; then
+    echo true
+else
+    if [ "$found" -gt 0 ]; then
+        echo "netflector-${version} is in $found tree(s) and missing from $missing: a publish did not finish" >&2
+    fi
+    echo false
+fi

--- a/ci/port-sync.py
+++ b/ci/port-sync.py
@@ -199,7 +199,17 @@ def update(version):
     print(f'  {tarball_name(version)}: {len(tarball)} bytes')
 
     makefile = MAKEFILE.read_text()
+    previous = re.search(r'^DISTVERSION=\t(.+)$', makefile, re.M)
     makefile = re.sub(r'^DISTVERSION=\t.+$', f'DISTVERSION=\t{version}', makefile, flags=re.M)
+    # PORTREVISION counts port-only changes against one DISTVERSION, so moving the version
+    # retires it: kept, it would publish netflector-<new>_<n>, claiming a revision of a
+    # version that has only just appeared. Guarded on the version actually moving, because
+    # --update is also how hashes get regenerated at the current version, and that must not
+    # undo a deliberate bump.
+    if previous and previous.group(1).strip() != version:
+        makefile, dropped = re.subn(r'^PORTREVISION=[^\n]*\n', '', makefile, flags=re.M)
+        if dropped:
+            print(f'  dropped PORTREVISION (it counted revisions of {previous.group(1).strip()})')
     makefile = re.sub(r'^CARGO_CRATES=\t(?:.*\\\n)*.*$', render_crates(crates), makefile, flags=re.M)
     MAKEFILE.write_text(makefile)
     DISTINFO.write_text(render_distinfo(crates, sizes, tarball_sha, len(tarball), version))

--- a/release-lib.sh
+++ b/release-lib.sh
@@ -28,10 +28,17 @@ ensure_releasable() {
 }
 
 # ensure_tag_absent <tag> <bump hint>: fail if the tag exists locally or on origin.
+# Origin first: once the tag is published the version is spent whatever the local tree
+# says, and the bump hint is the right advice.
 ensure_tag_absent() {
-    if git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1 \
-            || git ls-remote --exit-code --tags origin "refs/tags/$1" >/dev/null 2>&1; then
-        echo "Tag $1 already exists; $2." >&2
+    if git ls-remote --exit-code --tags origin "refs/tags/$1" >/dev/null 2>&1; then
+        echo "Tag $1 is already on origin; $2." >&2
+        exit 1
+    fi
+    if git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1; then
+        # confirm_and_push_tag cleans up after itself, so this means an interrupted run or a
+        # tag made by hand. The version is unspent either way, and bumping it would be wrong.
+        echo "Tag $1 exists locally but not on origin; push it or delete it." >&2
         exit 1
     fi
 }
@@ -48,5 +55,13 @@ confirm_and_push_tag() {
 
     echo "Tagging and pushing $1..."
     git tag -a "$1" -m "Release $1"
-    git push origin "$1"
+    # Leave nothing behind if the push fails -- an ssh agent waiting on approval is the usual
+    # cause. The version is unspent, so a bare re-run should just work rather than land on a
+    # stale local tag. If origin took the tag but the ack never arrived, deleting here is
+    # still right: the next run sees it on origin and says so.
+    if ! git push origin "$1"; then
+        git tag -d "$1" >/dev/null
+        echo "Push failed; removed the local tag $1. Fix the cause and re-run." >&2
+        exit 1
+    fi
 }


### PR DESCRIPTION
Seven findings in the scripts behind publishing, packaging and releasing. Four of them landed differently from what the audit proposed, noted per item.

**The is-published probe was pinned to one ABI.** Both publish guards stat a hardcoded `pkg-repo/opnsense/FreeBSD:14:amd64/latest/netflector-<ver>.pkg` - the only literal ABI outside a matrix row. Retire 14 and keep-all retention leaves that tree in place but unwritten, so the probe never matches again: publish-daemon republishes on every port-path push, overwriting a released package with fresh bytes at the same version, and publish-plugin treats every plugin tag as a pair publish.

`ci/pkg-published.sh` derives it instead. The majors come from `ci/freebsd<major>-opnsense.env`, which exists for exactly the series we serve, so adding or retiring one moves the probe with no edit. It requires **every** served tree rather than trusting one as a witness: a publish writes all four, so a partial result means a publish died midway, and calling that "published" would freeze the gap - both callers skip a version once and nothing revisits it. Found/missing goes to stderr, the verdict to stdout. It exits non-zero when it cannot resolve the ABI, so a broken probe stops a publish rather than silently repeating one.

Because a script in a `paths` list that no pipeline runs is a trap we just fixed elsewhere, the lint job exercises it: the probed set is rebuilt independently from the pins and compared, then empty -> complete -> partial are walked. Mutation-tested - a probe that always says published, a dropped arch, and probing only the newest major are each caught.

**The mirror probe branched on curl -f.** `-f` returns non-zero for an HTTP error and for DNS, connect and TLS failures alike, so a blip looked like "not archived yet" and pinned the CDN for an OPNsense base that outlives it there - the pin file is committed, so the bad URLs persist until someone re-runs the script. Measured: the archive carries 27 releases to the CDN's 4, current ones included, with nothing on the CDN missing from it. There is no fallback to make, so the probe is gone entirely and OPNsense bases always come from the archive. That is a net simplification rather than the extra branching the finding wanted. No official retention policy is published, so the comment records the measurement and its date.

**scp -r nests into an existing directory.** Two places push our own directory into a freshly cloned upstream tree under the same name: the port into `/usr/ports/net/netflector`, and the plugin into `/plugins/net/netflector`. Neither exists upstream yet. The day either is accepted - both are on the roadmap - the push lands ours a level down and every `make` builds the upstream one: portlint, stage-qa, check-plist, package, the native e2e against the installed binary, all green and testing a released version. The plugin path feeds publish-plugin, so a nested push would package and ship upstream's plugin under our tag. The audit only caught the port; the plugin is the worse of the two. Destination cleared at all four sites; the other twelve `push` calls were checked and are file-to-file or nest deliberately into our own paths.

**The conversion had no real post-condition.** `opnsense-bootstrap` ends in a reboot that kills the ssh session, so its exit status is discarded - but `opnsense-version` stood in as the check, and bootstrap pkg-installs it *before* the base swap, so it answers on a VM that never rebooted. The kernel string is compared instead, which the swap replaces. The audit also wanted `|| [ $? -eq 255 ]`; it concedes 255 covers both the expected disconnect and ssh's own errors, and with a real post-condition every case it would catch is caught one line later with a clearer message.

**--update kept a stale PORTREVISION.** It counts port-only changes against one DISTVERSION, so moving the version left it attached and the catalogue would get `netflector-<new>_1` - a first revision of a version with no base package beneath it. Dropped when the version moves, guarded on that: `--update` is also how hashes are regenerated in place (the documented way to finish a Renovate bump PR), and an unconditional delete would silently undo a deliberate bump.

**A failed release push left its tag behind.** `confirm_and_push_tag` tags then pushes, so a push failure - an ssh agent waiting on approval being the usual cause here - aborted with the tag local and absent from origin. `ensure_tag_absent` OR'd its two checks, so the next run said "bump the version", spending a version number over a transient auth prompt and abandoning a good tag. The failing push now deletes the tag it made, so a re-run just works; `ensure_tag_absent` checks origin first and keeps a short local-only branch for an interrupted run or a hand-made tag.

Also: the ssh runner's header claimed x86_64-unknown-freebsd, but the `_RUNNER` export is built from `matrix.arch.triple` and both matrices carry aarch64.

## Testing

`ci/port-sync.py --update` driven for real against a backed-up port directory, both paths: at the same version the revision survives, at 0.13.1 it is dropped with the notice and distinfo repins to `v0.13.1_GH0`; port restored byte-for-byte and `--check` still agrees with the lockfile. `ensure_tag_absent` and `confirm_and_push_tag` driven against a real repo with a real remote across push-succeeds, push-fails, re-run-after-failure, tag-on-origin and tag-local-only. The published-probe lint step run as CI will run it, plus the three mutations. Mirror selection checked against live URLs. shellcheck clean on every touched script, no new codes against HEAD; all workflows parse.