### PR TITLE
e2e suite: close two blind spots, correct stale text, rename the test interfaces

### DIFF
--- a/e2e/config-addrchange.toml
+++ b/e2e/config-addrchange.toml
@@ -5,7 +5,7 @@ log_level = "debug"
 # case then knocks out one (interface, family) source address at a time and proves -- via real
 # traffic -- that only that family's reflection stops, then resumes once the address returns.
 [reflectors.mdns]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 mdns = true
 address_family = "dual"

--- a/e2e/config-dial.toml
+++ b/e2e/config-dial.toml
@@ -3,7 +3,7 @@ log_level = "debug"
 # A single DIAL entry, so netflector's SSDP relay carries the device's 200 OK exactly once (the shared
 # config.toml's any-MAC [reflectors.discovery] entry would otherwise double-reflect it). DIAL requires ssdp.
 [reflectors.dial-tv]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 ssdp = true
 dial = true

--- a/e2e/config-family-v6.toml
+++ b/e2e/config-family-v6.toml
@@ -5,7 +5,7 @@ log_level = "debug"
 # is ignored. A lone reflector so it can't conflict with the dual "discovery" one in config.toml.
 # (Different protocol from the IPv4 case on purpose, so single-family gating is covered for both.)
 [reflectors.ssdp-v6]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 ssdp = true
 address_family = "ipv6"

--- a/e2e/config-family.toml
+++ b/e2e/config-family.toml
@@ -5,7 +5,7 @@ log_level = "debug"
 # A lone reflector (not sharing the interfaces with the dual "discovery" one in config.toml) so the
 # two mDNS reflectors can't conflict.
 [reflectors.mdns-v4]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 mdns = true
 address_family = "ipv4"

--- a/e2e/config-wsd.toml
+++ b/e2e/config-wsd.toml
@@ -1,10 +1,10 @@
 log_level = "debug"
 
-# A WSD-only reflector for the WS-Discovery e2e cases: bridges wol_src <-> wol_dst under the default
+# A WSD-only reflector for the WS-Discovery e2e cases: bridges nf_source <-> nf_target under the default
 # address-family policy, so both IPv4 (239.255.255.250) and IPv6 (ff02::c) announcements and searches
 # on UDP 3702 are exercised.
 
 [reflectors.discovery]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 wsd = true

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -5,20 +5,20 @@ log_level = "debug"
 # "dual" to also cover the strict require-both-families policy (and its startup check).
 
 [reflectors.wol-mac]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 macs = ["02:42:ac:11:00:09", "02:42:ac:11:00:0c"]
 wol = true
 wol_ports = [9009]
 
 [reflectors.wol-any]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 wol = true
 wol_ports = [9011]
 
 [reflectors.discovery]
-source_if = "wol_src"
-target_if = "wol_dst"
+source_if = "nf_source"
+target_if = "nf_target"
 mdns = true
 ssdp = true

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -19,6 +19,7 @@ import argparse
 import binascii
 import errno
 import http.server
+import signal
 import socket
 import struct
 import sys
@@ -52,6 +53,17 @@ def parse_payload_hex(value: str) -> bytes:
         return binascii.unhexlify(value)
     except (binascii.Error, ValueError) as exc:
         raise argparse.ArgumentTypeError(f"invalid hex payload: {value}") from exc
+
+
+class WindowClosed(Exception):
+    """SIGTERM: the harness closed an expect-none window once the sender had finished."""
+
+
+def _close_window(signum, frame):
+    del signum, frame
+    # PEP 475 retries an interrupted recvfrom unless the handler raises, so raising is what
+    # actually breaks the receive loop.
+    raise WindowClosed
 
 
 # How long a receiver keeps listening after its expected packet, to catch a second copy. A duplicate
@@ -141,6 +153,16 @@ def receive(args: argparse.Namespace) -> int:
     family = socket.AF_INET6 if args.family == 6 else socket.AF_INET
     bind_address = "::" if family == socket.AF_INET6 else "0.0.0.0"
 
