### PR TITLE
Correct twelve stale or wrong source comments

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -96,7 +96,8 @@ impl CaptureKey {
 /// A `Copy` handle to a routing registration: the generational arena [`Key`] of its slot, newtyped
 /// so it can't be confused with a reactor key or a [`CaptureKey`]. Returned by
 /// [`register`](PacketDispatcher::register); the SSDP search reflector will hold it to
-/// [`unregister`](PacketDispatcher::unregister) a per-searcher capture when its session ends.
+/// [`unregister`](PacketDispatcher::unregister) a per-searcher response registration when its
+/// session ends.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) struct RegistrationKey(Key);
 
@@ -338,7 +339,7 @@ impl PacketDispatcher {
 
     /// Register `handler`, gated by `filter`, for packets captured on `ingress`. The returned
     /// [`Key`] removes it again via [`unregister`](Self::unregister), for the per-searcher response
-    /// captures the SSDP search reflector creates dynamically; a static reflector ignores it.
+    /// registrations the SSDP search reflector creates dynamically; a static reflector ignores it.
     pub(crate) fn register(
         &mut self,
         ingress: CaptureKey,
@@ -353,7 +354,7 @@ impl PacketDispatcher {
     }
 
     /// Remove the registration `key` addresses, freeing its slot; a stale key is a safe no-op.
-    /// Tears down a per-searcher response capture when its session expires.
+    /// Tears down a per-searcher response registration when its session expires.
     pub(crate) fn unregister(&mut self, key: RegistrationKey) {
         self.registrations.remove(key.0);
     }
@@ -786,7 +787,7 @@ impl PacketDispatcher {
     /// backing `captures`, taking each handler out for its call so `&mut self` is free. Off the data
     /// path (only the interface-change / reconcile path, which allocates anyway), so it snapshots the
     /// live keys into a fresh `Vec` rather than a reused scratch. A handler that unregisters a sibling
-    /// mid-broadcast (a search reflector dropping its sessions' response captures) is fine: the vacated
+    /// mid-broadcast (a search reflector dropping its sessions' response registrations) is fine: the vacated
     /// slot is skipped.
     fn notify_iface_change(&mut self, captures: &[CaptureKey], reactor: &mut Reactor) {
         if captures.is_empty() {
@@ -804,7 +805,7 @@ impl PacketDispatcher {
                 .and_then(|reg| reg.handler.take())
             else {
                 // Expected, not an error: an earlier reflector in this broadcast cleared its sessions
-                // and unregistered their response captures, which are in this snapshot, so they resolve
+                // and unregistered their response registrations, which are in this snapshot, so they resolve
                 // to None here. Mirrors on_deadline's mid-sweep skip.
                 log::trace!(
                     "iface-change broadcast: handler for {key:?} gone mid-broadcast, skipped"

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -936,9 +936,11 @@ impl Handler for PacketDispatcher {
 
     /// The soonest deadline any registered handler keeps; the reactor waits within it.
     fn next_deadline(&self) -> Option<Instant> {
-        // O(registrations) every run-loop iteration. n stays small (a few base handlers plus the
-        // live SSDP sessions, ≤32), so the scan beats a min-heap, whose O(1) peek isn't worth the
-        // entry invalidation a cancelled or moved deadline would force. Revisit if timers grow.
+        // O(registrations) every run-loop iteration. n is bounded by MAX_SESSIONS per search
+        // reflector (SSDP and WSD each, per reflector pair) plus a few base handlers, so a
+        // fan-out config carries hundreds. The scan still beats a min-heap, whose O(1) peek isn't
+        // worth the entry invalidation a cancelled or moved deadline would force. Revisit if
+        // timers grow.
         self.registrations
             .iter()
             .filter_map(|(_, reg)| reg.handler.as_ref().and_then(|h| h.next_deadline()))

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -215,8 +215,10 @@ impl InterfaceTable {
     /// most one interface (they dedup by name, and the kernel gives each a distinct index), so this
     /// finds rather than scans. Returns the fields that changed if one matched, or `None` for a
     /// change on an interface we don't watch. Log-free, like [`take`](Self::take); the dispatcher
-    /// reports the outcome. The caller routes the `0` overflow-signal to [`refresh_all`], so
-    /// `ifindex` is always a real index here.
+    /// reports the outcome. `ifindex` is always a real index here: both monitor backends drop an
+    /// index-0 notification before forwarding it, and a buffer overflow arrives as its own
+    /// [`InterfaceEvent::Overflow`](crate::interface::InterfaceEvent), which the dispatcher routes
+    /// to [`refresh_all`]. A 0 reaching this would match the first parked entry, which caches 0.
     ///
     /// [`refresh_all`]: Self::refresh_all
     ///

--- a/src/interface/interface_monitor.rs
+++ b/src/interface/interface_monitor.rs
@@ -118,9 +118,9 @@ impl InterfaceMonitor {
                 overflows += 1;
                 if overflows == 1 {
                     // A dropped-notification overflow is abnormal (kernel buffer pressure or an
-                    // event storm): warn here, not just the dispatcher's debug. Signal
-                    // re-resolve-all once per burst; the dispatcher coalesces the 0, so repeating
-                    // it per ENOBUFS is redundant.
+                    // event storm): warn here, not just the dispatcher's debug. Emit Overflow once
+                    // per burst; the dispatcher re-resolves everything on it, so repeating it per
+                    // ENOBUFS is redundant.
                     log::warn!(
                         "interface monitor overflowed; notifications were dropped, re-resolving every interface"
                     );

--- a/src/interface/interface_monitor/route.rs
+++ b/src/interface/interface_monitor/route.rs
@@ -190,8 +190,8 @@ mod tests {
 
     #[test]
     fn never_forwards_index_zero() {
-        // 0 names no interface and is the parent's overflow sentinel, so a message carrying it
-        // must not be reported (which would trigger a spurious re-resolve of everything).
+        // Kernel indices start at 1, so a 0 is malformed. Forwarding it would match the first
+        // parked table entry, which caches 0, and re-resolve the wrong interface.
         let buf = message(libc::RTM_NEWADDR, 0, 20);
         let mut seen = Vec::new();
         for_each_change(&buf, &mut |e| seen.push(e));

--- a/src/interface/interface_monitor/route.rs
+++ b/src/interface/interface_monitor/route.rs
@@ -116,8 +116,11 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(InterfaceEv
     }
 }
 
-/// `PF_ROUTE` messages have no per-message sender identity; every one is the kernel's, so accept all.
-/// (Mirrors the netlink backend's `sender_ok`, which rejects locally-spoofed datagrams.)
+/// `PF_ROUTE` carries no per-message sender identity, and not every message is the kernel's: the
+/// stack echoes a local process's own request to every listener (hence `route monitor` showing other
+/// processes' traffic). Accept all anyway. An injected message only picks which interface to
+/// re-resolve, and the re-resolve reads the kernel, so it buys wasted work and nothing else.
+/// (The netlink backend's `sender_ok` rejects spoofed datagrams; `PF_ROUTE` offers nothing to check.)
 pub(super) fn sender_ok(_src: &libc::sockaddr_storage, _len: libc::socklen_t) -> bool {
     true
 }

--- a/src/interface/interface_monitor/rtnetlink.rs
+++ b/src/interface/interface_monitor/rtnetlink.rs
@@ -219,8 +219,8 @@ mod tests {
 
     #[test]
     fn never_forwards_index_zero() {
-        // 0 names no interface and is the parent's overflow sentinel, so a message carrying it
-        // must not be reported (which would trigger a spurious re-resolve of everything).
+        // Kernel indices start at 1, so a 0 is malformed. Forwarding it would match the first
+        // parked table entry, which caches 0, and re-resolve the wrong interface.
         let buf = message(libc::RTM_NEWADDR, &ifaddrmsg(0));
         let mut seen = Vec::new();
         for_each_change(&buf, &mut |e| seen.push(e));

--- a/src/net/http/framing.rs
+++ b/src/net/http/framing.rs
@@ -77,7 +77,8 @@ pub(crate) enum FramingError {
 /// One [`feed`](HttpFraming::feed) call's forwardable output: the rewritten `header` (a view into the
 /// framer's scratch, empty while a body streams across feeds), the `body` (a zero-copy slice of the fed
 /// input, possibly empty), and `consumed`, how many fed bytes to drop. `consumed == 0` means an
-/// incomplete header: read more and feed again. `application_url` is the device REST base the message's
+/// incomplete message: read more and feed again. It is the routine end of a multi-recv body, not a
+/// header-only condition. `application_url` is the device REST base the message's
 /// first `Application-URL` named, *before* the rewrite, reported on the feed that completes the header;
 /// the DIAL proxy dials it and re-learns it from a later description fetch. Only that header is
 /// reported: the others are rewritten per the policy, and nothing dials them.
@@ -117,7 +118,7 @@ impl HttpFraming {
     /// Feed a contiguous view of the owner's buffered bytes; returns the forwardable [`Framed`]. Each
     /// call yields at most one message's header plus as much of its body as arrived; the owner forwards
     /// `header` then `body`, drops `consumed` bytes, and feeds again until `consumed` is 0 (an
-    /// incomplete header, read more). `header` borrows the framer's scratch and `body` the input, so
+    /// incomplete message, read more). `header` borrows the framer's scratch and `body` the input, so
     /// the owner forwards both before advancing past `consumed`.
     ///
     /// Each authority header (`Host` on requests, `Application-URL` / `Location` on responses) is

--- a/src/net/stream_buffer.rs
+++ b/src/net/stream_buffer.rs
@@ -40,9 +40,10 @@ impl StreamBuffer {
     /// The unsent bytes, for one `send`.
     pub(crate) fn pending(&self) -> &[u8] {
         match &self.storage {
-            // SAFETY: bytes enter `[..filled]` only via `append` (which writes them) or `commit` (whose
-            // contract is that `free_tail_mut`'s region was written), so `[consumed..filled]` is
-            // initialized. `MaybeUninit<u8>` and `u8` share layout.
+            // SAFETY: bytes enter `[..filled]` only via `append` (which writes them) or `commit`
+            // (whose contract is that `free_tail_mut`'s region was written and that nothing moved
+            // `filled` in between), so `[consumed..filled]` is initialized. `MaybeUninit<u8>` and
+            // `u8` share layout.
             Some(storage) => unsafe {
                 let live = &storage[self.consumed..self.filled];
                 slice::from_raw_parts(live.as_ptr().cast::<u8>(), live.len())
@@ -108,8 +109,10 @@ impl StreamBuffer {
     ///
     /// # Safety
     /// The first `n` bytes of the most recent [`free_tail_mut`](Self::free_tail_mut) must have been
-    /// initialized (written) before this call. [`pending`](Self::pending) then reads `[consumed..filled]`
-    /// as initialized `u8`, so committing bytes that were never written is undefined behavior.
+    /// initialized (written), and no other `&mut self` method may have run in between: `commit` adds
+    /// `n` to whatever `filled` is now, and `append` or a compaction inside `free_tail_mut` moves it,
+    /// so an interleaved call marks bytes nobody wrote. [`pending`](Self::pending) then reads
+    /// `[consumed..filled]` as initialized `u8`, which is undefined behavior.
     pub(crate) unsafe fn commit(&mut self, n: usize) {
         debug_assert!(self.filled + n <= self.capacity, "commit past the capacity");
         self.filled += n;

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -508,9 +508,12 @@ impl Reactor {
         }
     }
 
-    /// Ask the run loop to stop once the current dispatch returns. Handlers call this (the self-pipe
-    /// handler does, on a shutdown signal). Calling it outside a run loop has no lasting effect:
-    /// [`run`](Self::run) clears the flag before entering the loop.
+    /// Ask the run loop to stop before its next iteration. The flag is only the `while` condition,
+    /// and a handler sets it mid-body, past this iteration's check, so the iteration underway
+    /// completes: the batch's remaining events, a pending dump broadcast, and a due deadline sweep
+    /// all still dispatch. Handlers call this (the self-pipe handler does, on a shutdown signal).
+    /// Calling it outside a run loop has no lasting effect: [`run`](Self::run) clears the flag
+    /// before entering the loop.
     pub(crate) fn request_shutdown(&mut self) {
         self.shutdown = true;
     }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -338,8 +338,11 @@ impl Reactor {
 
     /// Arm or disarm delivery of read readiness for the fd that `reg_key` addresses (armed at
     /// [`watch`](Self::watch)). Returns whether the registration was live. Disarming stops data and a
-    /// peer's half-close (FIN) from waking the handler; a full hangup/error still surfaces (as readable
-    /// on epoll, via the write filter or the deadline on kqueue), so a closed fd is never silently stuck.
+    /// peer's half-close (FIN) from waking the handler. epoll reports a hangup or error as readable
+    /// whatever the mask says, so it always surfaces there; kqueue does not, since `EV_DISABLE` on the
+    /// read filter suppresses `EV_EOF` and the write filter is deleted when write interest is off. A
+    /// handler that disarms read must therefore keep write interest armed or a `next_deadline` set, or
+    /// it will not hear about the fd again.
     ///
     /// # Errors
     /// Returns an error if updating the kernel's read interest fails.

--- a/src/reflector/dial/connection.rs
+++ b/src/reflector/dial/connection.rs
@@ -166,9 +166,11 @@ impl DirectionContext<'_> {
     /// destination stays open and writable, so the reverse direction keeps delivering. `Close` if the
     /// reactor rejects the disarm.
     fn half_close(&mut self, reactor: &mut Reactor) -> Outcome {
+        // Reached only while the flow is Open, and peer_gone marks a flow Done before taking that
+        // side's reg, so this side's is still set.
         let reg = self
             .from_reg
-            .expect("a persisted connection has its registration set");
+            .expect("an open flow's source keeps its registration");
         if reactor.set_read_interest(reg, false).is_err() {
             log::warn!("dial: disarming the half-closed source failed; closing");
             return Outcome::Close;
@@ -223,9 +225,10 @@ impl DirectionContext<'_> {
     /// rejects the change, which would otherwise strand the buffered send with no later re-arm.
     fn sync_write_interest(&self, reactor: &mut Reactor) -> Outcome {
         let armed = !self.flow.send.is_empty() || self.to.is_connecting();
+        // As in half_close: an Open flow means no peer_gone has taken this direction's regs.
         let reg = self
             .to_reg
-            .expect("a persisted connection has its registration set");
+            .expect("an open flow's destination keeps its registration");
         if reactor.set_write_interest(reg, armed).is_err() {
             log::warn!("dial: updating write interest failed; closing");
             return Outcome::Close;
@@ -236,8 +239,10 @@ impl DirectionContext<'_> {
 
 /// One proxied client↔device connection. Each socket is watched under its own reg; `device_endpoint`
 /// is where `device` connects and the `Host` rewrite target. `deadline` is the connect timeout while
-/// the device connect is in flight, then the idle timeout. The regs are `None` only between insert and
-/// watch in [`start_connection`](super::proxy::DialDeviceProxy), before [`attach_registrations`](Self::attach_registrations).
+/// the device connect is in flight, then the idle timeout. A reg is `None` before
+/// [`attach_registrations`](Self::attach_registrations) runs, and again once
+/// [`peer_gone`](Self::peer_gone) takes the hung-up side's: the connection outlives that, and
+/// [`forward`](Self::forward) reads the `None` as "a prior `peer_gone` took it".
 pub(super) struct Connection {
     client: TcpSocket,
     client_reg: Option<RegKey>,
@@ -331,8 +336,8 @@ impl Connection {
         self.on_writable(direction, reactor)
     }
 
-    /// Drop both watched fds' kernel interest, then shut both sockets down. A half-built connection may
-    /// have no registrations yet.
+    /// Drop both watched fds' kernel interest, then shut both sockets down. Either reg may be `None`:
+    /// a half-built connection has neither yet, and a `peer_gone` has taken the hung-up side's.
     pub(super) fn teardown(self, reactor: &mut Reactor) {
         if let Some(reg) = self.client_reg {
             reactor.unwatch(reg).ok();

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -1,6 +1,6 @@
 //! The mDNS reflector: reflects multicast DNS between the source and target interfaces so service
-//! discovery crosses the link. Per address family it registers two directional
-//! [`SimpleReflector`]s: queries flow source → target, responses target → source. Atop the
+//! discovery crosses the link. It registers two directional [`SimpleReflector`]s, each spanning
+//! every in-use family's group: queries flow source → target, responses target → source. Atop the
 //! capture's own-egress drop, this breaks the reflection loop. Each re-emits to the same group at
 //! TTL 255 (RFC 6762 §11), sourced from the egress interface. The dispatcher's filter pins the
 //! group, so the reflector only gates on the query/response classifier.
@@ -52,8 +52,8 @@ fn response_verdict(payload: &[u8]) -> Verdict {
 }
 
 /// Build the mDNS reflector for `reflector` and register its directional handlers on `dispatcher`.
-/// A no-op when mDNS isn't enabled. For each address family in use it joins the group on both
-/// interfaces (so each capture is admitted the group's frames) and registers two handlers: queries
+/// A no-op when mDNS isn't enabled. It joins each in-use family's group on both interfaces (so each
+/// capture is admitted the group's frames), then registers two handlers spanning them: queries
 /// source → target, responses target → source. A required family must be sendable on BOTH
 /// interfaces, since both re-emit.
 ///

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -3,7 +3,7 @@
 //! A search (SSDP `M-SEARCH`, WSD `Probe` / `Resolve`) is reflected source → target, and each
 //! searcher's *unicast* reply (SSDP `200 OK`, WSD `ProbeMatches` / `ResolveMatches`) is routed back
 //! through a per-searcher session: a reserved ephemeral port on the target with a dedicated response
-//! capture, so a reply reaches only the searcher that asked. [`SearchReflector`] owns the sessions and
+//! registration, so a reply reaches only the searcher that asked. [`SearchReflector`] owns the sessions and
 //! reflects searches; a per-session [`ResponseReflector`] routes each reply back.
 //!
 //! Protocol specifics enter as parameters: the [`Verdict`] classifier (is this payload a search?), the
@@ -32,7 +32,7 @@ const MAX_SESSIONS: usize = 64;
 /// searched: each group's replies arrive at a different scope-matched target address (link-local for
 /// `ff02::c`, routable for `ff05::c`), so one searcher's searches to two scopes need separate sessions.
 /// `expiry` is when the session lapses; `reservation` holds the ephemeral target reply port for the
-/// session's life (dropping it frees the port); `response_key` is the per-session response capture. A
+/// session's life (dropping it frees the port); `response_key` is the per-session response registration. A
 /// `RegistrationKey` is not a RAII guard, so eviction and rollback `unregister` it by hand.
 struct Session {
     searcher: SocketAddr,
@@ -127,7 +127,7 @@ pub(crate) struct SearchReflector {
     source: CaptureKey,
     /// The target capture: where the search is re-emitted and the replies are captured.
     target: CaptureKey,
-    /// The configured device allow-set, scoping the response capture as the announcement direction is.
+    /// The configured device allow-set, scoping the response registration as the announcement direction is.
     device_macs: Option<MacSet>,
     /// Protocol label for logs, e.g. `"SSDP"`.
     name: &'static str,
@@ -253,7 +253,7 @@ impl SearchReflector {
 }
 
 /// The target-side source address replies to `dest` come back to: the same scope-matched pick
-/// `build_udp` makes for the reflected search, so the reserved port and its response capture
+/// `build_udp` makes for the reflected search, so the reserved port and its response registration
 /// watch the address the device actually answers.
 fn reply_source(dispatcher: &PacketDispatcher, target: CaptureKey, dest: IpAddr) -> Option<IpAddr> {
     match dest {
@@ -359,7 +359,7 @@ impl PacketHandler for SearchReflector {
                 Outcome::Reflected(message_type)
             }
             Err(e) => {
-                // Roll back the response capture just registered; the reservation drops with `session`.
+                // Roll back the response registration just made; the reservation drops with `session`.
                 log::warn!(
                     "{}: cannot reflect search from {} to {}: {e}",
                     self.name,
@@ -458,7 +458,7 @@ mod tests {
     }
 
     /// Push a session for `searcher` onto `reflector`: a real loopback port reservation plus a
-    /// registered response capture, so eviction has a registration to tear down. (`PortReservation`
+    /// registered response registration, so eviction has something to tear down. (`PortReservation`
     /// binds a socket directly, so no capture / `CAP_NET_RAW` is needed.)
     fn push_session(
         reflector: &mut SearchReflector,
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore = "needs a real socket")]
-    fn on_deadline_evicts_expired_sessions_and_unregisters_their_captures() {
+    fn on_deadline_evicts_expired_sessions_and_unregisters_their_registrations() {
         let mut dispatcher = PacketDispatcher::new();
         let mut reactor = Reactor::new().unwrap();
         let mut reflector = test_reflector();
@@ -562,7 +562,7 @@ mod tests {
         assert_eq!(
             dispatcher.registration_count(),
             1,
-            "its response capture is unregistered with it"
+            "its response registration is removed with it"
         );
         assert_eq!(
             reflector.next_deadline(),
@@ -606,7 +606,7 @@ mod tests {
         assert_eq!(
             dispatcher.registration_count(),
             1,
-            "no second response capture is registered"
+            "no second response registration is made"
         );
         assert!(
             reflector.sessions[0].expiry > base,
@@ -705,7 +705,7 @@ mod tests {
         );
         assert_eq!(dispatcher.registration_count(), 2);
 
-        // The target capture, shared by every session: all cleared, their response captures gone.
+        // The target capture, shared by every session: all cleared, their response registrations gone.
         let target = reflector.target;
         reflector.on_iface_change(&[target], &mut dispatcher, &mut reactor);
         assert!(
@@ -715,7 +715,7 @@ mod tests {
         assert_eq!(
             dispatcher.registration_count(),
             0,
-            "each cleared session's response capture is unregistered"
+            "each cleared session's response registration is removed"
         );
     }
 
@@ -825,7 +825,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn a_failed_reflect_rolls_back_the_session_registration() {
-        // make_session registers the response capture before reflecting; if the reflect then fails, that
+        // make_session makes the response registration before reflecting; if the reflect then fails, that
         // registration must be rolled back, not leaked. A real loopback target lets make_session succeed;
         // an oversized payload then makes build_udp reject the reflect deterministically.
         let Some(target_cap) = open_loopback_or_skip() else {
@@ -866,7 +866,7 @@ mod tests {
         assert_eq!(
             dispatcher.registration_count(),
             before,
-            "make_session's response capture was rolled back"
+            "make_session's response registration was rolled back"
         );
     }
 }

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -135,9 +135,10 @@ fn search_window(payload: &[u8]) -> Duration {
 }
 
 /// Build the SSDP reflector for `reflector` and register both directions on `dispatcher`. A no-op
-/// when SSDP isn't enabled. For each address family in use it joins every group on BOTH interfaces and
-/// registers two handlers per group: advertisements target → source (a [`SimpleReflector`]),
-/// and searches source → target with their unicast 200-OK replies (the shared [`SearchReflector`]). A
+/// when SSDP isn't enabled. It joins every in-use family's group on BOTH interfaces, then registers
+/// two handlers spanning them: advertisements target → source (a [`SimpleReflector`]), and searches
+/// source → target with their unicast 200-OK replies (the shared [`SearchReflector`]). One
+/// [`SearchReflector`] for every group means its sessions share one table and one cap. A
 /// required family must be sendable on BOTH interfaces, since the reflector re-emits on both.
 ///
 /// # Errors

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -56,8 +56,8 @@ fn window(_: &[u8]) -> Duration {
 }
 
 /// Build the WSD reflector for `reflector` and register both directions on `dispatcher`. A no-op when
-/// WSD isn't enabled. For each address family in use it joins the group on BOTH interfaces and
-/// registers two handlers: `Hello` / `Bye` announcements target → source (a [`SimpleReflector`]), and
+/// WSD isn't enabled. It joins each in-use family's group on BOTH interfaces, then registers two
+/// handlers spanning them: `Hello` / `Bye` announcements target → source (a [`SimpleReflector`]), and
 /// `Probe` / `Resolve` searches source → target with their unicast replies (the shared
 /// [`SearchReflector`]). A required family must be sendable on BOTH interfaces, since both re-emit.
 ///


### PR DESCRIPTION
The audit's stale-text pile: comments and docs that contradict the code they sit on. No behavior changes; two test renames are the only non-comment edits. One commit per finding.

Three of the twelve were understated as filed, so the fixes are wider than the report — noted per item below.

**Contracts that were wrong, not just imprecise**

- **`consumed == 0` is an incomplete *message*, not a header.** Only the header branch advances `pos`, so every body-phase break leaves it at zero — and that is the normal way the caller's feed loop ends for a body spanning several recvs, not an edge case. The caller's own comment already said the right thing.
- **`commit`'s `# Safety` contract was insufficient for `pending()`'s soundness.** It bound `n` to the last `free_tail_mut` region, but `commit` adds `n` to whatever `filled` is *now*, and both `append` and the compaction inside `free_tail_mut` move it. A caller could satisfy the contract verbatim and still make `pending()` read uninitialized bytes. The one production caller does neither, so this is the text, not the code. The audit's alternative (a snapshot plus `debug_assert`) was declined: a field and a check on the data path to guard a two-line sequence with one caller.
- **A `Connection`'s registrations are `None` in two windows, not one.** The struct doc allowed only the pre-attach window; `peer_gone` takes the hung-up side's reg and the connection lives on, which `forward`'s guard depends on reading. The two `expect` strings asserted the same false invariant, and now state the guarantee that actually holds, in the idiom `peer_gone` already uses ten lines away. Not a latent panic: both sites are gated by the flow state.
- **`set_read_interest` promised a closed fd is never silently stuck.** True on epoll regardless of the mask; on kqueue `EV_DISABLE` suppresses `EV_EOF` and the write filter is deleted with write interest off, so it holds only while the handler keeps a write filter or a deadline. Both current callers do; the sentence would have betrayed the next one.
- **`request_shutdown` stops the loop before its next iteration**, not "once the current dispatch returns": the flag is only the `while` condition, so the batch's remaining events, a pending dump broadcast, and a due deadline sweep still reach handlers. The dump ordering is deliberate and tested.

**Numbers and mechanisms that had rotted**

- **The deadline scan's bound is per reflector, not 32.** The scan-vs-min-heap tradeoff was argued from "sessions ≤ 32"; the cap is 64 and applies per protocol per reflector pair, so a fan-out config carries hundreds. The tradeoff still holds at that size.
- **What keeps index 0 out of `refresh_by_ifindex`.** The precondition cited a "0 overflow-signal" the caller routes to `refresh_all`; overflow has had its own event variant for some time and no such routing exists. Both monitor backends drop index 0 before forwarding, which is the guarantee that holds — and a 0 arriving there would match the first parked entry, which caches 0.
- **The index-0 sentinel references are gone.** Two test comments still called 0 "the parent's overflow sentinel", contradicting the production path they exercise, which already gives the right reason. *The audit missed a third site*, the ENOBUFS arm that now emits `Overflow`; found by grepping the sentinel language rather than the listed lines.
- **`PF_ROUTE` messages are not all the kernel's.** `sender_ok` accepted everything on that basis. Verified in FreeBSD's `sys/net/rtsock.c`: `send_rtm_reply` hands the message to `rt_dispatch`, which delivers to every route-socket listener including on the error path, which is why `route monitor` shows other processes' traffic. Accepting all is still right and unchanged — an injected message only picks which interface to re-resolve, and the re-resolve reads the kernel — but the justification was false.

**Handler counts**

- **mDNS registers two handlers total**, not two per address family; both its module doc and its `build` doc attached the count to the per-family quantifier, so a dual-stack config read as four. The per-family loop covers the joins; the registers sit outside it.
- **SSDP registers two spanning the groups**, not "two per group" — six under the default policy. That count is load-bearing: one `SearchReflector` across all groups is why their sessions share a table and a `MAX_SESSIONS` cap. *The audit cited `wsd.rs` as the correct example*; it has the same per-family quantifier, so all three reflector build docs are fixed rather than two.

**Naming**

- **The per-searcher session state is a registration, not a "response capture".** Nothing is captured; it is a routing registration in the dispatcher's arena, which is what the surrounding `Registration`/`RegistrationKey`/`unregister` vocabulary already says. "Capture" pointed a reader at the capture layer. *The audit counted five sites in `dispatch.rs`*; it was 19 across two files, including three that only a cross-line search finds and one test name.

## Testing

`cargo test --lib` on macOS (472) and Linux (469 — `rtnetlink.rs` and the AF_PACKET paths only build there), clippy `--all-targets -D warnings` on both plus `x86_64-unknown-freebsd` (`route.rs` is BSD-only), fmt, and `cargo doc --no-deps --document-private-items` on both, which is what enforces the intra-doc links these comments carry.

No e2e: the branch touches only comments, docs, and two test names.