### PR TITLE
FreeBSD rc script and OPNsense validation fixes

### DIFF
--- a/dist/freebsd/net/netflector/files/netflector.in
+++ b/dist/freebsd/net/netflector/files/netflector.in
@@ -32,7 +32,7 @@ procname="%%PREFIX%%/bin/${name}"
 # inherited: without it the supervisor holds the caller's stdout open for the service's lifetime, so
 # `ssh host service netflector start` never returns. It does not affect -S, which redirects the child.
 command="/usr/sbin/daemon"
-command_args="-f -S -T ${name} -p ${pidfile} ${procname} ${netflector_config}"
+command_args="-f -S -T ${name} -p ${pidfile} ${procname} '${netflector_config}'"
 
 start_precmd="${name}_precmd"
 

--- a/dist/freebsd/net/netflector/files/netflector.in
+++ b/dist/freebsd/net/netflector/files/netflector.in
@@ -11,7 +11,7 @@
 # Optional:
 #
 #   netflector_config="/path/to/netflector.toml"   # default %%PREFIX%%/etc/netflector.toml
-#   netflector_flags=""                            # extra arguments
+#   netflector_flags="-r"                          # options for daemon(8), e.g. restart on exit
 
 . /etc/rc.subr
 

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
@@ -137,6 +137,20 @@ class Netflector extends BaseModel
             ));
         }
 
+        // MacAddressField validates with FILTER_VALIDATE_MAC, which also takes hyphen- and
+        // dot-separated forms; the daemon's parser takes colons only.
+        foreach (self::toSet((string)$entry->macs) as $mac) {
+            if (preg_match('/^[0-9a-f]{2}(:[0-9a-f]{2}){5}$/', $mac) !== 1) {
+                $messages->appendMessage(new Message(
+                    sprintf(
+                        gettext('%s must be written as six colon-separated hex octets.'),
+                        $mac
+                    ),
+                    $ref . '.macs'
+                ));
+            }
+        }
+
         // Per-item validation cannot see this: the tokenizer drops only byte-identical strings, so
         // aa:bb:cc:dd:ee:ff beside AA:BB:CC:DD:EE:FF reaches a daemon that rejects both lists.
         $duplicate = self::firstDuplicate((string)$entry->macs);

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
@@ -136,6 +136,27 @@ class Netflector extends BaseModel
                 $ref . '.wol_ports'
             ));
         }
+
+        // Per-item validation cannot see this: the tokenizer drops only byte-identical strings, so
+        // aa:bb:cc:dd:ee:ff beside AA:BB:CC:DD:EE:FF reaches a daemon that rejects both lists.
+        $duplicate = self::firstDuplicate((string)$entry->macs);
+        if ($duplicate !== null) {
+            $messages->appendMessage(new Message(
+                sprintf(
+                    gettext('%s is listed twice. Addresses are compared case-insensitive.'),
+                    $duplicate
+                ),
+                $ref . '.macs'
+            ));
+        }
+
+        $duplicate = self::firstDuplicate((string)$entry->wol_ports);
+        if ($duplicate !== null) {
+            $messages->appendMessage(new Message(
+                sprintf(gettext('Port %s is listed twice.'), $duplicate),
+                $ref . '.wol_ports'
+            ));
+        }
     }
 
     /**
@@ -249,6 +270,22 @@ class Netflector extends BaseModel
     private static function canonicalName($entry)
     {
         return strtolower(trim((string)$entry->name));
+    }
+
+    /**
+     * The first value a comma-separated field repeats, or null. Lowercased comparison matches the
+     * daemon: a MAC's hex case is not part of its identity, and the port mask forbids a leading zero.
+     */
+    private static function firstDuplicate($csv)
+    {
+        $seen = [];
+        foreach (self::toSet($csv) as $value) {
+            if (isset($seen[$value])) {
+                return $value;
+            }
+            $seen[$value] = true;
+        }
+        return null;
     }
 
     /** A comma-separated field as a set of trimmed, lowercased values, empties dropped. */

--- a/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/check.py
+++ b/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/check.py
@@ -101,4 +101,9 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except Exception as exc:
+        # configd discards a failing action's output, so an escaping exception reaches the GUI as a
+        # generic error. Catch broadly and answer on stdout with exit 0, like a rejected config.
+        report('failed', f'The validation could not run: {type(exc).__name__}: {exc}')

