### PR TITLE
Correct six user-facing doc claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ config ok: 1 reflector
 
 netflector opens one L2 packet-capture socket per interface: it both observes incoming packets and
 re-injects reflected ones through that same socket (the sender doesn't bind a port, so no port
-privileges are involved). mDNS and SSDP additionally join their multicast group(s) on it, which needs
-no privilege beyond opening the socket. That capture socket drives the requirements below.
+privileges are involved). mDNS, SSDP, and WSD additionally join their multicast group(s) on it, which
+needs no privilege beyond opening the socket. That capture socket drives the requirements below.
 
 #### Linux
 
@@ -365,8 +365,9 @@ requires both; `"ipv4"` / `"ipv6"` use only one. It applies to every protocol th
 **required** family that can't be initialized for an entry fails startup; a best-effort one that can't
 (IPv6 under `"default"`) is skipped and the entry keeps running on the family it has.
 
-mDNS and SSDP are bidirectional, so a handled family must have a source address on **both** interfaces
-(the target re-emits relayed queries/searches, the source re-emits relayed responses/advertisements).
+mDNS, SSDP, and WSD are bidirectional, so a handled family must have a source address on **both**
+interfaces (the target re-emits relayed queries/searches, the source re-emits relayed
+responses/advertisements).
 This condition is re-checked continuously at runtime (see
 [Reacting to address changes](#reacting-to-address-changes) below): a family is torn down if either
 interface loses its address and brought back up once both can send it again.
@@ -374,8 +375,9 @@ interface loses its address and brought back up once both can send it again.
 ### Reacting to address changes
 
 netflector watches the kernel for interface address and lifecycle changes (a `NETLINK_ROUTE`
-socket on Linux, a `PF_ROUTE` socket on the BSDs) and adapts at runtime, without a restart. mDNS and SSDP bring a family
-up (joining its multicast group(s) and installing its capture registrations) once that family becomes
+socket on Linux, a `PF_ROUTE` socket on the BSDs) and adapts at runtime, without a restart. mDNS,
+SSDP, and WSD bring a family up (joining its multicast group(s) and installing its capture
+registrations) once that family becomes
 reflectable (a source address for it is present on **both** interfaces), and tear it down when either
 interface loses the address; the family resumes automatically when the address returns. WoL keeps its
 captures installed and instead checks reachability per packet, so it has nothing to join or leave.

--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_
 ```toml
 log_level = "info"                 # optional; one of off | error | warn | info | debug | trace (default: info)
                                    # release builds compile trace out, where it behaves as debug
-debug_memory_interval_secs = 0     # optional; seconds between memory (RSS/peak) diagnostic reports; 0 disables (default 0)
+debug_memory_interval_secs = 0     # optional; seconds between memory diagnostic reports; 0 disables (default 0)
+                                   # reports peak RSS everywhere, current RSS on Linux only
 counters_interval_secs = 0         # optional; seconds between per-interface packet-counter summaries; 0 disables (default 0)
 
 [reflectors.tv]

--- a/README.md
+++ b/README.md
@@ -436,13 +436,14 @@ some Samsung TVs do it). Either way a client on a different segment discovers th
 drive it. Setting `dial = true` on an SSDP entry makes netflector bridge that gap.
 
 It is a **terminating HTTP reverse proxy**. When a DIAL `LOCATION` (in a relayed `NOTIFY` or `M-SEARCH`
-`200 OK`) crosses target→source, netflector mints a per-device ephemeral TCP listener on
-`source_if`'s address and rewrites the `LOCATION` authority to point at that listener. A source-side
-client then connects to netflector, which opens an upstream connection to the device **bound to
-`target_if`'s address**, so the device sees an on-subnet client and serves it. Along the way it
-rewrites the four authority-bearing headers (`LOCATION`, the description's `Application-URL`, request
-`Host`, and response `Location`) from the device's authority to a netflector authority and back; HTTP
-bodies stream through untouched. App launch (`POST`) and stop (`DELETE`) work end to end.
+`200 OK`) crosses target→source, netflector mints a pair of per-device ephemeral TCP listeners on
+`source_if`'s address, one for the device's description and one for its REST endpoints, and rewrites
+the `LOCATION` authority to point at the description listener. A source-side client then connects to
+netflector, which opens an upstream connection to the device **bound to `target_if`'s address**, so the
+device sees an on-subnet client and serves it. Along the way it rewrites the four authority-bearing
+headers (`LOCATION`, the description's `Application-URL`, request `Host`, and response `Location`) from
+the device's authority to a netflector authority and back; HTTP bodies stream through untouched.
+App launch (`POST`) and stop (`DELETE`) work end to end.
 
 `dial = true` requires `ssdp` and is **IPv4-only** (the DIAL spec ties the device authority to an IPv4
 address); an `ipv6`-only entry with `dial = true` is rejected at startup. It is the only DIAL knob;

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Docker backend for both image arches (plus a Valgrind memcheck job) and natively
 
 ## Build
 
-Prerequisites: a Rust toolchain. `rust-toolchain.toml` pins **stable** with the `rustfmt` and `clippy`
-components, so with [`rustup`](https://rustup.rs) the right toolchain (and any missing component) is
-installed on the first `cargo` invocation. The crate is edition 2024 (Rust ≥ 1.85), with a 1.93 MSRV.
+Prerequisites: a Rust toolchain. `rust-toolchain.toml` pins a specific stable release (bumped via
+Renovate) with the `rustfmt` and `clippy` components, so with [`rustup`](https://rustup.rs) the right
+toolchain (and any missing component) is installed on the first `cargo` invocation. The crate is
+edition 2024 (Rust ≥ 1.85), with a 1.93 MSRV.
 
 ```sh
 cargo build            # debug binary at target/debug/netflector

--- a/dist/freebsd/net/netflector/pkg-descr
+++ b/dist/freebsd/net/netflector/pkg-descr
@@ -1,9 +1,10 @@
 Reflects link-local service discovery traffic between two network interfaces, so
-devices on separate VLANs can find each other: Wake-on-LAN, mDNS (Bonjour,
-AirPlay), SSDP (UPnP), WS-Discovery (ONVIF cameras, Windows printers), and an
-optional DIAL proxy for casting.
+clients on one VLAN can discover and reach devices on another: Wake-on-LAN, mDNS
+(Bonjour, AirPlay), SSDP (UPnP), WS-Discovery (ONVIF cameras, Windows printers),
+and an optional DIAL proxy for casting.
 
 The traffic discovery depends on is link-local by design and does not cross a
 router, which is why a phone on the LAN cannot see a TV on the IoT VLAN.
 netflector re-emits it on the other interface with the addressing rewritten, so
-both sides discover each other without being bridged.
+clients on the source side discover the target side's devices without the VLANs
+being bridged.

--- a/dist/opnsense/net/netflector/pkg-descr
+++ b/dist/opnsense/net/netflector/pkg-descr
@@ -1,11 +1,12 @@
-Reflects link-local service discovery traffic between two interfaces, so devices
-on separate VLANs can find each other: Wake-on-LAN, mDNS (Bonjour, AirPlay),
-SSDP (UPnP), WS-Discovery (ONVIF cameras, Windows printers), and an optional
-DIAL proxy for casting.
+Reflects link-local service discovery traffic between two interfaces, so clients
+on one VLAN can discover and reach devices on another: Wake-on-LAN, mDNS
+(Bonjour, AirPlay), SSDP (UPnP), WS-Discovery (ONVIF cameras, Windows printers),
+and an optional DIAL proxy for casting.
 
 Traffic that discovery depends on is link-local by design and does not cross a
 router, which is why a phone on the LAN cannot see a TV on the IoT VLAN.
 Netflector re-emits it on the other interface with the addressing rewritten, so
-the two sides discover each other without being bridged.
+clients on the source side discover the target side's devices without the VLANs
+being bridged.
 
 WWW: https://github.com/netflector/netflector

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -91,7 +91,7 @@ Shut down gracefully.
 .It Dv SIGUSR1
 Dump diagnostics to the log: the per-interface packet counters
 .Pq see Sx DIAGNOSTICS
-and a memory report (current and peak RSS).
+and a memory report (peak RSS).
 This works on demand even when the periodic reports are disabled.
 .El
 .Sh ENVIRONMENT

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -60,7 +60,8 @@ Print a usage summary and exit.
 .Fl -help
 and
 .Fl -version
-are answered before anything else on the command line.
+take precedence over anything after them on the command line; an invalid
+argument before them is reported first.
 A lone
 .Ql -
 is read as a path, not an option.

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -37,7 +37,7 @@ Default
 is compiled out of this build and behaves as
 .Cm debug .
 .It Ic debug_memory_interval_secs
-Seconds between memory (RSS and peak) diagnostic reports.
+Seconds between memory (peak RSS) diagnostic reports.
 .Cm 0
 or absent disables them.
 Default

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -120,7 +120,7 @@ pub(crate) enum BuildError {
     UnknownInterface(String),
     /// An interface can't currently send a family the reflector requires, so it would reflect
     /// nothing for that family. A startup failure rather than a silent half-run. For a
-    /// bidirectional reflector (mDNS/SSDP) the named interface may be the source or the target.
+    /// bidirectional reflector (mDNS/SSDP/WSD) the named interface may be the source or the target.
     #[error("interface \"{interface}\" cannot send {family}, required by the reflector")]
     RequiredFamilyUnavailable { interface: String, family: IpFamily },
 }
@@ -150,7 +150,7 @@ fn missing_required_family(family: AddressFamily, addrs: &InterfaceAddresses) ->
 }
 
 /// Enforce that a bidirectional reflector can source every required family on BOTH interfaces.
