### PR TITLE
Config duplicates, logger syscalls, and the OPNsense log destination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,14 @@ jobs:
           ci/freebsd-vm.sh run 'sysrc netflector_enable=YES'
           ci/freebsd-vm.sh run 'printf "[reflectors.bad]\nsource_if = \"em0\"\ntarget_if = \"em0\"\nmdns = true\n" > /usr/local/etc/netflector.toml'
           ci/freebsd-vm.sh run 'service netflector start 2>&1 | grep -q "refusing to start" && echo "rc refused an invalid configuration"'
+      - name: Lint the installed man pages
+        run: |
+          # The strict pass needs a real manpath: -W style resolves Xr against the base system and
+          # our own siblings, while on Ubuntu (the man-lint job) every FreeBSD page reads as absent,
+          # so a typo'd reference there is indistinguishable from one that legitimately is not
+          # installed. Order matters: -W style must follow -T lint, which resets the floor.
+          ci/freebsd-vm.sh run 'makewhatis /usr/local/share/man'
+          ci/freebsd-vm.sh run 'mandoc -T lint -W style /usr/local/share/man/man8/netflector.8.gz /usr/local/share/man/man5/netflector.toml.5.gz'
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console

--- a/dist/opnsense/net/netflector/Makefile
+++ b/dist/opnsense/net/netflector/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		netflector
-PLUGIN_VERSION=		0.1.2
+PLUGIN_VERSION=		0.1.3
 PLUGIN_COMMENT=		Reflect link-local service discovery between interfaces
 PLUGIN_MAINTAINER=	sergii@bogomolov.io
 PLUGIN_WWW=			https://github.com/netflector/netflector

--- a/dist/opnsense/net/netflector/src/etc/inc/plugins.inc.d/netflector.inc
+++ b/dist/opnsense/net/netflector/src/etc/inc/plugins.inc.d/netflector.inc
@@ -50,6 +50,17 @@ function netflector_enabled()
     return false;
 }
 