+    try:
+        return _receive(args, expected, deadline, family, bind_address)
+    except WindowClosed:
+        # Only an expect-none receiver arms the handler, and reaching here means no packet arrived
+        # before the harness closed the window -- which it does only after the sender finished.
+        print("no packets before the harness closed the window", flush=True)
+        return 0
+
+
+def _receive(args, expected, deadline, family, bind_address) -> int:
     with socket.socket(family, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         bind_reporting_conflict(sock, bind_address, args.port)
@@ -149,6 +171,11 @@ def receive(args: argparse.Namespace) -> int:
             # interface; broadcast/all-nodes (the WoL IPv4 path) needs no join.
             join_group(sock, family, args.join_group, args.interface)
         print(f"receiver ready: UDP socket bound on port {args.port}", flush=True)
+
+        # An expect-none receiver outlives its own deadline: the harness stops it once the sender
+        # has finished, so the window provably spans the send instead of racing it.
+        if args.expect_none:
+            signal.signal(signal.SIGTERM, _close_window)
 
         while True:
             remaining = deadline - time.monotonic()

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -54,6 +54,12 @@ def parse_payload_hex(value: str) -> bytes:
         raise argparse.ArgumentTypeError(f"invalid hex payload: {value}") from exc
 
 
+# How long a receiver keeps listening after its expected packet, to catch a second copy. A duplicate
+# is near-simultaneous -- a doubled send, or an echo one reactor iteration later -- so this is jitter
+# margin, sized for the emulated lanes where that iteration costs tens of milliseconds.
+DUPLICATE_DRAIN_SECONDS = 0.5
+
+
 def packet_hex(payload: bytes) -> str:
     return binascii.hexlify(payload).decode("ascii")
 
@@ -169,7 +175,7 @@ def receive(args: argparse.Namespace) -> int:
                         flush=True,
                     )
                     return 1
