### PR TITLE
Frame buffer ceilings, BPF capture cap, and reactor/DIAL corrections

### DIFF
--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -19,13 +19,6 @@ use crate::libcex::BpfInsn;
 use crate::net::LinkType;
 use crate::sys::{IoStatus, socklen_of};
 
-/// Receive buffer for one frame, matched to the dispatcher's send scratch
-/// ([`SCRATCH_LEN`](crate::dispatch::SCRATCH_LEN)) — the forwarding limit. Capturing no more than can be
-/// re-emitted means a jumbo frame beyond it drops here at trace (see [`next_frame`](Capture::next_frame)),
-/// instead of being captured and then warned per packet when the send scratch rejects it. 2048
-/// comfortably holds a standard ~1518-byte Ethernet frame.
-const RECV_BUFFER_SIZE: usize = 2048;
-
 /// The fallback filter length: the egress-drop prologue plus the UDP classifier.
 const DROP_OUTGOING_FILTER_LEN: usize = DROP_OUTGOING_PROLOGUE.len() + ETHERNET_UDP_FILTER.len();
 
@@ -78,7 +71,7 @@ impl Capture {
         );
         Ok(Self {
             fd,
-            buf: vec![0u8; RECV_BUFFER_SIZE].into_boxed_slice(),
+            buf: vec![0u8; crate::net::MAX_FRAME_LEN].into_boxed_slice(),
             name: if_name.into(),
         })
     }

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -141,8 +141,8 @@ impl Capture {
                 // oversized frames. A per-frame warn would both break data-path-quiet and spam the
                 // operator's log. The frame is still correctly dropped.
                 Record::Oversized { datalen } => log::trace!(
-                    "dropping oversized frame: {datalen} bytes exceeds the {}-byte capture buffer",
-                    self.buf.len()
+                    "dropping oversized frame: {datalen} bytes exceeds the {}-byte forwarding limit",
+                    crate::net::MAX_FRAME_LEN
                 ),
             }
         };
@@ -235,8 +235,11 @@ fn parse_record(record: &[u8]) -> io::Result<(Record, usize)> {
         return Err(io::Error::other("BPF record did not advance"));
     }
 