+/**
+ * Registers the daemon's syslog tag as an application, so remote syslog destinations (System >
+ * Settings > Logging) can forward exactly its lines. The rc script starts the daemon under
+ * `daemon -S -T netflector`, so every line carries this tag; the name here must match that -T,
+ * as must the Syslog/local template filter that routes the tag into /var/log/netflector/.
+ */
+function netflector_syslog()
+{
+    return ['netflector' => ['facility' => ['netflector']]];
+}
+
 function netflector_services()
 {
     $services = [];

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
@@ -12,7 +12,7 @@
         <id>netflector.general.log_level</id>
         <label>Log level</label>
         <type>dropdown</type>
-        <help><![CDATA[Verbosity of the daemon's log. "Debug" and "Trace" are noisy and are meant for diagnosing a problem, not for running.]]></help>
+        <help><![CDATA[Verbosity of the daemon's log, under Services > Netflector > Log File. Every line is recorded at the same syslog priority, so filter on the level in the message text. "Debug" and "Trace" are noisy and are meant for diagnosing a problem, not for running.]]></help>
     </field>
     <field>
         <id>netflector.general.counters_interval_secs</id>

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Menu/Menu.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Menu/Menu.xml
@@ -1,5 +1,8 @@
 <menu>
     <Services>
-        <Netflector VisibleName="Netflector" cssClass="fa fa-exchange fa-fw" url="/ui/netflector"/>
+        <Netflector VisibleName="Netflector" cssClass="fa fa-exchange fa-fw">
+            <Settings VisibleName="Settings" order="10" url="/ui/netflector"/>
+            <Log VisibleName="Log File" order="20" url="/ui/diagnostics/log/core/netflector"/>
+        </Netflector>
     </Services>
 </menu>

--- a/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Syslog/local/netflector.conf
+++ b/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Syslog/local/netflector.conf
@@ -1,0 +1,6 @@
+###################################################################
+# Local syslog-ng configuration filter definition [netflector].
+###################################################################
+filter f_local_netflector {
+    program("netflector");
+};

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -70,6 +70,19 @@ stays reachable:
 .Ql netflector \-\- \-\-check-config
 reads a file named
 .Pa \-\-check-config .
+.Pp
+Under the
+.Xr rc 8
+service
+.Nm
+is started by
+.Xr daemon 8
+with
+.Fl S ,
+which routes its standard error into
+.Xr syslogd 8 .
+A record's level does not survive that, so filter on the level in the message
+text; each line also carries two timestamps, syslog's and the daemon's.
 .Sh SIGNALS
 .Bl -tag -width "SIGTERM"
 .It Dv SIGINT , Dv SIGTERM

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,9 +21,10 @@ pub(crate) enum Invocation<'a> {
 
 /// Parse `args` (with `argv[0]` already stripped).
 ///
-/// `--help` and `--version` win over everything else, so they answer even when the rest of the
-/// line is nonsense. Otherwise netflector takes at most one positional; extras are rejected
-/// rather than ignored, since a second path is far more likely a typo than an intent.
+/// `--help` and `--version` win over anything after them on the line, so they answer even when
+/// the rest is nonsense; an unknown option before them still errors, first bad token wins.
+/// Otherwise netflector takes at most one positional; extras are rejected rather than ignored,
+/// since a second path is far more likely a typo than an intent.
 ///
 /// `--` ends option parsing, so a config file whose name begins with a dash is still reachable
 /// (`netflector -- --check-config` reads a file called `--check-config`). Without it such a path

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -32,26 +32,40 @@ struct PartialReflector {
 impl PartialReflector {
     /// `var` is the full variable name, used only to label errors.
     fn set(&mut self, param: &str, value: &str, var: &str) -> Result<(), ConfigError> {
-        match param {
-            "name" => self.name = Some(env_value(value, var)?),
-            "source_if" => self.source_if = Some(env_value(value, var)?),
-            "target_if" => self.target_if = Some(env_value(value, var)?),
-            "macs" => self.macs = Some(env_value(value, var)?),
-            "wol_ports" => self.wol_ports = Some(env_value(value, var)?),
-            "address_family" => self.address_family = Some(env_value(value, var)?),
-            "wol" => self.wol = Some(env_bool(value, var)?),
-            "mdns" => self.mdns = Some(env_bool(value, var)?),
-            "ssdp" => self.ssdp = Some(env_bool(value, var)?),
-            "dial" => self.dial = Some(env_bool(value, var)?),
-            "wsd" => self.wsd = Some(env_bool(value, var)?),
-            _ => {
-                return Err(ConfigError::EnvUnknownParam {
+        // Write-once slots: params fold case-insensitively, so two case-variant variables land in
+        // the same slot, and environ order must not pick a silent winner.
+        fn put<T>(
+            slot: &mut Option<T>,
+            value: T,
+            param: &str,
+            var: &str,
+        ) -> Result<(), ConfigError> {
+            if slot.is_some() {
+                return Err(ConfigError::EnvDuplicateParam {
                     var: var.to_owned(),
                     param: param.to_owned(),
                 });
             }
+            *slot = Some(value);
+            Ok(())
         }
-        Ok(())
+        match param {
+            "name" => put(&mut self.name, env_value(value, var)?, param, var),
+            "source_if" => put(&mut self.source_if, env_value(value, var)?, param, var),
+            "target_if" => put(&mut self.target_if, env_value(value, var)?, param, var),
+            "macs" => put(&mut self.macs, env_value(value, var)?, param, var),
+            "wol_ports" => put(&mut self.wol_ports, env_value(value, var)?, param, var),
+            "address_family" => put(&mut self.address_family, env_value(value, var)?, param, var),
+            "wol" => put(&mut self.wol, env_bool(value, var)?, param, var),
+            "mdns" => put(&mut self.mdns, env_bool(value, var)?, param, var),
+            "ssdp" => put(&mut self.ssdp, env_bool(value, var)?, param, var),
+            "dial" => put(&mut self.dial, env_bool(value, var)?, param, var),
+            "wsd" => put(&mut self.wsd, env_bool(value, var)?, param, var),
+            _ => Err(ConfigError::EnvUnknownParam {
+                var: var.to_owned(),
+                param: param.to_owned(),
+            }),
+        }
     }
 
     /// The two interface fields are required; the rest default.
@@ -218,6 +232,21 @@ mod tests {
         assert_eq!(r.source_if.as_str(), "lan");
         assert_eq!(r.target_if.as_str(), "iot");
         assert!(r.mdns);
+    }
+
+    #[test]
+    fn a_case_variant_env_param_is_rejected_not_last_wins() {
+        let err = from_env(&[
+            ("NETFLECTOR_TV_SOURCE_IF", "eth0"),
+            ("NETFLECTOR_TV_source_if", "eth1"),
+            ("NETFLECTOR_TV_TARGET_IF", "iot"),
+        ])
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::EnvDuplicateParam { var, param }
+                if var == "NETFLECTOR_TV_source_if" && param == "source_if"
+        ));
     }
 
     #[test]

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -94,6 +94,12 @@ pub(crate) enum ConfigError {
     #[error("environment variable \"{var}\" sets unknown parameter \"{param}\"")]
     EnvUnknownParam { var: String, param: String },
 
+    #[error(
+        "environment variable \"{var}\" sets \"{param}\", which another variable already set \
+         (names are case-insensitive)"
+    )]
+    EnvDuplicateParam { var: String, param: String },
+
     #[error("environment variable \"{var}\" has invalid value \"{value}\": {source}")]
     EnvBadValue {
         var: String,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -9,7 +9,8 @@
 //! Records go to stderr (stdout is left for program output) as
 //! `<utc> <LEVEL> <target>: <message>` with a UTC ISO-8601 timestamp.
 
-use std::fmt;
+use std::cell::RefCell;
+use std::fmt::{self, Write as _};
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -33,16 +34,18 @@ impl Log for StderrLogger {
         if !self.enabled(record.metadata()) {
             return;
         }
-        let mut stderr = std::io::stderr();
-        writeln!(
-            stderr,
-            "{} {:>5} {}: {}",
-            Utc::now(),
-            record.level(),
-            record.target(),
-            record.args(),
-        )
-        .ok();
+        // Build the line first and write it whole. Stderr is unbuffered and its write_fmt issues
+        // one write(2) per formatting fragment (20-30 for a typical record), which matters once
+        // debug/trace logs per frame. The buffer is reused, so no per-record allocation either.
+        thread_local! {
+            static LINE: RefCell<String> = const { RefCell::new(String::new()) };
+        }
+        LINE.with(|line| {
+            let mut line = line.borrow_mut();
+            line.clear();
+            format_record(&mut line, Utc::now(), record);
+            std::io::stderr().write_all(line.as_bytes()).ok();
+        });
     }
 
     fn flush(&self) {
@@ -50,7 +53,21 @@ impl Log for StderrLogger {
     }
 }
 
+/// Format `record`, stamped `now`, as the one-line stderr entry, newline included. The caller
+/// reads the clock, so the formatting is exercisable against a fixed timestamp.
+fn format_record(line: &mut String, now: Utc, record: &Record) {
+    // Formatting into a String is infallible.
+    let _ = writeln!(
+        line,
+        "{now} {:>5} {}: {}",
+        record.level(),
+        record.target(),
+        record.args(),
+    );
+}
+
 /// A civil UTC date-time, rendered as ISO 8601 (e.g. `2026-06-19T18:49:58Z`).
+#[derive(Clone, Copy)]
 struct Utc {
     year: u64,
     month: u64,
@@ -174,6 +191,21 @@ mod tests {
             Utc::from_unix(951_782_400).to_string(),
             "2000-02-29T00:00:00Z"
         );
+    }
+
+    #[test]
+    fn a_record_formats_as_one_stamped_line() {
+        let mut line = String::new();
+        format_record(
+            &mut line,
+            Utc::from_unix(0),
+            &log::Record::builder()
+                .level(log::Level::Info)
+                .target("netflector::test")
+                .args(format_args!("hello"))
+                .build(),
+        );
+        assert_eq!(line, "1970-01-01T00:00:00Z  INFO netflector::test: hello\n");
     }
 
     #[test]


### PR DESCRIPTION
Five audit findings across config parsing, the CLI, logging, and the OPNsense plugin, plus one CI follow-up.

- **A parameter set twice is now an error, not last-wins.** `parse_env` folds tags and params to lowercase, so `NETFLECTOR_TV_SOURCE_IF=eth0` and `NETFLECTOR_TV_source_if=eth1` landed in the same slot and whichever came later in environ silently won — reachable with a systemd `Environment=` plus an `EnvironmentFile`, or a container image plus an override. This was the only ambiguity the config layer accepted quietly; duplicate TOML keys, env/file collisions, and folded file keys all error. The slots are write-once now, and the error names the variable and parameter.
- **Each log record is one `write(2)`.** Stderr is unbuffered and `StderrLock` doesn't override `write_fmt`, so std's default issued one syscall per formatting fragment — 23 for a plain info line, 31 for the per-frame trace in the drain loop. Records are formatted into a reused thread-local buffer and written whole. Output is byte-identical and a test pins the line by equality. Interior mutability is required because `Log::log` takes `&self` and `set_logger` requires `Sync`; `thread_local!` keeps the daemon at exactly one buffer while staying sound under the multi-threaded test harness. `format_record` takes the timestamp as a parameter rather than reading the clock, so the formatting is exercisable under Miri's isolation.
- **The daemon gets its own log file and GUI page on OPNsense.** The rc script tags stderr with `-T netflector`, but the plugin registered nothing on top, so lines landed in the General log with no way to view, rotate, or forward them separately. Three registrations were needed, each with a different consumer, and the audit had identified only the last: a `Syslog/local` template filter (what actually generates the `/var/log/netflector/` syslog-ng destination — 20 official plugins ship one), a `Menu.xml` Log File entry (without which the file is unreachable from the GUI — 29 plugins have one), and the `_syslog()` hook (whose only consumer is the Applications picker for *remote* syslog destinations). `PLUGIN_VERSION` 0.1.3.
- **`netflector(8)` documents the rc service's logging.** Under `daemon -S` a record's level does not reach syslog and each line carries two timestamps, so filtering by syslog level gets everything or nothing.
- **The CLI's `--help` precedence claim corrected.** The doc said the flags win over everything; an unknown option before them errors first (`--bogus --help` reports `--bogus`). Reworded rather than adding a GNU-style pre-scan, which would change shipped behavior to cure a doc bug.
- **The from-source port build now lints the installed man pages.** `ci.yml`'s man-lint job discards every "referenced manual not found" finding — it must, since our own sibling pages don't resolve on Ubuntu — which also hides a typo'd reference to a base-system page (this PR adds `.Xr rc 8` and `.Xr syslogd 8`, the live example). The strict `-W style` pass needs a real manpath, and `freebsd-port-build-src` already installs the port from the current commit on FreeBSD 14 and 15, so the check is a `makewhatis` plus a `mandoc` in a VM that was booting anyway. Two rejected alternatives: triggering all of ci-port on `man/**` (23-26 min of QEMU, and its port build uses the pinned release tarball, so it would lint the previous release's pages, not the diff), and a staged-`MANPATH` lint on Ubuntu (validates sibling refs, but base pages are absent there either way, so a typo is indistinguishable from a legitimately missing page).

## Testing

`cargo test --lib` on macOS (472) and Linux (469), clippy `--all-targets -D warnings` on both plus `x86_64-unknown-freebsd`, fmt, `cargo doc` on both, **Miri over the whole lib (353 passed, 0 failed)**, both layers of the man-lint gate as CI runs them, `php -l` on the hook, XML well-formedness. Docker e2e 57/57.

The plugin change was verified end to end on a live OPNsense 26.7 aarch64 VM rather than by inspection, which is what caught the audit's incomplete fix: with the hook alone installed and the Syslog template reloaded, `plugins_syslog()` returned the entry and `/var/log/netflector/` still did not exist. After adding the filter file, the generated `syslog-ng-local.conf` carries the destination, the `log{}` statement, and `netflector` excluded from the `f_local_system` catch-all; the log file fills with real daemon output; the Applications picker offers `netflector (netflector)`; and Services → Netflector → Log File renders it.