-                return 0
+                return drain_for_duplicate(sock, expected)
 
             print(
                 f"received payload does not match the expected {packet_hex(expected)}",
@@ -184,6 +190,30 @@ def receive(args: argparse.Namespace) -> int:
 
     print(f"timed out waiting for expected packet after {args.timeout:.3f}s", file=sys.stderr, flush=True)
     return 1
+
+
+def drain_for_duplicate(sock: socket.socket, expected: bytes) -> int:
+    # One reflection per packet is the contract, and nothing else in the suite can see a second one:
+    # a doubled emission on the correct egress, or the daemon's own re-emission echoed back to it
+    # (the own-egress drop and the Verdict::Skip loop-breaker both prevent that). Every config keeps
+    # its entries non-overlapping, so a second identical datagram is always a fault.
+    deadline = time.monotonic() + DUPLICATE_DRAIN_SECONDS
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return 0
+        sock.settimeout(remaining)
+        try:
+            payload, peer = sock.recvfrom(4096)
+        except TimeoutError:
+            return 0
+        if payload == expected:
+            print(
+                f"received a second copy from {peer[0]}:{peer[1]}: the packet was reflected twice",
+                file=sys.stderr,
+                flush=True,
+            )
+            return 1
 
 
 def respond(args: argparse.Namespace) -> int:

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -224,7 +224,7 @@ def search(args: argparse.Namespace) -> int:
 
     with socket.socket(family, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((bind_address, args.source_port))  # the searcher's known source port
+        bind_reporting_conflict(sock, bind_address, args.source_port)  # the searcher's known source port
 
         scope_id = 0
         if family == socket.AF_INET6:
@@ -537,7 +537,7 @@ def _dial_discover(args):
             print(f"dial-client: no DIAL NOTIFY for {args.timeout:.3f}s", file=sys.stderr, flush=True)
             return None
         # Active discovery: send the M-SEARCH from a bound source port, await the proxied unicast 200 OK.
-        sock.bind((udp_bind, args.source_port))
+        bind_reporting_conflict(sock, udp_bind, args.source_port)
         if family == socket.AF_INET6:
             scope = socket.if_nametoindex(args.interface)
             sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_IF, scope)

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -6,11 +6,12 @@
 # magic packet (broadcast for IPv4, all-nodes multicast for IPv6) toward netflector. The receiver's
 # process exit code is the verdict run.py waits on: 0 = expectation held, non-zero = failed.
 #
-# The send/receive verbs cover WoL and the verbatim-relay protocols (mDNS, one-way SSDP). The
-# respond/search verbs drive the SSDP M-SEARCH round trip: a `respond` device unicasts a 200 OK back to
-# whoever searched, and a `search` searcher awaits that reply proxied across segments by netflector.
-# The DIAL probe verbs (dial-device/dial-client) from the C++ harness are absent because the DIAL cases
-# (see DIAL_CASES in run.py) drive a dedicated HTTP emulator rather than this prober.
+# The send/receive verbs cover WoL and the verbatim-relay protocols (mDNS, one-way SSDP and WSD). The
+# respond/search verbs drive the query/response round trips, SSDP M-SEARCH and WSD Probe/Resolve
+# alike: a `respond` device unicasts a reply back to whoever searched, and a `search` searcher awaits
+# that reply proxied across segments by netflector. The dial-device/dial-client verbs emulate a DIAL
+# device (HTTP description + REST servers behind an SSDP NOTIFY) and a client that follows the
+# rewritten LOCATION through netflector's proxy.
 
 from __future__ import annotations
 

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -171,7 +171,11 @@ def receive(args: argparse.Namespace) -> int:
                     return 1
                 return 0
 
-            print("received payload does not match expected magic packet", file=sys.stderr, flush=True)
+            print(
+                f"received payload does not match the expected {packet_hex(expected)}",
+                file=sys.stderr,
+                flush=True,
+            )
             return 1
 
     if args.expect_none:

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -3,7 +3,7 @@
 # End-to-end tests for netflector, runnable on two backends.
 #
 # Each case stands up two isolated dual-stack segments (a source and a target), runs netflector
-# straddling both with its interface names pinned to wol_src / wol_dst, then runs a sender prober on
+# straddling both with its interface names pinned to nf_source / nf_target, then runs a sender prober on
 # one segment and a receiver prober on the other and asserts the traffic is (or is not) reflected
 # across. The default docker backend realizes segments as bridge networks and participants as
 # containers (netflector image built from ./Dockerfile, CAP_NET_RAW on that container only; probers
@@ -241,11 +241,11 @@ VALGRIND_STOP_GRACE_SECONDS = 60
 # ~8s), so it only ever fires on a wedge; the emulated arm64 lanes are the slow case to clear.
 COMMAND_TIMEOUT_SECONDS = 120.0
 
-NETFLECTOR_SOURCE_IFNAME = "wol_src"
-NETFLECTOR_TARGET_IFNAME = "wol_dst"
+NETFLECTOR_SOURCE_IFNAME = "nf_source"
+NETFLECTOR_TARGET_IFNAME = "nf_target"
 RECEIVER_IFNAME = "probe0"
 NETFLECTOR_IFNAMES = {"source": NETFLECTOR_SOURCE_IFNAME, "target": NETFLECTOR_TARGET_IFNAME}
-DECOY_IFNAME = "rfxdecoy"
+DECOY_IFNAME = "nf_decoy"
 
 IPV6_ALL_NODES = "ff02::1"
 
@@ -866,7 +866,7 @@ class Phase:
     label: str
     protocol: str  # "wol" | "mdns" -> PROBE_SPECS
     family: int  # 4 | 6
-    interface: str  # "source" (wol_src) | "target" (wol_dst): which netflector interface to toggle
+    interface: str  # "source" (nf_source) | "target" (nf_target): which netflector interface to toggle
     # Recreate cases only: plant a throwaway interface between the delete and the recreate. It
     # occupies the freed slot, so FreeBSD's lowest-free index allocator is forced to hand the
     # recreated interface a DIFFERENT index; without it the same index comes back. The two
@@ -1520,7 +1520,7 @@ class NativeBackend(Backend):
 
 class NativeLinuxBackend(NativeBackend):
     # Segments as veth pairs between per-participant network namespaces: a dut namespace holds
-    # wol_src + wol_dst (so the checked-in configs work unchanged), and one persistent far
+    # nf_source + nf_target (so the checked-in configs work unchanged), and one persistent far
     # namespace per segment holds the peer end, always named probe0. Every participant gets its
     # own namespace for the same reasons Docker gave them one: wildcard binds and --expect-none
     # windows must only see the segment's traffic, unicast to netflector must cross the wire
@@ -1646,7 +1646,7 @@ class NativeLinuxBackend(NativeBackend):
 class NativeFreeBSDBackend(NativeBackend):
     # Segments as epair(4) pairs -- FreeBSD's veth -- between persistent vnet jails, one per
     # participant, mirroring the Linux namespaces: a dut jail holds the renamed a ends
-    # (wol_src/wol_dst), each probe jail owns a b end (renamed probe0). A vnet jail is
+    # (nf_source/nf_target), each probe jail owns a b end (renamed probe0). A vnet jail is
     # FreeBSD's network namespace: its own stack, with interfaces, routes, PF_ROUTE events,
     # and /dev/bpf attachment all per-vnet, and the host filesystem shared via path=/. Per-jail
     # stacks keep every probe packet on the wire (nothing short-circuits over lo0), and jailing

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -226,7 +226,8 @@ WSD_RESOLVEMATCHES_HEX = (
 # reflection of that family stops, then restore it and prove it resumes. netflector reacts on
 # its own event loop after the netlink notification, so each check polls across that async window.
 ADDR_CHANGE_REFLECTED_WINDOW = 4.0
-ADDR_CHANGE_SILENCE_WINDOW = 2.5
+# A silence probe is bounded by its send, not by a window, so only the count matters here: one
+# silence proves reflection was down across that send, two proves it stayed down.
 ADDR_CHANGE_SILENCE_CONSECUTIVE = 2
 ADDR_CHANGE_POLL_DEADLINE = 60.0
 # An expect-none receiver is stopped once the sender has finished, so its own deadline is only a
@@ -2552,13 +2553,13 @@ class AddressChangeRunner(CaseRunner):
         return False
 
     def _poll_not_reflected(self, phase: Phase) -> bool:
-        # Require consecutive silent windows: while reflection is still up the probe returns
-        # quickly (the reflected packet arrives, failing --expect-none), resetting the streak;
-        # only a genuine teardown yields an unbroken run of silences before the deadline.
+        # Poll until the daemon has reacted to the address change: while reflection is still up the
+        # probe sees the packet and fails --expect-none, resetting the streak. Each probe now spans
+        # its own send, so a silence is evidence rather than a window that may have missed it.
         deadline = time.monotonic() + ADDR_CHANGE_POLL_DEADLINE
         consecutive = 0
         while time.monotonic() < deadline:
-            if self._probe(phase, expect=False, timeout=ADDR_CHANGE_SILENCE_WINDOW):
+            if self._probe(phase, expect=False, timeout=EXPECT_NONE_BACKSTOP_SECONDS):
                 consecutive += 1
                 if consecutive >= ADDR_CHANGE_SILENCE_CONSECUTIVE:
                     return True
@@ -2673,12 +2674,12 @@ class RecreateRunner(AddressChangeRunner):
                 )
             print(f"{desc}: reflection stopped after interface deletion", flush=True)
         else:
-            # The segment's wire died with the interface, so there is nothing to probe on;
-            # the "is gone" log assertion stands in as the observed-death proof. The pause
-            # lets netflector see the departure and park before the name returns --
-            # otherwise it would (correctly) log only the recreation.
+            # The segment's wire died with the interface, so there is nothing to probe on. Wait
+            # for netflector to say it parked: the name must not return before it noticed the
+            # departure, or it would (correctly) log only the recreation.
             print(f"{desc}: segment wire gone; skipping the silence probe", flush=True)
-            time.sleep(2.0)
+            ifname = NETFLECTOR_IFNAMES[phase.interface]
+            self.wait_for_log("netflector", f"interface {ifname} is gone", f"{phase.interface} parking")
 
         self.backend.recreate_interface(phase.interface)
         if phase.decoy:

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -107,7 +107,7 @@ SSDP_OK_HEX = (
     "USN: uuid:device::ssdp:all\r\n"
     "LOCATION: http://device.invalid/desc.xml\r\n\r\n"
 ).encode().hex()
-SEARCHER_SOURCE_PORT = 49152
+SEARCHER_SOURCE_PORT = 9012  # below the ephemeral range, like the WoL ports above
 
 # DIAL discovery: a DIAL-targeted M-SEARCH (ST is the DIAL service type). The emulator answers it with a
 # 200 OK whose LOCATION points at its own target-side HTTP description endpoint.
@@ -119,7 +119,7 @@ SSDP_DIAL_MSEARCH_HEX = (
     "MX: 2\r\n"
     f"ST: {DIAL_SERVICE_TYPE}\r\n\r\n"
 ).encode().hex()
-DIAL_CLIENT_SOURCE_PORT = 49153
+DIAL_CLIENT_SOURCE_PORT = 9013
 # --- WSD (WS-Discovery): SOAP-over-UDP. Groups 239.255.255.250 / ff02::c (shared with SSDP) on UDP
 # 3702 -- the port distinguishes it from SSDP. netflector classifies on the <Action> URI segment and
 # relays the bytes verbatim, so the receiver expects exactly what was sent. Real ONVIF-style envelopes

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -1660,6 +1660,9 @@ class NativeFreeBSDBackend(NativeBackend):
         self.jails = {"dut": f"{base}_dut", "source": f"{base}_src", "target": f"{base}_dst"}
         # The host-side end of a live decoy epair (see add_decoy_interface), for teardown.
         self._decoy_host_end: str | None = None
+        # Every epair a end ever created, by its raw name, so teardown can reach a pair that a
+        # setup failure stranded before its rename.
+        self._epair_a_ends: list[str] = []
 
     @staticmethod
     def require_available() -> None:
@@ -1685,13 +1688,17 @@ class NativeFreeBSDBackend(NativeBackend):
         run_command(["jexec", jail, "sysctl", "net.inet6.ip6.dad_count=0"])
         run_command(["jexec", jail, "ifconfig", "lo0", "up"])
 
+    def _create_epair(self) -> tuple[str, str]:
+        a_end = run_command(["ifconfig", "epair", "create"]).stdout.strip()
+        if not a_end.endswith("a"):
+            raise RuntimeError(f"unexpected epair name: {a_end}")
+        self._epair_a_ends.append(a_end)
+        return a_end, f"{a_end[:-1]}b"
+
     def setup_segments(self) -> None:
         ends = {}
         for segment in SEGMENTS:
-            a_end = run_command(["ifconfig", "epair", "create"]).stdout.strip()
-            if not a_end.endswith("a"):
-                raise RuntimeError(f"unexpected epair name: {a_end}")
-            ends[segment] = (a_end, f"{a_end[:-1]}b")
+            ends[segment] = self._create_epair()
 
         dut = self.jails["dut"]
         self._make_jail(dut, *(a_end for a_end, _ in ends.values()))
@@ -1726,10 +1733,7 @@ class NativeFreeBSDBackend(NativeBackend):
         # A fresh epair, moved into the LIVE jails -- setup assigns interfaces at jail
         # creation (vnet.interface=...); this is the move-into-a-running-vnet path -- then
         # configured exactly as setup did.
-        a_end = run_command(["ifconfig", "epair", "create"]).stdout.strip()
-        if not a_end.endswith("a"):
-            raise RuntimeError(f"unexpected epair name: {a_end}")
-        b_end = f"{a_end[:-1]}b"
+        a_end, b_end = self._create_epair()
         run_command(["ifconfig", a_end, "vnet", self.jails["dut"]])
         run_command(["ifconfig", b_end, "vnet", self.jails[segment]])
         self._configure_segment(segment, a_end, b_end)
@@ -1738,12 +1742,10 @@ class NativeFreeBSDBackend(NativeBackend):
         # The move into the dut vnet is what occupies the freed index there: FreeBSD's
         # per-vnet allocator hands the mover the lowest free slot, exactly where the deleted
         # interface sat. The b end stays on the host (destroyed with the pair later).
-        a_end = run_command(["ifconfig", "epair", "create"]).stdout.strip()
-        if not a_end.endswith("a"):
-            raise RuntimeError(f"unexpected epair name: {a_end}")
+        a_end, b_end = self._create_epair()
         run_command(["ifconfig", a_end, "vnet", self.jails["dut"]])
         run_command(["jexec", self.jails["dut"], "ifconfig", a_end, "name", DECOY_IFNAME])
-        self._decoy_host_end = f"{a_end[:-1]}b"
+        self._decoy_host_end = b_end
 
     def remove_decoy_interface(self) -> None:
         # Destroying the dut-side end tears down the pair, the host b end included.
@@ -1753,12 +1755,16 @@ class NativeFreeBSDBackend(NativeBackend):
     def _teardown_fabric(self) -> None:
         # Destroy the a ends (from inside the dut jail) first: killing one end tears down the
         # whole pair, including the b end inside its probe jail -- so no jail removal can return
-        # a probe0 to a stack where the other jail's probe0 already sits. The host-side destroy
-        # covers a setup that failed before the interfaces moved into the dut jail.
+        # a probe0 to a stack where the other jail's probe0 already sits.
         for ifname in NETFLECTOR_IFNAMES.values():
             run_command(["jexec", self.jails["dut"], "ifconfig", ifname, "destroy"],
                         check=False, echo=False)
-            run_command(["ifconfig", ifname, "destroy"], check=False, echo=False)
+        # A setup failure before the renames strands pairs under their raw epair names, on the
+        # host or already inside the dut jail; try both, either end tears down the pair.
+        for a_end in self._epair_a_ends:
+            run_command(["jexec", self.jails["dut"], "ifconfig", a_end, "destroy"],
+                        check=False, echo=False)
+            run_command(["ifconfig", a_end, "destroy"], check=False, echo=False)
         if self._decoy_host_end is not None:  # a case failed mid-decoy; free the pair
             run_command(["ifconfig", self._decoy_host_end, "destroy"], check=False, echo=False)
         for jail in self.jails.values():

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -1981,6 +1981,17 @@ class CaseRunner:
             detach=False,
         )
 