-/// mDNS and SSDP re-emit on the source *and* the target, so a family required by `address_family`
+/// mDNS, SSDP and WSD re-emit on the source *and* the target, so a family required by `address_family`
 /// must be sendable on each. Checks each required family on both interfaces (v4 before v6, the
 /// single-interface policy order) and blames the side that actually lacks it: the source when it's
 /// the one missing, otherwise the target.


### PR DESCRIPTION
The last of the audit: user-facing text that told an operator something the code does not do. README, both `pkg-descr` files, both man pages, and two `reflector.rs` docs. One commit per finding, no behavior changes.

- **DIAL mints two listeners per device, not one.** The README described "a per-device ephemeral TCP listener"; `mint_proxy` binds a description listener *and* a REST listener on `source_if`'s address, both before the device is contacted. Someone sizing ephemeral ports or writing firewall rules for that interface was told half the real count, and with the 64-proxy cap that is 128 bound ports rather than 64.
- **The toolchain pins a release, not the stable channel.** `rust-toolchain.toml` pins one version and its own comment opens with `Pinned (not "stable")`; the Build section claimed the opposite, which would lead a reader to expect the newest stable compiler. The version number stays out of the README so it cannot rot on the next Renovate bump.
- **WSD named alongside mDNS and SSDP where it behaves the same.** Five passages listed only the other two for behavior WSD shares exactly: it is bidirectional, joins the same groups on the same capture socket, and calls `require_bidirectional_families` itself. *The audit listed three README passages*; its verifier added the two `reflector.rs` docs, one of which documents that very function.
- **Discovery is directional, not mutual.** Both package descriptions promised "both sides discover each other". An entry relays searches source to target and responses back, so only source-side clients discover target-side devices, which is what the man pages already state plainly. Someone reading `pkg search` or the OPNsense plugin list was told the opposite of what one configured entry does; mutual discovery needs a mirrored second entry.
- **`--help` precedes what follows it, not an earlier error.** `netflector.8` said the flags are answered before anything else; the parser scans left to right and reports the first bad token, so `netflector --nonsense --help` exits 1 with `UnknownOption`. The `cli.rs` half of this finding was corrected in #123. The audit's alternative, pre-scanning for the flags to make the sentence true, was rejected in the value pass: that changes shipped CLI behavior to cure a doc bug.
- **Current RSS is in the memory report on Linux only.** `log_report` logs peak RSS everywhere and current RSS from `/proc/self/status`; `netflector.8`, `netflector.toml.5` and the README all promised both. The man pages now say peak alone, since the port installs them only on FreeBSD, so the Linux caveat would document something their reader cannot observe. The README keeps it, as it serves Docker and Linux users too.

## Testing

`cargo test --lib` (472), clippy `--all-targets -D warnings`, fmt, and `cargo doc --no-deps --document-private-items` for the two `reflector.rs` doc edits. Both mandoc lint layers exactly as CI runs them: `-T lint -W warning` exit 0, and the STYLE layer minus the sibling-`Xr` filter clean.

The branch touches `man/`, `dist/freebsd/**` and `dist/opnsense/**`, so all three pipelines run, and `ci-port` lints the pages as installed against a full manpath inside the FreeBSD VM.

`pkg-descr` is packaged port content, so the usual bump rule applies: **deliberately no `PORTREVISION` bump**. The corrected description ships with the v0.14.0 re-pin rather than triggering a republish of `0.13.2_1` days before a release supersedes it. The merge fires `publish-daemon`, whose existence check finds 0.13.2 already published and skips, which is the intended no-op.

With this, all 69 findings from the 2026-07-27 audit are resolved.