### PR TITLE
HTTP framing and DIAL proxy log volume

### DIFF
--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -131,8 +131,14 @@ impl HttpFraming {
         let mut header_complete = false;
         let mut authority = None;
         if matches!(self.phase, Phase::Header) {
-            let Some(end) = find_header_end(input) else {
-                if input.len() > MAX_HEADER {
+            // RFC 9112 §2.2: empty lines before a start line belong to no message. Skipped here
+            // rather than in the scan: find_header_end reads a pair of them as a header block's end.
+            while input[pos..].starts_with(CRLF) {
+                pos += CRLF.len();
+            }
+            let rest = &input[pos..];
+            let Some(end) = find_header_end(rest) else {
+                if rest.len() > MAX_HEADER {
                     return Err(FramingError::HeaderTooLong);
                 }
                 return Ok(Framed {
@@ -145,8 +151,8 @@ impl HttpFraming {
             if end > MAX_HEADER {
                 return Err(FramingError::HeaderTooLong);
             }
-            authority = self.scan_and_rewrite_header(&input[..end])?;
-            pos = end;
+            authority = self.scan_and_rewrite_header(&rest[..end])?;
+            pos += end;
             header_complete = true;
         }
         // Forward as much of the body as arrived (a zero-copy slice of `input`), stopping at the message
@@ -518,6 +524,42 @@ mod tests {
             f.header,
             b"GET /apps/YouTube HTTP/1.1\r\nHost: 10.1.3.80:36866\r\n\r\n"
         );
+    }
+
+    #[test]
+    fn refuses_a_head_request_behind_a_leading_empty_line() {
+        // The device ignores the empty line and answers the HEAD, so the proxy must see what it sees.
+        let mut f = HttpFraming::new(Kind::Request, RewritePolicy::NONE);
+        assert_eq!(
+            f.feed(b"\r\nHEAD /dd.xml HTTP/1.1\r\nHost: 10.0.0.1:80\r\n\r\n")
+                .err(),
+            Some(FramingError::UnsupportedMethod)
+        );
+    }
+
+    #[test]
+    fn does_not_forward_leading_empty_lines() {
+        // Normalized away, so the device never has to decide whether to tolerate it.
+        let input = b"\r\n\r\nGET /dd.xml HTTP/1.1\r\nHost: 10.0.0.1:80\r\n\r\n";
+        let mut f = HttpFraming::new(Kind::Request, RewritePolicy::NONE);
+        let framed = f.feed(input).unwrap();
+        assert_eq!(
+            framed.header,
+            b"GET /dd.xml HTTP/1.1\r\nHost: 10.0.0.1:80\r\n\r\n"
+        );
+        assert_eq!(
+            framed.consumed,
+            input.len(),
+            "the skipped bytes are consumed too"
+        );
+    }
+
+    #[test]
+    fn reads_the_status_line_behind_leading_empty_lines() {
+        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
+        f.feed(b"\r\n\r\n\r\nHTTP/1.1 204 No Content\r\nContent-Length: 100\r\n\r\n")
+            .unwrap();
+        assert_eq!(f.phase, Phase::Header, "204 is bodyless despite the length");
     }
 
     #[test]

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -77,15 +77,15 @@ pub(crate) enum FramingError {
 /// One [`feed`](HttpFraming::feed) call's forwardable output: the rewritten `header` (a view into the
 /// framer's scratch, empty while a body streams across feeds), the `body` (a zero-copy slice of the fed
 /// input, possibly empty), and `consumed`, how many fed bytes to drop. `consumed == 0` means an
-/// incomplete header: read more and feed again. `authority` is the authority header this message carried
-/// (with the endpoint it named, *before* the rewrite), reported on the feed that completes the header;
-/// the DIAL proxy acts on `Application-URL` to learn and re-learn the device's REST target. `None` when
-/// the header carried no rewritable authority.
+/// incomplete header: read more and feed again. `application_url` is the device REST base the message's
+/// first `Application-URL` named, *before* the rewrite, reported on the feed that completes the header;
+/// the DIAL proxy dials it and re-learns it from a later description fetch. Only that header is
+/// reported: the others are rewritten per the policy, and nothing dials them.
 pub(crate) struct Framed<'a> {
     pub(crate) header: &'a [u8],
     pub(crate) body: &'a [u8],
     pub(crate) consumed: usize,
-    pub(crate) authority: Option<AuthorityHeader>,
+    pub(crate) application_url: Option<SocketAddrV4>,
 }
 
 /// Per-direction incremental HTTP/1.1 framing with an authority-header rewrite. Buffers only the header
@@ -129,7 +129,7 @@ impl HttpFraming {
     pub(crate) fn feed<'a>(&'a mut self, input: &'a [u8]) -> Result<Framed<'a>, FramingError> {
         let mut pos = 0;
         let mut header_complete = false;
-        let mut authority = None;
+        let mut application_url = None;
         if matches!(self.phase, Phase::Header) {
             // RFC 9112 §2.2: empty lines before a start line belong to no message. Skipped here
             // rather than in the scan: find_header_end reads a pair of them as a header block's end.
@@ -145,13 +145,13 @@ impl HttpFraming {
                     header: &[],
                     body: &[],
                     consumed: 0,
-                    authority: None,
+                    application_url: None,
                 }); // incomplete: read more
             };
             if end > MAX_HEADER {
                 return Err(FramingError::HeaderTooLong);
             }
-            authority = self.scan_and_rewrite_header(&rest[..end])?;
+            application_url = self.scan_and_rewrite_header(&rest[..end])?;
             pos += end;
             header_complete = true;
         }
@@ -227,7 +227,7 @@ impl HttpFraming {
             header: if header_complete { &self.header } else { &[] },
             body: &input[body_start..pos],
             consumed: pos,
-            authority,
+            application_url,
         })
     }
 
@@ -240,11 +240,11 @@ impl HttpFraming {
     fn scan_and_rewrite_header(
         &mut self,
         block: &[u8],
-    ) -> Result<Option<AuthorityHeader>, FramingError> {
+    ) -> Result<Option<SocketAddrV4>, FramingError> {
         self.header.clear();
         let mut content_length = None;
         let mut chunked = false;
-        let mut authority = None;
+        let mut application_url = None;
         let mut status = 0;
         let mut pos = 0;
         let mut first = true;
@@ -263,10 +263,12 @@ impl HttpFraming {
                 }
                 self.copy_line(line);
                 first = false;
-            } else if let Some(found) =
+            } else if let Some(AuthorityHeader::ApplicationUrl(ep)) =
                 self.inspect_and_emit(line, &mut content_length, &mut chunked)?
             {
-                authority = Some(found);
+                // First wins: a client reads the first of a repeated field (RFC 9110 §5.3), so the
+                // proxy has to dial that same one. Every occurrence is still rewritten above.
+                application_url.get_or_insert(ep);
             }
             pos = line_end + CRLF.len();
         }
@@ -274,7 +276,7 @@ impl HttpFraming {
             return Err(FramingError::ContentLengthWithChunked);
         }
         self.set_body_phase(status, content_length, chunked);
-        Ok(authority)
+        Ok(application_url)
     }
 
     /// Detect the framing headers (`Content-Length` / `Transfer-Encoding`), rewrite a `Host` /
@@ -302,8 +304,8 @@ impl HttpFraming {
             return Ok(None);
         }
         if let Some((value_off, found, header)) = rewritable_authority(line, self.kind) {
-            // Rewrite to wherever the policy points this header, but report the header either way so the
-            // owner learns the endpoint it named (it acts on `Application-URL` only).
+            // Rewrite to wherever the policy points this header, and report it either way: the caller
+            // keeps the first `Application-URL` and discards the rest.
             if let Some(repl) = self.rewrite.target(header) {
                 let auth_start = value_off + found.offset;
                 self.header.extend_from_slice(&line[..auth_start]);
@@ -636,10 +638,8 @@ mod tests {
             .unwrap();
         // The owner learns the device's REST base (to dial it) even as the header is rewritten to the proxy.
         assert_eq!(
-            framed.authority,
-            Some(AuthorityHeader::ApplicationUrl(
-                "10.0.0.7:8008".parse().unwrap()
-            ))
+            framed.application_url,
+            Some("10.0.0.7:8008".parse().unwrap())
         );
         assert_eq!(
             framed.header,
@@ -653,10 +653,55 @@ mod tests {
                 b"HTTP/1.1 201 Created\r\nLocation: http://10.0.0.7:8008/apps/X/run\r\nContent-Length: 0\r\n\r\n",
             )
             .unwrap();
-        assert!(matches!(
-            framed.authority,
-            Some(AuthorityHeader::Location(_))
-        ));
+        // Rewritten per the policy, but never reported: nothing dials a Location.
+        assert_eq!(framed.application_url, None);
+    }
+
+    #[test]
+    fn reports_the_first_application_url_of_a_repeated_field() {
+        // Both lines rewrite to the same listener, so the client cannot tell them apart; it uses the
+        // first, and an appended duplicate must not steer the proxy somewhere else.
+        let repl: SocketAddrV4 = "10.1.1.5:44747".parse().unwrap();
+        let mut f = HttpFraming::new(Kind::Response, rewrite_all(repl));
+        let framed = f
+            .feed(
+                b"HTTP/1.1 200 OK\r\nApplication-URL: http://10.0.0.7:8008/apps\r\nApplication-URL: http://10.0.0.9:9/x\r\nContent-Length: 0\r\n\r\n",
+            )
+            .unwrap();
+        assert_eq!(
+            framed.application_url,
+            Some("10.0.0.7:8008".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn a_trailing_location_does_not_displace_the_application_url() {
+        let repl: SocketAddrV4 = "10.1.1.5:44747".parse().unwrap();
+        let mut f = HttpFraming::new(Kind::Response, rewrite_all(repl));
+        let framed = f
+            .feed(
+                b"HTTP/1.1 200 OK\r\nApplication-URL: http://10.0.0.7:8008/apps\r\nLocation: http://10.0.0.7:8008/apps/X/run\r\nContent-Length: 0\r\n\r\n",
+            )
+            .unwrap();
+        assert_eq!(
+            framed.application_url,
+            Some("10.0.0.7:8008".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn a_leading_location_does_not_hide_a_later_application_url() {
+        let repl: SocketAddrV4 = "10.1.1.5:44747".parse().unwrap();
+        let mut f = HttpFraming::new(Kind::Response, rewrite_all(repl));
+        let framed = f
+            .feed(
+                b"HTTP/1.1 200 OK\r\nLocation: http://10.0.0.7:8008/apps/X/run\r\nApplication-URL: http://10.0.0.7:8008/apps\r\nContent-Length: 0\r\n\r\n",
+            )
+            .unwrap();
+        assert_eq!(
+            framed.application_url,
+            Some("10.0.0.7:8008".parse().unwrap())
+        );
     }
 
     #[test]
@@ -671,7 +716,7 @@ mod tests {
                          Location: http://192.168.9.9:23/\r\n\r\n";
         let mut f = HttpFraming::new(Kind::Request, rewrite_all(repl));
         let framed = f.feed(request).unwrap();
-        assert_eq!(framed.authority, None);
+        assert_eq!(framed.application_url, None);
         assert_eq!(framed.header, request);
     }
 
@@ -682,7 +727,7 @@ mod tests {
         let mut f = HttpFraming::new(Kind::Response, rewrite_all(repl));
         let request = b"HTTP/1.1 200 OK\r\nHost: 192.168.9.9:22\r\nContent-Length: 0\r\n\r\n";
         let framed = f.feed(request).unwrap();
-        assert_eq!(framed.authority, None);
+        assert_eq!(framed.application_url, None);
         assert_eq!(framed.header, request);
     }
 

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -58,6 +58,10 @@ pub(crate) enum FramingError {
     /// Multiple `Content-Length` header fields with differing values: RFC 9112 §6.3 treats a message with
     /// conflicting Content-Lengths as unrecoverable (a request-smuggling vector), so the proxy refuses it.
     ConflictingContentLength,
+    /// Both a `Content-Length` and a chunked `Transfer-Encoding`. The same §6.3 lets an intermediary
+    /// forward one only after stripping the `Content-Length`; forwarding both leaves the proxy and the
+    /// device free to disagree about where the message ends. Refused rather than stripped.
+    ContentLengthWithChunked,
     /// A chunk-size line that isn't a hex integer.
     MalformedChunkSize,
     /// A chunk size so large that adding its terminating CRLF would overflow `usize`. No legitimate
@@ -259,6 +263,9 @@ impl HttpFraming {
                 authority = Some(found);
             }
             pos = line_end + CRLF.len();
+        }
+        if content_length.is_some() && chunked {
+            return Err(FramingError::ContentLengthWithChunked);
         }
         self.set_body_phase(status, content_length, chunked);
         Ok(authority)
@@ -893,13 +900,33 @@ mod tests {
     }
 
     #[test]
-    fn chunked_takes_precedence_over_content_length() {
-        let mut f = HttpFraming::new(Kind::Response, RewritePolicy::NONE);
-        f.scan_and_rewrite_header(
-            b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\nTransfer-Encoding: chunked\r\n\r\n",
-        )
-        .unwrap();
-        assert_eq!(f.phase, Phase::BodyChunked);
+    fn rejects_a_content_length_beside_a_chunked_encoding() {
+        // Both kinds in both orders: the check runs once the whole block is scanned, so neither
+        // the side nor the header order should reach it.
+        for (kind, block) in [
+            (
+                Kind::Response,
+                &b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\nTransfer-Encoding: chunked\r\n\r\n"[..],
+            ),
+            (
+                Kind::Response,
+                &b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 100\r\n\r\n"[..],
+            ),
+            (
+                Kind::Request,
+                &b"POST /apps/X HTTP/1.1\r\nContent-Length: 6\r\nTransfer-Encoding: chunked\r\n\r\n"[..],
+            ),
+            (
+                Kind::Request,
+                &b"POST /apps/X HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n"[..],
+            ),
+        ] {
+            let mut f = HttpFraming::new(kind, RewritePolicy::NONE);
+            assert_eq!(
+                f.scan_and_rewrite_header(block),
+                Err(FramingError::ContentLengthWithChunked)
+            );
+        }
     }
 
     #[test]

--- a/src/reflector/dial/connection.rs
+++ b/src/reflector/dial/connection.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddrV4;
 use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
-use crate::net::http::framing::{AuthorityHeader, HttpFraming, Kind, RewritePolicy};
+use crate::net::http::framing::{HttpFraming, Kind, RewritePolicy};
 use crate::net::stream_buffer::StreamBuffer;
 use crate::net::tcp::TcpSocket;
 use crate::reactor::{Reactor, RegKey};
@@ -137,9 +137,9 @@ impl DirectionContext<'_> {
                 }
             };
             // Learn the device REST base from a response's Application-URL; a later description fetch can
-            // move it, so the latest wins. Only the response framer reports that header, so this can't
+            // move it, so the latest message wins. Only the response framer reports it, so this can't
             // fire on the client→device side, where the endpoint would be the client's to choose.
-            if let Some(AuthorityHeader::ApplicationUrl(ep)) = framed.authority {
+            if let Some(ep) = framed.application_url {
                 *self.learned_rest = Some(ep);
             }
             if framed.consumed == 0 {

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -10,7 +10,7 @@
 use std::fmt;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::fd::{AsRawFd, RawFd};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::net::tcp::TcpSocket;
 use crate::reactor::{Arena, Handler, HandlerKey, Key, Reactor, ReadyEvent};
@@ -19,6 +19,10 @@ use super::connection::{Connection, Outcome};
 
 /// Cap on concurrent proxied connections (drop-new past it).
 const MAX_CONNECTIONS: usize = 64;
+
+/// How often saturation is reported while it lasts. A source-side host can reach the cap on its own,
+/// so a line per rejected client would hand it the log; silence would hide an outage in progress.
+const CAP_WARN_INTERVAL: Duration = Duration::from_mins(1);
 
 /// A `Copy` handle into the proxy's connection [`Arena`]: a newtype over the arena [`Key`] so it
 /// can't be confused with the reactor's keys. Round-trips through a watched fd's `user_data`: the
@@ -77,6 +81,9 @@ pub(super) struct DialDeviceProxy {
     /// The device's REST endpoint, learned (and re-learned) from a description response's `Application-URL`;
     /// `None` until the first description fetch reveals it. REST connections proxy here.
     rest_endpoint: Option<SocketAddrV4>,
+    /// When saturation was last reported, so it repeats at [`CAP_WARN_INTERVAL`] rather than per
+    /// rejected client.
+    last_cap_warn: Option<Instant>,
     conns: Arena<Connection>,
 }
 
@@ -98,6 +105,7 @@ impl DialDeviceProxy {
             desc_endpoint,
             rest,
             rest_endpoint: None,
+            last_cap_warn: None,
             conns: Arena::new(),
         }
     }
@@ -118,12 +126,11 @@ impl DialDeviceProxy {
     /// stays queued and this level-triggered listener re-fires on it without end; shedding the proxy
     /// stops that and hands its fds back. The device re-mints on its next advertisement, as it would
     /// after any eviction.
-    fn accept_client(
-        &self,
-        listener: &TcpSocket,
-        what: Listener,
-        reactor: &mut Reactor,
-    ) -> Option<TcpSocket> {
+    fn accept_client(&mut self, what: Listener, reactor: &mut Reactor) -> Option<TcpSocket> {
+        let listener = match what {
+            Listener::Description => &self.desc,
+            Listener::Rest => &self.rest,
+        };
         let client = match listener.accept() {
             Ok(Some(client)) => client,
             Ok(None) => return None, // the client died before we reached it, or a spurious readiness
@@ -138,7 +145,17 @@ impl DialDeviceProxy {
             }
         };
         if self.conns.iter().count() >= MAX_CONNECTIONS {
-            log::warn!("dial: connection cap ({MAX_CONNECTIONS}) reached; dropping a new client");
+            let now = Instant::now();
+            if self
+                .last_cap_warn
+                .is_none_or(|t| now - t >= CAP_WARN_INTERVAL)
+            {
+                self.last_cap_warn = Some(now);
+                log::warn!(
+                    "dial: connection cap ({MAX_CONNECTIONS}) reached for {}; dropping new clients",
+                    self.desc_endpoint
+                );
+            }
             return None; // `client` drops here, closing it
         }
         Some(client)
@@ -146,7 +163,7 @@ impl DialDeviceProxy {
 
     /// Accept a client on the description listener and proxy it to the device's description endpoint.
     fn accept_desc(&mut self, reactor: &mut Reactor) {
-        if let Some(client) = self.accept_client(&self.desc, Listener::Description, reactor) {
+        if let Some(client) = self.accept_client(Listener::Description, reactor) {
             self.start_connection(client, self.desc_endpoint, self.desc.local_addr(), reactor);
         }
     }
@@ -155,7 +172,7 @@ impl DialDeviceProxy {
     /// description fetch. A client reaching here before that fetch is dropped (the proxy minted the
     /// listener's address into the description's `Application-URL`, so this is unexpected).
     fn accept_rest(&mut self, reactor: &mut Reactor) {
-        let Some(client) = self.accept_client(&self.rest, Listener::Rest, reactor) else {
+        let Some(client) = self.accept_client(Listener::Rest, reactor) else {
             return;
         };
         let Some(device) = self.rest_endpoint else {
@@ -407,20 +424,16 @@ mod tests {
     #[cfg_attr(miri, ignore = "needs a real poll backend")]
     fn a_failed_accept_sheds_the_proxy() {
         let mut reactor = Reactor::new().expect("reactor");
-        let (proxy, rest_addr) = watched_proxy(&mut reactor);
+        let (mut proxy, rest_addr) = watched_proxy(&mut reactor);
         let key = proxy.own_key();
         assert!(reactor.is_registered(key));
 
         // Accepting on a connected socket fails with EINVAL, standing in for the EMFILE the proxy
         // cannot drain. Either way it must not stay registered and re-firing on a readiness it
         // will never consume.
-        let connected =
+        proxy.rest =
             TcpSocket::connect(rest_addr, Ipv4Addr::LOCALHOST, None).expect("client connect");
-        assert!(
-            proxy
-                .accept_client(&connected, Listener::Rest, &mut reactor)
-                .is_none()
-        );
+        assert!(proxy.accept_client(Listener::Rest, &mut reactor).is_none());
         assert!(
             !reactor.is_registered(key),
             "the proxy unregisters itself rather than spin on a listener it cannot drain"


### PR DESCRIPTION
Four audit findings in the DIAL proxy's HTTP path, one commit each.

- **Content-Length beside Transfer-Encoding** is now refused (RFC 9112 §6.3). Both headers were forwarded intact while the framer silently picked chunked, so the proxy and the device could disagree about where a message ends. The framer already refused two differing Content-Lengths on the same grounds.
- **Empty lines before the start line** are skipped (RFC 9112 §2.2). A leading CRLF parsed as the start line, so a HEAD request walked past the refusal and a status line read as 0, losing the bodyless 204/304 handling. The skip lives in `feed` rather than the header scan: `find_header_end` reads a pair of empty lines as a header block's end, so a skip inside the scan never runs.
- **The learned REST base is the first `Application-URL`**, not whichever authority header came last. One slot held them all, so a repeated `Application-URL` left the client reading the first while the proxy dialled the second, and a trailing `Location` displaced the REST base entirely, dropping every REST client. First-wins matches what a client does with a repeated field (RFC 9110 §5.3).
- **The connection-cap warning is rate-limited** to once a minute per device. Reaching the cap needs nothing but a source-side host opening connections, and every rejected one emitted a warn line. Kept at warn rather than demoted to debug: an operator should see a saturated proxy.

## Testing

`cargo test --lib` on macOS and Linux, clippy (`--all-targets -D warnings`) on both plus `x86_64-unknown-freebsd`, fmt, and `cargo doc` on both. Docker e2e 57/57. Each fix was mutation-checked by reverting it and confirming the intended test fails.