+    def assert_receiver_outlived_sender(self) -> None:
+        # An expect-none verdict only means something if the receiver was still listening when the
+        # sender fired: a slow start can otherwise close the window first and turn "nothing arrived"
+        # into a fact about the harness rather than about reflection.
+        running, state = self.backend.status("receiver")
+        if not running:
+            raise RuntimeError(
+                f"receiver stopped before the sender finished ({state}); the expect-none result "
+                f"would be vacuous"
+            )
+
     def wait_for_result(self) -> None:
         exit_code = self.backend.wait("receiver")
         out, err = self.backend.logs("receiver")
@@ -2020,6 +2031,8 @@ class CaseRunner:
         self.start_netflector()
         self.start_receiver()
         self.run_sender()
+        if self.case.expect_payload_hex is None and self.case.expect_mac is None:
+            self.assert_receiver_outlived_sender()
         self.wait_for_result()
         print(f"PASS {self.case.name}", flush=True)
         if self.args.show_netflector_logs:
@@ -2499,6 +2512,8 @@ class AddressChangeRunner(CaseRunner):
         self._select_direction(case.direction)
         self.start_receiver(case)
         self.run_sender(case)
+        if not expect:
+            self.assert_receiver_outlived_sender()
         return self.backend.wait("receiver") == 0
 
     def _poll_reflected(self, phase: Phase) -> bool:

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -229,6 +229,14 @@ ADDR_CHANGE_REFLECTED_WINDOW = 4.0
 ADDR_CHANGE_SILENCE_WINDOW = 2.5
 ADDR_CHANGE_SILENCE_CONSECUTIVE = 2
 ADDR_CHANGE_POLL_DEADLINE = 60.0
