### PR TITLE
Dispatch and reflector behavior under pressure and floods

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -28,6 +28,7 @@ mod pair_tests;
 
 pub(crate) use self::counters::{MessageType, Outcome};
 pub(crate) use self::dial_context::{DialContext, DialProxyKey};
+pub(crate) use self::multicast::join_deferrable;
 
 use std::io;
 use std::net::{IpAddr, SocketAddr};
@@ -848,16 +849,24 @@ impl PacketDispatcher {
                 }
             }
             match self.table.rebind_interface(stale.key, stale.cur) {
-                // Deferred joins are usually "no address yet" and heal on the interface's next
-                // address event, but after a recreation a deaf group is a real outage: warn.
-                Ok(counts) if counts.deferred > 0 => {
-                    log::warn!(
-                        "{} group membership(s) on {name} not re-joined yet; retrying \
-                         on its next address event",
-                        counts.deferred
-                    );
+                // Both kinds are retried on every later address event, but only a deferral has a
+                // trigger that will resolve it, so only that one may promise a retry.
+                Ok(counts) => {
+                    if counts.failed > 0 {
+                        log::warn!(
+                            "{} group membership(s) on {name} did not re-join; that traffic is \
+                             not reflected until they do",
+                            counts.failed
+                        );
+                    }
+                    if counts.deferred > 0 {
+                        log::warn!(
+                            "{} group membership(s) on {name} not re-joined yet; retrying \
+                             on its next address event",
+                            counts.deferred
+                        );
+                    }
                 }
-                Ok(_) => {}
                 Err(e) => {
                     log::warn!("re-resolving {name} failed: {e}; will retry");
                     failed = true;

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -7,7 +7,7 @@ use std::num::NonZeroU32;
 use std::os::fd::{AsRawFd, RawFd};
 
 use crate::capture::Capture;
-use crate::interface::{AddressChange, Interface, InterfaceAddresses, if_index};
+use crate::interface::{AddressChange, Interface, InterfaceAddresses, if_index_checked};
 
 use super::CaptureKey;
 use super::counters::{CaptureCounters, Outcome};
@@ -256,7 +256,10 @@ impl InterfaceTable {
             .filter_map(|(index, entry)| {
                 let key = InterfaceKey(u32::try_from(index).expect("interface count fits a u32"));
                 let cached = entry.interface.ifindex;
-                let cur = if_index(&entry.interface.name).unwrap_or(0);
+                // A lookup that couldn't run says nothing about the interface. Reading it as 0
+                // would park a healthy entry: leave it out of this pass and re-scan on the next
+                // tick, by which point whatever exhausted the fds has usually let go.
+                let cur = if_index_checked(&entry.interface.name).ok()?.unwrap_or(0);
                 let dead_capture = |c: &CaptureEntry| {
                     c.interface == key && c.capture.as_ref().is_some_and(|cap| !cap.attached(cur))
                 };

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -16,14 +16,25 @@ use crate::libcex::{GroupReq, MCAST_JOIN_GROUP};
 use crate::sys::{open_socket, sockaddr_for, socklen_of};
 
 /// How a [`rejoin`](MulticastJoiner::rejoin) replay landed: `joined` groups are members after the
-/// call (freshly re-joined, or already member), `deferred` groups could not join yet and wait for
-/// the next address event. The two sum to the desired-group count. `joined` (not "rejoined": the
-/// parked-return replay is a first join) is the signal a caller uses to tell a real replay from a
-/// vacuous one over an empty desired list.
+/// call (freshly re-joined, or already member), `deferred` groups have no address of their family
+/// yet, `failed` groups hit something else. The three sum to the desired-group count. Every desired
+/// group is re-applied on every call, so both failure kinds are retried alike; the split is about
+/// what to expect, since only a deferral has a known trigger that resolves it. `joined` (not
+/// "rejoined": the parked-return replay is a first join) is the signal a caller uses to tell a real
+/// replay from a vacuous one over an empty desired list.
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub(crate) struct RejoinCounts {
     pub(crate) joined: usize,
     pub(crate) deferred: usize,
+    pub(crate) failed: usize,
+}
+
+/// One recorded membership: the group wanted on this interface, and whether its current failure has
+/// been reported, so a group that can't join logs once per failure episode rather than on every
+/// replay. Cleared when the group joins, so a later relapse reports again.
+struct Desired {
+    group: IpAddr,
+    reported: bool,
 }
 
 /// One capture interface's multicast memberships: one unbound `SOCK_DGRAM` fd per family, opened on
@@ -34,7 +45,7 @@ pub(crate) struct RejoinCounts {
 pub(crate) struct MulticastJoiner {
     v4: Option<OwnedFd>,
     v6: Option<OwnedFd>,
-    desired: Vec<IpAddr>,
+    desired: Vec<Desired>,
 }
 
 impl MulticastJoiner {
@@ -48,11 +59,16 @@ impl MulticastJoiner {
 
     /// Record `group` for a later [`rejoin`](Self::rejoin) without joining now: the
     /// parked-interface path, where no live index exists to join on. Deduped, like
-    /// [`join`](Self::join)'s own recording.
-    pub(crate) fn record(&mut self, group: IpAddr) {
-        if !self.desired.contains(&group) {
-            self.desired.push(group);
+    /// [`join`](Self::join)'s own recording. Returns the group's index in the desired list.
+    pub(crate) fn record(&mut self, group: IpAddr) -> usize {
+        if let Some(index) = self.desired.iter().position(|d| d.group == group) {
+            return index;
         }
+        self.desired.push(Desired {
+            group,
+            reported: false,
+        });
+        self.desired.len() - 1
     }
 
     /// Join `group` on the interface `ifindex` and record it, so a later interface change
@@ -63,10 +79,17 @@ impl MulticastJoiner {
     /// # Errors
     /// The OS error if the socket can't open or the membership can't be added. `EADDRNOTAVAIL` (no
     /// address of that family yet) is deferrable: the group is recorded and [`rejoin`](Self::rejoin)
-    /// retries it on the next address-up event.
+    /// retries it on the next address-up event. Any other error is marked reported before it
+    /// returns -- the caller's log is the report, and the replay repeats it at debug only.
     pub(crate) fn join(&mut self, group: IpAddr, ifindex: NonZeroU32) -> io::Result<()> {
-        self.record(group);
-        self.apply(group, ifindex)
+        let index = self.record(group);
+        let result = self.apply(group, ifindex);
+        if let Err(e) = &result
+            && !join_deferrable(e)
+        {
+            self.desired[index].reported = true;
+        }
+        result
     }
 
     /// Drop the per-family sockets, so the next join starts from fresh ones. For an interface
@@ -81,22 +104,45 @@ impl MulticastJoiner {
     }
 
     /// Re-attempt every recorded membership after the interface re-resolves, returning the
-    /// [`RejoinCounts`] split of joined vs deferred. A group not joinable before its address
-    /// existed succeeds now; an already-held one is a no-op that still counts as joined.
-    /// Best-effort: a still-unavailable family logs at debug and waits for the next change
-    /// (routine on the address-up path; the recreation rebuild warns on a nonzero deferred count
-    /// instead). `NonZeroU32` makes the parked case unrepresentable: `MCAST_JOIN_GROUP` on index 0
+    /// [`RejoinCounts`] split of joined, deferred and failed. A group not joinable before its
+    /// address existed succeeds now; an already-held one is a no-op that still counts as joined.
+    /// Best-effort: a [deferrable](join_deferrable) failure logs at debug, since the address event
+    /// that resolves it is coming. Anything else logs at warn once per failure episode -- repeats
+    /// at debug, since the replay runs on every address event -- and at info when the group
+    /// finally joins.
+    /// `NonZeroU32` makes the parked case unrepresentable: `MCAST_JOIN_GROUP` on index 0
     /// would let the kernel pick an arbitrary interface by route lookup and advertise our groups
     /// there, so callers skip explicitly while parked.
     pub(crate) fn rejoin(&mut self, ifindex: NonZeroU32) -> RejoinCounts {
         let mut counts = RejoinCounts::default();
         for i in 0..self.desired.len() {
-            let group = self.desired[i];
+            let group = self.desired[i].group;
             match self.apply(group, ifindex) {
-                Ok(()) => counts.joined += 1,
-                Err(e) => {
+                Ok(()) => {
+                    counts.joined += 1;
+                    if self.desired[i].reported {
+                        self.desired[i].reported = false;
+                        log::info!(
+                            "re-join of {group} on ifindex {ifindex} succeeded after an \
+                             earlier failure"
+                        );
+                    }
+                }
+                Err(e) if join_deferrable(&e) => {
                     log::debug!("re-join of {group} on ifindex {ifindex} deferred: {e}");
                     counts.deferred += 1;
+                }
+                Err(e) => {
+                    counts.failed += 1;
+                    if self.desired[i].reported {
+                        log::debug!("re-join of {group} on ifindex {ifindex} still failing: {e}");
+                    } else {
+                        self.desired[i].reported = true;
+                        log::warn!(
+                            "re-join of {group} on ifindex {ifindex} failed; its traffic is \
+                             not reflected: {e}"
+                        );
+                    }
                 }
             }
         }
@@ -159,11 +205,27 @@ pub(crate) fn join_unsupported(err: &io::Error) -> bool {
     )
 }
 
+/// Whether a group-join failure is deferrable: `EADDRNOTAVAIL` means the interface has no address of
+/// the group's family yet, so the group joins on the address event that supplies one. Every other
+/// error is replayed just the same, but has no trigger anyone can name, so it reports as a failure
+/// rather than a wait.
+pub(crate) fn join_deferrable(e: &io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EADDRNOTAVAIL)
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use super::*;
+
+    #[test]
+    fn only_eaddrnotavail_is_a_deferrable_join() {
+        let of = io::Error::from_raw_os_error;
+        assert!(join_deferrable(&of(libc::EADDRNOTAVAIL))); // an address event will fix it
+        assert!(!join_deferrable(&of(libc::ENODEV))); // nothing in particular will
+        assert!(!join_deferrable(&of(libc::EINVAL)));
+    }
 
     impl MulticastJoiner {
         /// Whether no family socket is open (nothing joined since the last reset). Reachable
@@ -219,6 +281,54 @@ mod tests {
             joiner.v4.is_some(),
             "rejoin re-opens a fresh socket and re-joins"
         );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
+    fn a_replayed_hard_failure_reports_once() {
+        let mut joiner = MulticastJoiner::new();
+        // A unicast address can never join, so every replay fails hard (EINVAL) deterministically.
+        joiner.record(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let first = joiner.rejoin(loopback_ifindex());
+        assert_eq!((first.joined, first.deferred, first.failed), (0, 0, 1));
+        assert!(joiner.desired[0].reported, "the first failure is reported");
+        let second = joiner.rejoin(loopback_ifindex());
+        assert_eq!(second.failed, 1, "the group is still retried");
+        assert!(joiner.desired[0].reported);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
+    fn join_marks_a_hard_failure_reported() {
+        let mut joiner = MulticastJoiner::new();
+        let err = joiner
+            .join(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), loopback_ifindex())
+            .expect_err("a unicast address cannot join");
+        assert!(!join_deferrable(&err));
+        assert!(
+            joiner.desired[0].reported,
+            "the caller logs this error; the replay must not re-report it"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
+    fn a_join_clears_the_reported_mark() {
+        let mut joiner = MulticastJoiner::new();
+        let ifindex = loopback_ifindex();
+        match joiner.join(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251)), ifindex) {
+            Ok(()) => {}
+            Err(e) if join_unsupported(&e) => {
+                eprintln!("skip a_join_clears_the_reported_mark: unsupported here ({e})");
+                return;
+            }
+            Err(e) => panic!("kernel must accept the loopback join: {e}"),
+        }
+        // As if an earlier replay failed: the next success closes the episode.
+        joiner.desired[0].reported = true;
+        let counts = joiner.rejoin(ifindex);
+        assert_eq!((counts.joined, counts.failed), (1, 0));
+        assert!(!joiner.desired[0].reported, "the join cleared the mark");
     }
 
     // The parked-interface path: record keeps the group for the rebuild's replay without

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -637,8 +637,8 @@ fn pair_interface_table_recovers_after_interface_recreation() -> io::Result<()> 
         let counts = table.rebind_interface(s.key, s.cur)?;
         let expected_joined = if s.key == receive_key { 2 } else { 0 };
         assert_eq!(
-            (counts.joined, counts.deferred),
-            (expected_joined, 0),
+            (counts.joined, counts.deferred, counts.failed),
+            (expected_joined, 0, 0),
             "the interface re-joined its recorded groups on the fresh socket, none deferred"
         );
         for capture in table.captures_of(s.key) {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -191,14 +191,35 @@ impl Interface {
     }
 }
 
-/// The kernel ifindex of `name`, or `None` if it names no interface (a NUL in the name, or
-/// an unknown name). Address-change events report an ifindex; an [`Interface`] caches its
-/// own so a notification maps back to it.
+/// The kernel ifindex of `name`, or `None` if it names no interface *or* the lookup itself
+/// failed. Address-change events report an ifindex; an [`Interface`] caches its own so a
+/// notification maps back to it. A caller that acts destructively on absence wants
+/// [`if_index_checked`] instead.
 pub(crate) fn if_index(name: &str) -> Option<u32> {
-    let cname = std::ffi::CString::new(name).ok()?;
+    if_index_checked(name).ok().flatten()
+}
+
+/// The kernel ifindex of `name`, telling "no such interface" apart from a lookup that could not
+/// run. `if_nametoindex` is not a pure lookup: glibc and musl open a socket inside it, so under fd
+/// pressure it reports 0 for a perfectly live interface.
+///
+/// # Errors
+/// Only the resource errnos yield `Err`. Any other failure still reads as absent, so an errno this
+/// list happens to miss can't mask a genuinely removed interface.
+pub(crate) fn if_index_checked(name: &str) -> io::Result<Option<u32>> {
+    let Ok(cname) = std::ffi::CString::new(name) else {
+        return Ok(None); // an interior NUL names no interface
+    };
     // SAFETY: `cname` is a valid NUL-terminated C string for the call's duration.
     let index = unsafe { libc::if_nametoindex(cname.as_ptr()) };
-    (index != 0).then_some(index)
+    if index != 0 {
+        return Ok(Some(index));
+    }
+    let err = io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(libc::EMFILE | libc::ENFILE | libc::ENOMEM | libc::ENOBUFS) => Err(err),
+        _ => Ok(None),
+    }
 }
 
 /// The name of interface `index`, or `None` if it names no interface. The reverse of [`if_index`],
@@ -444,6 +465,19 @@ mod tests {
             Some("fc00::1".parse::<Ipv6Addr>().unwrap()),
             "best non-link-local is the ULA"
         );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real if_nametoindex")]
+    fn a_name_that_resolves_to_nothing_is_absent_not_an_error() {
+        assert!(matches!(
+            if_index_checked(LOOPBACK_IFACE),
+            Ok(Some(index)) if index != 0
+        ));
+        // The two ways a name can fail to be one: no such interface, and an interior NUL that
+        // can't reach the C call at all. Neither is a lookup failure.
+        assert!(matches!(if_index_checked("nf-no-such-iface"), Ok(None)));
+        assert!(matches!(if_index_checked("lo\0extra"), Ok(None)));
     }
 
     // Opt-in diagnostic: trace-log every address (and each v6's flag status) the resolver

--- a/src/interface/getifaddrs.rs
+++ b/src/interface/getifaddrs.rs
@@ -18,11 +18,12 @@ use crate::net::mac::MacAddr;
 /// Resolve `if_name`'s current source addresses in one `getifaddrs` pass.
 ///
 /// # Errors
-/// Returns an error only if `getifaddrs` fails; an unknown interface (or one with no
-/// addresses yet) yields an all-absent [`InterfaceAddresses`].
+/// Returns an error if `getifaddrs` fails or the v6 flag socket can't open; an unknown
+/// interface (or one with no addresses yet) yields an all-absent [`InterfaceAddresses`],
+/// as does a host with no IPv6 stack.
 pub(super) fn resolve(if_name: &str) -> io::Result<InterfaceAddresses> {
-    // One socket for the per-v6 `SIOCGIFAFLAG_IN6` ioctl; no IPv6 stack just means no v6.
-    let v6_sock = inet6_socket();
+    // One socket for the per-v6 `SIOCGIFAFLAG_IN6` ioctl.
+    let v6_sock = inet6_socket()?;
 
     let mut head: *mut libc::ifaddrs = ptr::null_mut();
     // SAFETY: `getifaddrs` writes a freshly-allocated linked list into `head` (or returns
@@ -156,13 +157,32 @@ fn canonical_v6(mut octets: [u8; 16]) -> Ipv6Addr {
 }
 
 /// An `AF_INET6` datagram socket for the flag ioctl, or `None` if the host has no IPv6.
-fn inet6_socket() -> Option<OwnedFd> {
+///
+/// # Errors
+/// Any other `socket` failure. Under fd or memory pressure the host still has IPv6, and
+/// reading that as "no v6" would filter every candidate and commit the false loss; the error
+/// fails the whole resolve instead, which the caller retries.
+fn inet6_socket() -> io::Result<Option<OwnedFd>> {
     // SAFETY: `socket` returns a fresh fd or -1.
     let raw = unsafe { libc::socket(libc::AF_INET6, libc::SOCK_DGRAM, 0) };
-    (raw >= 0).then(|| {
+    if raw >= 0 {
         // SAFETY: `raw` is a fresh owned socket fd.
-        unsafe { OwnedFd::from_raw_fd(raw) }
-    })
+        return Ok(Some(unsafe { OwnedFd::from_raw_fd(raw) }));
+    }
+    let err = io::Error::last_os_error();
+    if no_ipv6_stack(&err) {
+        return Ok(None);
+    }
+    Err(err)
+}
+
+/// Whether a `socket(AF_INET6, ...)` failure means the host has no IPv6 stack, the one case
+/// where an absent socket is the truth rather than a transient failure.
+fn no_ipv6_stack(e: &io::Error) -> bool {
+    matches!(
+        e.raw_os_error(),
+        Some(libc::EAFNOSUPPORT | libc::EPROTONOSUPPORT)
+    )
 }
 
 /// The `IN6_IFF_*` flags of `addr` on `if_name`, queried via `SIOCGIFAFLAG_IN6`, or `None`
@@ -189,6 +209,16 @@ mod tests {
     use std::mem::offset_of;
 
     use super::*;
+
+    #[test]
+    fn only_a_missing_ipv6_stack_reads_as_no_v6() {
+        let of = io::Error::from_raw_os_error;
+        assert!(no_ipv6_stack(&of(libc::EAFNOSUPPORT)));
+        assert!(no_ipv6_stack(&of(libc::EPROTONOSUPPORT)));
+        // Pressure errnos fail the resolve instead of committing a false v6 loss.
+        assert!(!no_ipv6_stack(&of(libc::EMFILE)));
+        assert!(!no_ipv6_stack(&of(libc::ENOBUFS)));
+    }
 
     #[test]
     fn canonical_v6_strips_the_embedded_scope_from_link_local() {

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -15,13 +15,12 @@ pub(crate) use search::SearchReflector;
 pub(crate) use simple::SimpleReflector;
 
 use std::fmt;
-use std::io;
 use std::net::{IpAddr, SocketAddr};
 
 use thiserror::Error;
 
 use crate::config::AddressFamily;
-use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher};
+use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_deferrable};
 use crate::interface::InterfaceAddresses;
 use crate::reactor::Reactor;
 
@@ -186,17 +185,10 @@ fn require_bidirectional_families(
     Ok(())
 }
 
-/// Whether a group-join failure is deferrable: `EADDRNOTAVAIL` means the interface has no address of the
-/// group's family yet, so the joiner records the group and retries on the next address change. Every
-/// other error is a hard failure that will not self-heal.
-fn join_deferrable(e: &io::Error) -> bool {
-    e.raw_os_error() == Some(libc::EADDRNOTAVAIL)
-}
-
 /// Join `group` on `capture` for `protocol`'s `side` leg (`"source"`/`"target"`), logging the outcome.
 /// A [deferrable](join_deferrable) failure logs at debug (it retries on the next address change); any
-/// other failure is a warning, since that group's traffic won't be reflected and won't self-heal — a
-/// dead reflector must not hide behind a debug line.
+/// other failure is a warning, matching its re-join sibling — a dead reflector must not hide behind
+/// a debug line.
 fn join_group_logged(
     dispatcher: &mut PacketDispatcher,
     capture: CaptureKey,
@@ -213,7 +205,7 @@ fn join_group_logged(
         }
         Err(e) => {
             log::warn!(
-                "{protocol}: join {group} on {side} failed; its traffic will not be reflected: {e}"
+                "{protocol}: join {group} on {side} failed; its traffic is not reflected: {e}"
             );
         }
     }
@@ -224,14 +216,6 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use super::*;
-
-    #[test]
-    fn only_eaddrnotavail_is_a_deferrable_join() {
-        let of = io::Error::from_raw_os_error;
-        assert!(join_deferrable(&of(libc::EADDRNOTAVAIL))); // no address of this family yet; retried
-        assert!(!join_deferrable(&of(libc::ENODEV))); // a hard failure: warn, don't hide
-        assert!(!join_deferrable(&of(libc::EINVAL)));
-    }
 
     #[test]
     fn missing_required_family_enforces_the_requires_policy() {

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -201,7 +201,7 @@ impl SearchReflector {
             return Err(Outcome::Dropped(message_type));
         };
         let Some(our_addr) = reply_source(dispatcher, self.target, packet.dest.ip()) else {
-            log::warn!(
+            log::debug!(
                 "{}: cannot reflect search from {}: target has no source address for {} yet",
                 self.name,
                 packet.source,

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -301,7 +301,7 @@ impl PacketHandler for SearchReflector {
         };
         let expiry = Instant::now() + (self.window)(packet.payload);
 
-        // A retransmit from a known searcher to the same group reuses its session: refresh the window
+        // A retransmit from a known searcher to the same group reuses its session: extend the window
         // and re-reflect from the same reserved port. A new searcher, or the same searcher to a
         // different group (a different reply scope), opens a fresh session. No staleness check here:
         // an interface recreation or address change orphans a session's reservation, but the dispatcher
@@ -318,7 +318,9 @@ impl PacketHandler for SearchReflector {
                 packet.payload,
             ) {
                 Ok(()) => {
-                    session.expiry = expiry;
+                    // Extend, never shorten: devices answering an earlier search may use its whole
+                    // MX window, so a retransmit with a smaller MX must not cut their replies off.
+                    session.expiry = session.expiry.max(expiry);
                     log::debug!(
                         "re-reflected {} search from {} to {} on reserved port {port}",
                         self.name,
@@ -609,6 +611,38 @@ mod tests {
         assert!(
             reflector.sessions[0].expiry > base,
             "the session's window is refreshed"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket")]
+    fn a_retransmit_with_a_smaller_window_does_not_shorten_the_session() {
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reactor = Reactor::new().unwrap();
+        let mut reflector = test_reflector();
+        // Well past anything the retransmit's own window can reach.
+        let far = Instant::now() + Duration::from_hours(1);
+        push_session(
+            &mut reflector,
+            &mut dispatcher,
+            "10.0.0.7:50000",
+            "239.255.255.250:1900",
+            far,
+        );
+
+        let packet = Packet {
+            source: "10.0.0.7:50000".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
+            payload: b"a search",
+        };
+        reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
+
+        assert_eq!(
+            reflector.sessions[0].expiry, far,
+            "replies promised by the earlier window are still collected"
         );
     }
 

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -126,7 +126,7 @@ const SESSION_GRACE: Duration = Duration::from_secs(2);
 /// reply grace. A search with no usable MX falls back to the protocol default.
 fn search_window(payload: &[u8]) -> Duration {
     let mx = parse_msearch_mx(payload).unwrap_or_else(|| {
-        log::info!(
+        log::debug!(
             "SSDP: M-SEARCH has no usable MX; using the default {MSEARCH_MX_DEFAULT}s window"
         );
         MSEARCH_MX_DEFAULT


### PR DESCRIPTION
Six audit findings in the dispatch/reflector layer, one commit each. The common thread: resource pressure and remote input driving wrong state or log floods.

- **A failed `if_nametoindex` no longer parks a healthy interface.** glibc and musl open a socket inside it, so under fd pressure it reports 0 for a live interface; the reconcile read that as removal and took the full teardown (group leaves, addresses cleared, DIAL proxies evicted, sessions dropped) across every interface at once, the failure being process-wide. `stale_interfaces` now uses a checked lookup and skips an entry it couldn't resolve. Only the resource errnos count as lookup failure; anything else still reads as absent, so a mis-listed errno can't pin a genuinely removed interface.
- **Deferred vs failed re-joins.** `rejoin` counted every error as deferred, so the recreation rebuild promised "retrying on its next address event" for errors no address event addresses. `join_deferrable` now classifies both the build path and the replay; every desired group is still retried on every address event, so the split is about expectation. Each group carries a reported mark: first hard failure at warn, repeats at debug, the join that closes the episode at info. Removing failed groups instead was rejected — the replay is what joins a group once its blocker clears (IPv6 enabled later, a memory blip passing).
- **BSD v6 resolution fails instead of faking "no v6".** `inet6_socket` read every `socket()` failure as "host has no IPv6", so under fd/memory pressure the resolver filtered every good v6 source, closed the v6 egress gate, and logged an address loss that never happened. Only `EAFNOSUPPORT`/`EPROTONOSUPPORT` mean no v6 stack now; anything else fails the resolve, which the dispatcher already retries.
- **Search-path log floods.** Two remote-input-driven per-packet lines demoted: the no-source-address stall in `make_session` (warn → debug, matching its sibling handlers — no session is created, so the dedup never engaged and every search re-logged) and the no-usable-MX fallback in `search_window` (info → debug, the only per-packet event at info).
- **A retransmit never shortens a live session.** The retransmit path overwrote the session expiry from the current packet's MX, so a follow-up search with a smaller MX evicted the session while devices were still answering the earlier one inside its promised window — reservation dropped, late replies ICMP-rejected. Extend with `max` instead.

## Testing

`cargo test --lib` on macOS (470) and Linux (467, includes the privileged pair tests), clippy `--all-targets -D warnings` on both plus `x86_64-unknown-freebsd`, fmt, `cargo doc` on both. Docker e2e running at PR time; result posted below. Fixes with testable behavior are mutation-checked: the checked-lookup classifier, all three reported-mark transitions, the v6-stack classifier, and the session-window `max` each have a test that fails when the fix is reverted.