--- a/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/modelcheck.php
+++ b/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/modelcheck.php
@@ -114,6 +114,9 @@ foreach (
         /* the daemon rejects a repeated value, and only the model can catch a case variant */
         ['aa:bb:cc:dd:ee:ff,AA:BB:CC:DD:EE:FF', '7', false],
         ['aa:bb:cc:dd:ee:ff', '7,7', false],
+        /* FILTER_VALIDATE_MAC takes these separators, the daemon's parser does not */
+        ['aa-bb-cc-dd-ee-ff', '7', false],
+        ['aabb.ccdd.eeff', '7', false],
     ] as [$macs, $wol_ports, $expect_valid]
 ) {
     $messages = validation_messages($macs, $wol_ports);

--- a/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/modelcheck.php
+++ b/dist/opnsense/net/netflector/src/opnsense/scripts/netflector/modelcheck.php
@@ -111,6 +111,9 @@ foreach (
         ['aa:bb:cc:dd:ee:ff', '7', true],
         ['aa:bb:cc:dd:ee:ff,nonsense', '7', false],
         ['aa:bb:cc:dd:ee:ff', '7,70000', false],
+        /* the daemon rejects a repeated value, and only the model can catch a case variant */
+        ['aa:bb:cc:dd:ee:ff,AA:BB:CC:DD:EE:FF', '7', false],
+        ['aa:bb:cc:dd:ee:ff', '7,7', false],
     ] as [$macs, $wol_ports, $expect_valid]
 ) {
     $messages = validation_messages($macs, $wol_ports);


### PR DESCRIPTION
Four audit findings across the FreeBSD rc script and the OPNsense plugin, plus one found while verifying them. Everything behavioral was proven on a live OPNsense 26.7 aarch64 VM, both before (bug reproduced) and after (fix observed).

**rc script**

- **`netflector_flags` documented as `daemon(8)`'s.** The header advertised it as "extra arguments", implying the daemon's, but rc.subr splices `${name}_flags` between `$command` and `$command_args`, and `$command` is `/usr/sbin/daemon` — verified in rc.subr (`eval rc_flags=\$${name}_flags`, then `$command $rc_flags $command_args`) and with an eval harness showing `--debug` landing at argv[1] of `daemon(8)`. The daemon takes no flags; `daemon(8)` takes useful ones (`-r` restart-on-exit among them), so the knob is now documented as that rather than removed. No port in the tree clears the variable, so neither do we.
- **Config path quoted.** rc.subr evals the assembled command line, so an unquoted `netflector_config` containing spaces word-split into two positionals and the daemon exited with a usage error — after the precmd, which quotes the same variable, had validated that path. Single quotes survive the eval; harness shows argc 10 → 9 with the path intact.

**OPNsense plugin**

- **Duplicates rejected at Validate.** The daemon refuses a repeated MAC or WoL port (`MacSetError::Duplicate`, `WolPortsError::Duplicate`), but the model had no duplicate check and the GUI tokenizer drops only byte-identical strings — so `aa:bb:cc:dd:ee:ff` beside `AA:BB:CC:DD:EE:FF` validated, saved, rendered, and took the service down at the next Apply while the GUI reported success (`--check-config` runs on the Validate button and the rc precmd, not at Apply). Comparison is lowercased, matching the daemon: `MacAddr::from_str` accepts only colon-separated hex, so case is the only possible variation, and the port field's mask already forbids leading zeros. Reproduced through the GUI before the fix.
- **Colon MAC form required** (not in the audit; found during VM verification). `MacAddressField` validates with `FILTER_VALIDATE_MAC`, which also accepts `aa-bb-cc-dd-ee-ff` and `aabb.ccdd.eeff`; the daemon parses six colon-separated octets and refuses the whole config otherwise — proven live: model accepts the hyphen form, daemon fails with a TOML parse error. Windows renders MACs with hyphens, so this is reachable by paste, no case trickery needed.
- **`check.py` answers the GUI even when validation cannot run.** The audit's stated trigger (a Jinja `UndefinedError` from the template) turned out impossible — `Template.generate()` catches everything, logs to syslog, and returns `None`, which the existing no-configuration branch already reports; verified by breaking the template on the VM. The reachable escape is everything before the render, the config load: a malformed `config.xml` exited 1 with a traceback, and configd discards a failing action's output, so the Validate button showed a generic error. The `__main__` call is now wrapped: shipped → exit 1, no JSON; fixed → exit 0, `{"status": "failed", "message": "The validation could not run: ParseError: ..."}`. Happy path and the `configctl netflector check` route re-verified unchanged.

Model coverage went into the plugin's own `modelcheck.php` (run by the CI gate): four new cases, each failing against the unfixed model and passing against the fixed one, executed on the VM.

## Testing

`sh -n` on the rc script; `php -l` on every plugin PHP file; `python3 -m py_compile` on `check.py` (the same check ci-opnsense runs); XML well-formedness; `modelcheck.php` green on OPNsense 26.7 with the unfixed-model mutation check failing all four new cases. No `src/` changes, so the Rust suites are untouched. `PLUGIN_VERSION` stays 0.1.3, unreleased since #123.