+# An expect-none receiver is stopped once the sender has finished, so its own deadline is only a
+# backstop: it must outlast container startup on the slowest lane, never bound the assertion.
+EXPECT_NONE_BACKSTOP_SECONDS = 60.0
+# After the sender exits, how long the receiver keeps listening before the window is closed --
+# the packet's flight time through the daemon, not a guess at when the sender got around to it.
+EXPECT_NONE_FLIGHT_SECONDS = 1.5
+# SIGTERM grace for a probe the harness stops; it only has to unwind and print.
+PROBE_STOP_GRACE_SECONDS = 5
 # A substring of the line the daemon logs immediately before entering its event loop.
 NETFLECTOR_READY_LOG = "running; press Ctrl-C or send SIGTERM to stop"
 RECEIVER_READY_LOG = "receiver ready: UDP socket bound"
@@ -1281,6 +1289,9 @@ class DockerBackend(Backend):
         docker(["stop", "-t", str(grace_seconds), self.roles["netflector"]])
         return self.wait("netflector")
 
+    def stop_probe(self, role: str, grace_seconds: int) -> None:
+        docker(["stop", "-t", str(grace_seconds), self.roles[role]], check=False, echo=False)
+
     def admin(self, script: str, *, capture: bool = False) -> str:
         # Address/route changes need CAP_NET_ADMIN and a writable /proc/sys, which the netflector
         # container (scratch image, NET_RAW only) has by neither. Run a throwaway privileged