-    if header.bh_datalen > header.bh_caplen {
-        // Captured fewer bytes than the frame's real length; don't parse a partial frame.
+    // Truncated by the kernel, or whole but past what we can re-emit. BPF sizes its buffer from
+    // BIOCGBLEN, not from MAX_FRAME_LEN, so it can hand up frames the send path would go on to
+    // reject once per packet.
+    if header.bh_datalen > header.bh_caplen || header.bh_caplen as usize > crate::net::MAX_FRAME_LEN
+    {
         return Ok((
             Record::Oversized {
                 datalen: header.bh_datalen,
@@ -379,6 +382,31 @@ mod tests {
             offset += advance;
         }
         assert_eq!(frames, vec![vec![0xaa; 3], vec![0xbb; 5], vec![0xcc; 1]]);
+    }
+
+    #[test]
+    fn skips_a_frame_past_the_forwarding_limit() {
+        // Whole, not truncated: this one would otherwise route and then fail in build_udp.
+        let over = u32::try_from(crate::net::MAX_FRAME_LEN + 1).expect("fits u32");
+        let mut batch = Vec::new();
+        push_record(&mut batch, over, over, 0xaa);
+        push_record(&mut batch, 2, 2, 0xbb);
+
+        let (first, advance) = parse_record(&batch).unwrap();
+        assert!(matches!(first, Record::Oversized { datalen } if datalen == over));
+        let (second, _) = parse_record(&batch[advance..]).unwrap();
+        assert!(
+            matches!(second, Record::Frame(_)),
+            "the next record still parses"
+        );
+    }
+
+    #[test]
+    fn keeps_a_frame_at_the_forwarding_limit() {
+        let at = u32::try_from(crate::net::MAX_FRAME_LEN).expect("fits u32");
+        let mut batch = Vec::new();
+        push_record(&mut batch, at, at, 0xaa);
+        assert!(matches!(parse_record(&batch).unwrap().0, Record::Frame(_)));
     }
 
     #[test]

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -65,12 +65,6 @@ const RECONCILE_TICK: Duration = Duration::from_secs(30);
 /// retry driver that picks up the interface's return and re-attempts failed re-binds.
 const RECONCILE_RETRY: Duration = Duration::from_secs(1);
 
-/// The dispatcher's reused send-buffer size. A standard-MTU datagram fits. One buffer serves
-/// every reflector: the single-threaded loop runs one [`send_udp_group`](PacketDispatcher::send_udp_group)
-/// at a time. An oversized payload is a `BufferTooSmall` error, not a truncation. It also caps a
-/// forwardable datagram, so the DIAL rewrite scratch ([`REWRITE_BUF_LEN`](crate::reflector::dial::REWRITE_BUF_LEN)) anchors to it.
-pub(crate) const SCRATCH_LEN: usize = 2048;
-
 /// A `Copy` handle to a capture the dispatcher owns: an index into the interface table's
 /// captures. A newtype, not a bare alias, so it can't be passed where an [`InterfaceKey`](interface_table::InterfaceKey)
 /// or a reactor key is expected, where it would silently miss instead of failing to
@@ -251,7 +245,8 @@ pub(crate) struct PacketDispatcher {
     /// The DIAL proxy registry, shared across the SSDP advertisement/response reflectors. Empty unless a
     /// DIAL reflector is configured; the dispatcher evicts its past-grace proxies on the deadline sweep.
     dial: DialContext,
-    /// The reused frame-build buffer shared by every reflector's send (see [`SCRATCH_LEN`]).
+    /// The reused frame-build buffer shared by every reflector's send. One buffer serves them all:
+    /// the single-threaded loop runs one `send_udp_group` at a time.
     scratch: Box<[u8]>,
     /// The periodic counter-summary schedule, or `None` when the summary is disabled.
     report: Option<CounterReport>,
@@ -277,7 +272,7 @@ impl PacketDispatcher {
             route_keys: Vec::new(),
             monitor: Self::open_monitor(),
             dial: DialContext::new(),
-            scratch: vec![0u8; SCRATCH_LEN].into_boxed_slice(),
+            scratch: vec![0u8; crate::net::MAX_FRAME_LEN].into_boxed_slice(),
             report: None,
             max_seen_ifindex: 0,
             next_reconcile: Instant::now() + RECONCILE_TICK,
@@ -430,8 +425,8 @@ impl PacketDispatcher {
     /// destination, and inject it on `egress`. The caller supplies the L2 MAC, so this serves
     /// unicast, multicast, and broadcast alike; the link framing (Ethernet vs `DLT_NULL`) follows
     /// the egress's link type, and the source port, `ttl`, and `payload` are carried verbatim.
-    /// Builds into the dispatcher's reused [`scratch`](SCRATCH_LEN) buffer, so the data path never
-    /// allocates. An unknown or draining egress is a logged drop, like [`send`](Self::send).
+    /// Builds into the dispatcher's reused scratch buffer, so the data path never allocates. An
+    /// unknown or draining egress is a logged drop, like [`send`](Self::send).
     ///
     /// # Errors
     /// Propagates a send failure, and reports a frame that can't be built from the egress's

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -11,6 +11,7 @@
 mod bpf;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod bpf_device;
+mod errno;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod in6_ifreq;
 mod multicast;
@@ -30,6 +31,7 @@ pub(crate) use self::in6_ifreq::{IN6_IFF_UNUSABLE, In6Ifreq, siocgifaflag_in6};
 // via `bpf_wordalign`), so re-export it only for tests.
 #[cfg(all(test, any(target_os = "macos", target_os = "freebsd")))]
 pub(crate) use self::bpf_device::BPF_ALIGN;
+pub(crate) use self::errno::errno_location;
 pub(crate) use self::multicast::{GroupReq, MCAST_JOIN_GROUP};
 #[cfg(target_os = "linux")]
 pub(crate) use self::netlink::{

--- a/src/libcex/errno.rs
+++ b/src/libcex/errno.rs
@@ -1,0 +1,21 @@
+//! The calling thread's `errno` cell. libc declares the accessor for the BSDs (`__error`) but not for
+//! Linux, where both glibc and musl export `__errno_location`.
+
+use libc::c_int;
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" {
+    fn __errno_location() -> *mut c_int;
+}
+
+/// A pointer to the calling thread's `errno`. Async-signal-safe: the accessor only computes a
+/// thread-local address, so a signal handler can save and restore `errno` through it.
+pub(crate) fn errno_location() -> *mut c_int {
+    #[cfg(target_os = "linux")]
+    // SAFETY: the accessor takes no arguments and always returns the thread's errno cell.
+    let location = unsafe { __errno_location() };
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    // SAFETY: as above, through libc's declaration.
+    let location = unsafe { libc::__error() };
+    location
+}

--- a/src/net.rs
+++ b/src/net.rs
@@ -41,3 +41,16 @@ const DLT_NULL_HEADER_SIZE: usize = 4;
 const IPV4_HEADER_SIZE: usize = 20;
 const IPV6_HEADER_SIZE: usize = 40;
 const UDP_HEADER_SIZE: usize = 8;
+
+/// The largest frame the daemon builds, captures or forwards. Every buffer on the frame path is
+/// sized from this: the dispatcher's send scratch, and each capture backend's read buffer, so
+/// anything captured can be re-emitted. Clears a standard 1514-byte Ethernet frame (the FCS is
+/// stripped before capture) with headroom for a baby-jumbo MTU. True 9000-byte jumbo is out of
+/// reach, and no discovery protocol comes near it.
+pub(crate) const MAX_FRAME_LEN: usize = 2048;
+
+/// The largest UDP payload that still fits [`MAX_FRAME_LEN`] once framed, so anything built within
+/// it is forwardable. The worst-case header stack: Ethernet (over `DLT_NULL`) plus IPv6 (over
+/// IPv4, and fixed at 40 since the builders emit no extension headers) plus UDP.
+pub(crate) const MAX_UDP_PAYLOAD_LEN: usize =
+    MAX_FRAME_LEN - (ETHERNET_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE);

--- a/src/net/ssdp/dial.rs
+++ b/src/net/ssdp/dial.rs
@@ -16,36 +16,28 @@ pub(crate) fn is_dial_service_message(payload: &[u8]) -> bool {
 /// mapped into the whole `payload` so the SSDP path splices a netflector authority over it. The
 /// `LOCATION` must be a rewritable `http://ipv4[:port]` URL; `None` otherwise (forward unchanged).
 pub(crate) fn parse_dial_location_authority(payload: &[u8]) -> Option<Authority> {
-    for line in payload.split(|&b| b == b'\n') {
-        let line = line.strip_suffix(b"\r").unwrap_or(line);
-        let Some(url) = strip_prefix_ignore_ascii_case(line, b"LOCATION:") else {
-            continue;
-        };
-        let url = url.trim_ascii_start();
-        if url.is_empty() {
-            return None;
-        }
-        let found = parse_authority(url, false)?;
-        // `url` is a subslice of `payload`, so the distance between their starts is `url`'s offset
-        // within `payload`; add the authority's offset within `url`.
-        let url_offset = url.as_ptr().addr() - payload.as_ptr().addr();
-        return Some(Authority {
-            endpoint: found.endpoint,
-            offset: url_offset + found.offset,
-            len: found.len,
-        });
-    }
-    None
+    let url = dial_location_value(payload)?;
+    let found = parse_authority(url, false)?;
+    // `url` is a subslice of `payload`, so the distance between their starts is `url`'s offset
+    // within `payload`; add the authority's offset within `url`.
+    let url_offset = url.as_ptr().addr() - payload.as_ptr().addr();
+    Some(Authority {
+        endpoint: found.endpoint,
+        offset: url_offset + found.offset,
+        len: found.len,
+    })
 }
 
-/// The raw, trimmed `LOCATION:` header value (the URL), or `None` if the message carries none. For the
-/// debug log when [`parse_dial_location_authority`] rejects the URL as non-rewritable.
+/// The raw, trimmed value of the first `LOCATION:` header, or `None` if the message carries none or
+/// it is empty. Both the rewrite decision and the debug log that reports a rejection read this, so
+/// the log can't name a header the rewrite never looked at.
 pub(crate) fn dial_location_value(payload: &[u8]) -> Option<&[u8]> {
-    payload.split(|&b| b == b'\n').find_map(|line| {
-        let line = line.strip_suffix(b"\r").unwrap_or(line);
-        let url = strip_prefix_ignore_ascii_case(line, b"LOCATION:")?.trim_ascii_start();
-        (!url.is_empty()).then_some(url)
-    })
+    let url = payload
+        .split(|&b| b == b'\n')
+        .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+        .find_map(|line| strip_prefix_ignore_ascii_case(line, b"LOCATION:"))?
+        .trim_ascii_start();
+    (!url.is_empty()).then_some(url)
 }
 
 /// The advertisement's freshness lifetime from a `CACHE-CONTROL: max-age=<seconds>` header: how long
@@ -142,6 +134,14 @@ mod tests {
             Some(&b"https://tv.local/x"[..])
         );
         assert!(dial_location_value(b"NOTIFY * HTTP/1.1\r\nNT: foo\r\n\r\n").is_none());
+    }
+
+    #[test]
+    fn an_empty_location_does_not_fall_through_to_a_later_one() {
+        let payload =
+            b"NOTIFY * HTTP/1.1\r\nLOCATION:\r\nLOCATION: http://10.0.0.5:8008/dd.xml\r\n\r\n";
+        assert!(parse_dial_location_authority(payload).is_none());
+        assert!(dial_location_value(payload).is_none());
     }
 
     #[test]

--- a/src/reactor/poll/epoll.rs
+++ b/src/reactor/poll/epoll.rs
@@ -82,8 +82,9 @@ impl Poller {
         Ok(())
     }
 
-    /// Drop all interest on `fd`. An fd the kernel already dropped (e.g. on close)
-    /// reports `ENOENT`, which is benign.
+    /// Drop all interest on `fd`. `ENOENT` (open but not registered, e.g. a repeated remove) is
+    /// benign and swallowed. A closed fd reports `EBADF` instead, which propagates: the reactor
+    /// drops kernel interest before a handler closes its fds, so that would mean the order broke.
     pub(crate) fn remove(&self, fd: RawFd) -> io::Result<()> {
         // SAFETY: poll_fd is our epoll instance; EPOLL_CTL_DEL ignores the event arg.
         let rc = unsafe {
@@ -196,5 +197,15 @@ mod tests {
         // A second add surfaces EEXIST instead of silently modifying.
         let err = poller.add(a.as_raw_fd(), key).unwrap_err();
         assert_eq!(err.raw_os_error(), Some(libc::EEXIST));
+    }
+
+    #[test]
+    fn remove_of_a_dead_fd_surfaces_ebadf() {
+        let poller = Poller::new(CAPACITY).unwrap();
+        // An fd the process doesn't hold is EBADF, not the ENOENT `remove` swallows, so a removal
+        // ordered after the close still surfaces. The number is far past what the kernel hands out,
+        // so a parallel test can't recycle it into a live fd mid-test.
+        let err = poller.remove(1_000_000).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::EBADF));
     }
 }

--- a/src/reactor/poll/kqueue.rs
+++ b/src/reactor/poll/kqueue.rs
@@ -85,8 +85,9 @@ impl Poller {
         Ok(())
     }
 
-    /// Drop all interest on `fd`. Filters the kernel already removed (e.g. when
-    /// `fd` was closed) report `ENOENT`, which is benign.
+    /// Drop all interest on `fd`. Both filters are deleted, but [`add`](Self::add) arms only the
+    /// read one, so deleting an unarmed write filter reports `ENOENT`. That is the usual case, not
+    /// an error, so it is swallowed.
     pub(crate) fn remove(&self, fd: RawFd) -> io::Result<()> {
         for filter in [libc::EVFILT_READ, libc::EVFILT_WRITE] {
             match self.change_raw(fd, filter, libc::EV_DELETE, 0) {

--- a/src/reactor/signal.rs
+++ b/src/reactor/signal.rs
@@ -37,6 +37,12 @@ static DUMP_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// The signal handler: async-signal-safe, so it only records intent and wakes the loop.
 extern "C" fn on_signal(signum: c_int) {
+    // The handler can land between a failed syscall and the `errno` read that reports it, so the
+    // write below must leave no errno of its own behind.
+    let location = crate::libcex::errno_location();
+    // SAFETY: the calling thread's `errno` cell; reading and writing it is async-signal-safe.
+    let saved = unsafe { *location };
+
     // The pipe byte is a pure wakeup; its value carries nothing, the atomic flags carry the intent.
     if signum == DUMP_SIGNAL {
         DUMP_REQUESTED.store(true, Ordering::Relaxed);
@@ -53,6 +59,9 @@ extern "C" fn on_signal(signum: c_int) {
             libc::write(fd, (&raw const byte).cast(), 1);
         }
     }
+
+    // SAFETY: as above.
+    unsafe { *location = saved };
 }
 
 /// An installed self-pipe with the previous signal dispositions saved. Dropping it
@@ -276,6 +285,30 @@ mod tests {
         assert!(SignalGuard::install().is_err());
 
         drop(guard); // restores the previous dispositions
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real write(2) failure")]
+    fn the_handler_leaves_errno_alone() {
+        let _serialized = SIGNAL_STATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // A pipe's read end refuses a write (EBADF), so the handler's write fails the way it would
+        // on a full pipe. No handler is installed: `on_signal` is called directly.
+        let (read, _write) = self_pipe().unwrap();
+        let previous = WRITE_FD.swap(read.as_raw_fd(), Ordering::SeqCst);
+
+        let location = crate::libcex::errno_location();
+        // SAFETY: the calling thread's errno cell.
+        let observed = unsafe {
+            *location = libc::EEXIST;
+            on_signal(DUMP_SIGNAL);
+            *location
+        };
+
+        WRITE_FD.store(previous, Ordering::SeqCst);
+        DUMP_REQUESTED.store(false, Ordering::Relaxed);
+        assert_eq!(observed, libc::EEXIST);
     }
 
     #[test]

--- a/src/reflector/dial.rs
+++ b/src/reflector/dial.rs
@@ -17,4 +17,4 @@ mod connection;
 mod proxy;
 mod rewrite;
 
-pub(crate) use self::rewrite::{ProxyPlacement, REWRITE_BUF_LEN, rewrite_location};
+pub(crate) use self::rewrite::{ProxyPlacement, rewrite_location};

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -28,12 +28,6 @@ const DEFAULT_DESC_GRACE: Duration = Duration::from_mins(30);
 /// DIAL device's re-advertise interval, so a live device still refreshes its grace in time.
 const MAX_DESC_GRACE: Duration = Duration::from_hours(2);
 
-/// Stack scratch to rewrite one SSDP datagram into. Anchored to the dispatcher's send frame buffer
-/// ([`SCRATCH_LEN`](crate::dispatch::SCRATCH_LEN)): the reflector builds its outgoing frame there, so
-/// anything that doesn't fit can't be forwarded anyway. A `LOCATION` rewrite can grow the datagram;
-/// one that overruns this falls back to verbatim rather than truncating.
-pub(crate) const REWRITE_BUF_LEN: usize = crate::dispatch::SCRATCH_LEN;
-
 /// Where a minted DIAL description proxy sits across the two interfaces: it binds its source-side
 /// listeners on `source`, egress-pins device connections to `target`/`target_iface`, and is evicted if
 /// either `source_capture`'s or `target_capture`'s IPv4 address later changes. Bundling the two
@@ -53,8 +47,8 @@ pub(crate) struct ProxyPlacement<'a> {
 /// On a rewrite the datagram is written to `out` and `true` is returned. `false` means forward `payload`
 /// unchanged: it isn't a DIAL message, its `LOCATION` isn't a rewritable IPv4 `http` URL, the proxy cap
 /// was reached / a mint failed (device stays visible but unproxied), or the rewrite didn't fit `out`.
-/// `out` is the caller's reused sink; a fixed-capacity one (sized [`REWRITE_BUF_LEN`]) makes an
-/// over-long rewrite fail rather than truncate.
+/// `out` is the caller's reused sink; a fixed-capacity one makes an over-long rewrite fail rather
+/// than truncate.
 pub(crate) fn rewrite_location(
     ctx: &mut DialContext,
     reactor: &mut Reactor,

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{CaptureKey, Filter, IpSet, MessageType, PacketDispatcher};
 use crate::interface::InterfaceAddresses;
+use crate::net::MAX_UDP_PAYLOAD_LEN;
 use crate::net::ssdp::{
     MSEARCH_MX_DEFAULT, SSDP_GROUP_V4, SSDP_GROUP_V6_LINK_LOCAL, SSDP_GROUP_V6_SITE_LOCAL,
     SSDP_PORT, SSDP_TTL, SsdpKind, classify, parse_msearch_mx,
@@ -20,7 +21,7 @@ use crate::net::ssdp::{
 use crate::net::uninit_buf::UninitBuf;
 use crate::reactor::Reactor;
 
-use super::dial::{ProxyPlacement, REWRITE_BUF_LEN, rewrite_location};
+use super::dial::{ProxyPlacement, rewrite_location};
 use super::{
     BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
     join_group_logged, require_bidirectional_families,
@@ -32,7 +33,9 @@ use super::{
 /// (the advertisement direction, and one per M-SEARCH session's response reflector), so it isn't `Copy`.
 struct DialRewrite {
     target: CaptureKey,
-    /// Reused sink for the rewritten datagram; see the [`ReplyRewrite`] impl.
+    /// Reused sink for the rewritten datagram; see the [`ReplyRewrite`] impl. Bounded by the
+    /// payload that still frames within [`MAX_FRAME_LEN`](crate::net::MAX_FRAME_LEN), so a rewrite
+    /// that fits is always sendable.
     scratch: UninitBuf,
 }
 
@@ -41,7 +44,7 @@ impl DialRewrite {
     fn new(target: CaptureKey) -> Self {
         Self {
             target,
-            scratch: UninitBuf::with_capacity(REWRITE_BUF_LEN),
+            scratch: UninitBuf::with_capacity(MAX_UDP_PAYLOAD_LEN),
         }
     }
 }


### PR DESCRIPTION
Five audit findings across the capture backends, the reactor, and DIAL `LOCATION` parsing, one commit each.

- **One constant per buffer ceiling.** `REWRITE_BUF_LEN` bounded a UDP *payload* with `SCRATCH_LEN`, a *frame* size, so the DIAL rewrite accepted payloads that no longer fit once the headers went back on — measured: 2006 bytes frames, 2007 gives `BufferTooSmall { needed: 2049, available: 2048 }`. A `LOCATION` rewrite grows the datagram and the payload comes from a remote advertisement, so a peer sizing its NOTIFY into that window drew a warn per packet. `net::MAX_FRAME_LEN` is now the single frame ceiling (dispatcher scratch plus both capture read buffers, which had duplicated the literal), and `MAX_UDP_PAYLOAD_LEN` subtracts the worst-case Ethernet+IPv6+UDP stack from it. `REWRITE_BUF_LEN` retired: it had become a second name for the same number, re-exported through two modules for one use site.
- **BPF drops a frame past the forwarding limit.** BPF sizes its read buffer from `BIOCGBLEN`, not from anything of ours, so on a jumbo-MTU interface it handed up frames the send path would reject once per packet. AF_PACKET already dropped them, its buffer being the limit itself.
- **One `LOCATION` for both the decision and the log.** `parse_dial_location_authority` stopped at the first `LOCATION:` header and rejected an empty one; `dial_location_value` skipped it and returned a later header's URL. So an empty `LOCATION` followed by a valid one was correctly forwarded unproxied while the debug line blamed the second URL — pointing an operator at a header the rewrite never consulted. The parser now reads its value through the same helper, so there is one scan.
- **`errno` preserved across the signal handler.** `on_signal`'s `write(2)` sets `errno` when it fails, and a handler can land between a failed syscall and the `errno` read that reports it, so the interrupted code would classify the handler's error as its own. Needed a `libcex` entry: libc declares the accessor for the BSDs (`__error`) but not for Linux, where glibc and musl export `__errno_location`.
- **Both `remove()` docs corrected.** Each claimed the tolerated `ENOENT` comes from an fd closed out from under the poller. Measured: on epoll a closed fd is `EBADF` and propagates, while `ENOENT` means open-but-unregistered; on kqueue the routine source is the write filter, which `add` never arms, so every `remove` deletes one that isn't there. No behavior change — epoll's `EBADF` propagates deliberately, since it would mean the teardown ordering broke.

## Testing

`cargo test --lib` on macOS (464) and Linux (462), clippy `--all-targets -D warnings` on both plus `x86_64-unknown-freebsd`, fmt, and `cargo doc` on both. Docker e2e 57/57. Each fix was mutation-checked by reverting it and confirming the intended test fails; the epoll `EBADF` test uses an fd number the kernel would never hand out rather than closing a real one, so it can't race a parallel test recycling the descriptor.