@@ -1501,6 +1512,17 @@ class NativeBackend(Backend):
                 proc.kill()
                 proc.wait()
         return proc.returncode
+
+    def stop_probe(self, role: str, grace_seconds: int) -> None:
+        proc = self.procs.get(role)
+        if proc is None or proc.poll() is not None:
+            return
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=grace_seconds)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
     def netflector_ip(self, segment: str) -> str:
         return f"{SEGMENT_V4_SUBNET[segment]}.{NATIVE_NETFLECTOR_HOST}"
@@ -1928,12 +1950,15 @@ class CaseRunner:
     def start_receiver(self, case: TestCase | None = None) -> None:
         case = case or self.case
         ifname = self.backend.helper_ifname(self.receiver_ifname)
+        expect_none = case.expect_payload_hex is None and case.expect_mac is None
         probe_args = [
             "receive",
             "--port",
             str(case.receive_port),
             "--timeout",
-            str(case.timeout_seconds),
+            # A positive receiver exits on its packet, so its window is the failure deadline. A
+            # negative one is closed by the harness at the send instead (see close_expect_none_window).
+            str(EXPECT_NONE_BACKSTOP_SECONDS if expect_none else case.timeout_seconds),
         ]
         if case.expect_payload_hex is not None:
             probe_args.extend(["--expect-payload-hex", case.expect_payload_hex])
@@ -1981,16 +2006,19 @@ class CaseRunner:
             detach=False,
         )
 
-    def assert_receiver_outlived_sender(self) -> None:
-        # An expect-none verdict only means something if the receiver was still listening when the
-        # sender fired: a slow start can otherwise close the window first and turn "nothing arrived"
-        # into a fact about the harness rather than about reflection.
+    def close_expect_none_window(self) -> None:
+        # The sender has exited, so the packet -- if the daemon were going to relay one -- is either
+        # already delivered or in flight. Give it that flight time, then stop the receiver and let it
+        # report. Bounding the window by the send rather than by a fixed timeout is what keeps the
+        # assertion from going vacuous when container startup outruns it, as it does under valgrind.
         running, state = self.backend.status("receiver")
         if not running:
             raise RuntimeError(
                 f"receiver stopped before the sender finished ({state}); the expect-none result "
                 f"would be vacuous"
             )
+        time.sleep(EXPECT_NONE_FLIGHT_SECONDS)
+        self.backend.stop_probe("receiver", PROBE_STOP_GRACE_SECONDS)
 
     def wait_for_result(self) -> None:
         exit_code = self.backend.wait("receiver")
@@ -2032,7 +2060,7 @@ class CaseRunner:
         self.start_receiver()
         self.run_sender()
         if self.case.expect_payload_hex is None and self.case.expect_mac is None:
-            self.assert_receiver_outlived_sender()
+            self.close_expect_none_window()
         self.wait_for_result()
         print(f"PASS {self.case.name}", flush=True)
         if self.args.show_netflector_logs:
@@ -2513,7 +2541,7 @@ class AddressChangeRunner(CaseRunner):
         self.start_receiver(case)
         self.run_sender(case)
         if not expect:
-            self.assert_receiver_outlived_sender()
+            self.close_expect_none_window()
         return self.backend.wait("receiver") == 0
 
     def _poll_reflected(self, phase: Phase) -> bool:

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -242,6 +242,8 @@ PROBE_STOP_GRACE_SECONDS = 5
 NETFLECTOR_READY_LOG = "running; press Ctrl-C or send SIGTERM to stop"
 RECEIVER_READY_LOG = "receiver ready: UDP socket bound"
 CONTAINER_READY_TIMEOUT_SECONDS = 15.0
+# Every resource a run creates is named with this prefix, so a sweep can find what a killed run left.
+E2E_RESOURCE_PREFIX = "netflector-e2e-"
 # A clean SIGTERM exit triggers valgrind's leak analysis; give `docker stop` this much grace before it
 # SIGKILLs, so the analysis (which can take tens of seconds) finishes and its exit code is read.
 VALGRIND_STOP_GRACE_SECONDS = 60
@@ -1044,6 +1046,13 @@ class Backend:
         self.args = args
         self.prefix = prefix
 
+    @staticmethod
+    def preflight_clean() -> None:
+        # Remove what a killed run left behind, before the first case. Only the docker backend needs
+        # it: a leaked netns, jail or epair is untidy but harmless, since every name carries a
+        # per-run uuid and the epair allocator just takes the next free index.
+        pass
+
     def setup_segments(self) -> None:
         raise NotImplementedError
 
@@ -1173,6 +1182,23 @@ class DockerBackend(Backend):
     @staticmethod
     def require_available() -> None:
         require_command("docker")
+
+    @staticmethod
+    def preflight_clean() -> None:
+        # A run killed mid-case -- a crashed engine, a cancelled CI job, a Ctrl-C -- leaves its
+        # containers and networks behind. The names carry a per-run uuid so they never collide, but
+        # the networks pin fixed subnets, so one survivor makes every later run fail at creation
+        # with "Pool overlaps with other one on this address space". Containers go first: a network
+        # with an endpoint still attached refuses to be removed.
+        for kind, listing in (("container", ["ps", "-aq"]), ("network", ["network", "ls", "-q"])):
+            found = docker(
+                [*listing, "--filter", f"name=^{E2E_RESOURCE_PREFIX}"], echo=False
+            ).stdout.split()
+            if not found:
+                continue
+            print(f"preflight: removing {len(found)} stale e2e {kind}(s)", flush=True)
+            remove = ["rm", "-f", *found] if kind == "container" else ["network", "rm", *found]
+            docker(remove, check=False, echo=False)
 
     def setup_segments(self) -> None:
         # Both networks are dual-stack: IPv4 cases are unaffected, and IPv6 cases need the
@@ -1870,7 +1896,7 @@ class CaseRunner:
     def __init__(self, args: argparse.Namespace, case: TestCase) -> None:
         self.args = args
         self.case = case
-        self.prefix = f"netflector-e2e-{case.name.replace('_', '-')}-{uuid.uuid4().hex[:8]}"
+        self.prefix = f"{E2E_RESOURCE_PREFIX}{case.name.replace('_', '-')}-{uuid.uuid4().hex[:8]}"
         self.backend = make_backend(args, self.prefix)
         self.config_path = E2E_DIR / case.config
 
@@ -2784,6 +2810,8 @@ def parse_args() -> argparse.Namespace:
         help="netflector binary to run (native backend, required); build it unprivileged first, "
              "e.g. cargo build --release --locked")
     parser.add_argument("--keep-on-failure", action="store_true", help="leave resources behind after a failure")
+    parser.add_argument("--keep-stale", action="store_true",
+        help="skip the preflight sweep, keeping what an earlier --keep-on-failure run left behind")
     parser.add_argument("--show-netflector-logs", action="store_true", help="print netflector logs after each passing case")
     parser.add_argument(
         "--case",
@@ -2808,13 +2836,14 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    if args.backend == "native":
-        native_backend_class().require_available()
-    else:
-        DockerBackend.require_available()
+    backend_cls = native_backend_class() if args.backend == "native" else DockerBackend
+    backend_cls.require_available()
+    if args.backend == "docker":
         # --valgrind selects the valgrind image unless one was passed explicitly.
         if args.valgrind and args.image == DEFAULT_NETFLECTOR_IMAGE:
             args.image = VALGRIND_NETFLECTOR_IMAGE
+    if not args.keep_stale:
+        backend_cls.preflight_clean()
 
     cases = select_cases(args.case)
     print(f"expected magic payload: {magic_packet_hex(CONFIGURED_MAC)}", flush=True)


### PR DESCRIPTION
All six e2e findings from the audit, plus three changes the review and CI surfaced: an interface rename, a rework of how negative cases bound their window, and a preflight sweep.

**Blind spots the audit named**

- **A duplicate re-emission was invisible.** Every probe verb returned on its first match, and the only probes on the originating segment bind a unicast port without joining the group — so nothing in the suite could observe a second copy. That left two regressions uncovered: a doubled emission on the correct egress, and the daemon's own re-emission echoed back onto the ingress if `PACKET_IGNORE_OUTGOING` / `BIOCSSEESENT` or the `Verdict::Skip` loop-breaker regressed. Receivers now drain briefly after the match and fail on a second identical datagram. This cannot fire falsely: the daemon's conflict check forbids two entries reflecting the same traffic across the same pair, and the one genuine double-reflection (the shared config's any-MAC `[reflectors.discovery]` against a DIAL entry) was already resolved by giving DIAL its own config.
- **expect-none verdicts were not anchored to the send.** The audit framed this as a risk; the Valgrind lane proved it was already happening. Measured there: the receiver's 1.5s window opened at ≈46.4 and closed at ≈47.9, while the sender container took 2.07s to start and sent at ≈48.0–48.4 — after the receiver had exited 0. Not Valgrind-specific either, just `docker run` plus Python startup in `python:3.13-alpine` exceeding 1.5s on a loaded runner, so **all 14 `ignores_*` cases had been asserting nothing.** Fixed structurally rather than by a wider guess: an expect-none receiver now runs to a backstop, and the harness stops it once the sender has finished and a relayed packet would have arrived, so the window provably spans the send. `probe.py` reports what it saw on SIGTERM — the handler must *raise*, since PEP 475 otherwise retries the interrupted `recvfrom`.

**Stale text and hygiene**

- **probe.py's header described a different harness.** It claimed the DIAL verbs were absent and served by a separate emulator; `dial_device`/`dial_client` are defined in that very file and `run.py` drives them. WSD, which reuses all four verbs, went unmentioned.
- **The payload-mismatch message said "magic packet" for every protocol**, sending triage toward the WoL reflector whichever protocol actually failed. It now names the expected payload and prints its hex.
- **Fixed source ports moved out of the ephemeral range.** The WoL ports moved to 9009-9011 after a real CI `EADDRINUSE`; the searcher's 49152 and the dial client's 49153 stayed inside every lane's window with the same exposure, bound via plain `bind()` so a recurrence would not even dump `/proc/net/udp*`. Now 9012/9013 through `bind_reporting_conflict()`.
- **The FreeBSD teardown leaked epairs.** Its host-side destroy used the renamed interface names, which never exist on the host — renames happen inside a jail, so the line was dead code from the pre-jail layout and its comment was false. A setup failure before the renames stranded the raw `epairNa/b` pairs, tracked nowhere. Every a end is now recorded at creation and destroyed by raw name, in the dut jail and on the host.

**From the review**

- **Interfaces renamed.** `wol_src`/`wol_dst` named the DUT-side pair after one of the six protocols run across them; they become `nf_source`/`nf_target`, matching the daemon's own `source_if`/`target_if`. The decoy loses `rfx`, the project's pre-rename name. Its own commit, mechanically verified to be a pure substitution.
- **Remaining guessed waits made deterministic.** A `time.sleep(2.0)` waiting for netflector to notice an interface departure becomes `wait_for_log` on the line it emits for exactly that. `ADDR_CHANGE_SILENCE_WINDOW` is deleted — it bounded the negative receiver, which the rework replaced. Every wait left in the suite is a failure backstop the happy path never reaches; the only two timed waits assert an *absence*, which has no event to wait for: how long a relayed packet stays in flight, and how long a duplicate could trail the first.
- **Preflight sweep.** The networks pin fixed subnets so the recreate cases can re-attach a static address, so one survivor of an interrupted run blocks every later run with `Pool overlaps with other one on this address space` — the whole suite, not a case. Docker's engine restarting mid-run triggered exactly this during development. The sweep removes anything under the e2e prefix before the first case, reporting what it takes; `--keep-stale` preserves an earlier `--keep-on-failure` run's evidence. Native backends need none of it: their names are uuid-scoped and nothing they leak is exclusive.

## Testing

Full Docker e2e green at each stage — 57/57 after the rename, after the drain and anchor, and again after the deterministic-window rework. `py_compile` on both scripts; all six configs parse as TOML.

The two structural changes were verified against their actual failure modes rather than by inspection. The SIGTERM window-close was exercised standalone (a receiver with a 30s deadline, stopped after 1s, exits 0 reporting it saw nothing). The preflight sweep was proven by planting the exact leftover that broke a real run — a network holding `192.0.2.0/24` plus an attached container: with `--keep-stale` it reproduces `Pool overlaps` and the run dies; without, the sweep reports what it removes and the case passes.

The FreeBSD teardown fix is exercised by the `freebsd-native-e2e` lanes rather than locally.