### PR TITLE
opnsense, freebsd: gate the reflector on a CARP vhid

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ sysrc netflector_enable=YES
 service netflector start
 ```
 
+On a CARP failover pair, `netflector_carp_vhid` confines the service to the MASTER node so the
+backup does not reflect a second copy of everything; netflector(8) has the details.
+
 On OPNsense, install the plugin instead. It pulls in the daemon and owns the configuration and the
 service from its GUI page under Services > Netflector:
 

--- a/dist/freebsd/net/netflector/files/netflector.in
+++ b/dist/freebsd/net/netflector/files/netflector.in
@@ -12,6 +12,8 @@
 #
 #   netflector_config="/path/to/netflector.toml"   # default %%PREFIX%%/etc/netflector.toml
 #   netflector_flags="-r"                          # options for daemon(8), e.g. restart on exit
+#   netflector_carp_vhid="1"                       # only start if this CARP vhid is MASTER
+#   netflector_carp_interface="em0"                # interface holding it; needed if the vhid is reused
 
 . /etc/rc.subr
 
@@ -23,6 +25,8 @@ load_rc_config $name
 
 : ${netflector_enable:="NO"}
 : ${netflector_config:="%%PREFIX%%/etc/netflector.toml"}
+: ${netflector_carp_vhid:=""}
+: ${netflector_carp_interface:=""}
 
 pidfile="/var/run/${name}.pid"
 procname="%%PREFIX%%/bin/${name}"
@@ -51,6 +55,24 @@ netflector_precmd()
         done
         err 1 "refusing to start: ${netflector_config} is not valid"
     fi
+
+    # Checked after the config, not before: on a backup node a bad configuration should still be
+    # reported now, rather than at failover.
+    if [ -n "${netflector_carp_vhid}" ] &&
+        ! carp_is_master "${netflector_carp_vhid}" "${netflector_carp_interface}"; then
+        warn "CARP vhid ${netflector_carp_vhid} is not MASTER here; not starting netflector"
+        return 1
+    fi
+}
+
+# A carp line reads "carp: MASTER vhid 1 advbase 1 advskew 0". Neither field identifies a group on its
+# own: one interface can carry several vhids, and the same vhid can run on several interfaces as
+# unrelated groups. $2 narrows ifconfig to the one that matters, and can be empty for a unique vhid.
+carp_is_master()
+{
+    ifconfig ${2:+"$2"} 2>/dev/null |
+        awk -v vhid="$1" '$1 == "carp:" && $4 == vhid { print $2 }' |
+        grep -q '^MASTER$'
 }
 
 run_rc_command "$1"

--- a/dist/opnsense/net/netflector/src/etc/rc.syshook.d/carp/20-netflector
+++ b/dist/opnsense/net/netflector/src/etc/rc.syshook.d/carp/20-netflector
@@ -1,0 +1,78 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Sergii Bogomolov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Both nodes of a pair reflecting would put two copies of every relayed packet on the segment, and two
+ * DIAL proxies would rewrite the same device's LOCATION to different authorities.
+ *
+ * devd passes the transitioning group as "<vhid>@<interface>" (see /usr/local/etc/devd/carp.conf). A
+ * node can hold one group and not another, so the vhid is matched too, not the state alone.
+ */
+
+require_once('script/load_phalcon.php');
+
+use OPNsense\Netflector\Netflector;
+use OPNsense\Interfaces\Vip;
+
+$subsystem = $argv[1] ?? '';
+$type = $argv[2] ?? '';
+
+/* INIT is a transient on the way to MASTER or BACKUP; acting on it would start and stop needlessly. */
+if (!in_array($type, ['MASTER', 'BACKUP'], true) || strpos($subsystem, '@') === false) {
+    exit(0);
+}
+
+$model = new Netflector();
+$depends_on = (string)$model->general->carp_depend_on;
+if ((string)$model->general->enabled !== '1' || $depends_on === '') {
+    exit(0);
+}
+
+/* Deferred until something is actually configured: every vhid on the box lands here on every
+ * transition, and these are the expensive includes. get_real_interface() needs them. */
+require_once('config.inc');
+require_once('util.inc');
+require_once('interfaces.inc');
+
+/* carp_depend_on holds the VIP's uuid; the event carries "<vhid>@<interface>", so resolve one to the
+ * other. Both halves are compared: the same vhid can run on several interfaces as unrelated groups. */
+$group = null;
+foreach ((new Vip())->vip->iterateItems() as $uuid => $vip) {
+    if ($uuid === $depends_on && (string)$vip->mode === 'carp') {
+        $group = sprintf('%s@%s', (string)$vip->vhid, get_real_interface((string)$vip->interface));
+        break;
+    }
+}
+if ($group === null || $group !== $subsystem) {
+    exit(0);
+}
+
+$action = $type === 'MASTER' ? 'start' : 'stop';
+log_msg(sprintf('CARP %s is %s, running netflector %s', $subsystem, $type, $action));
+mwexecf('/usr/local/etc/rc.d/netflector %s', [$action]);

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
@@ -15,6 +15,12 @@
         <help><![CDATA[Verbosity of the daemon's log, under Services > Netflector > Log File. Every line is recorded at the same syslog priority, so filter on the level in the message text. "Debug" and "Trace" are noisy and are meant for diagnosing a problem, not for running.]]></help>
     </field>
     <field>
+        <id>netflector.general.carp_depend_on</id>
+        <label>CARP dependency</label>
+        <type>dropdown</type>
+        <help><![CDATA[Reflect only while this node holds the selected CARP virtual IP. Leave empty on a single firewall. On an HA pair both nodes reflecting would send two copies of every relayed packet.]]></help>
+    </field>
+    <field>
         <id>netflector.general.counters_interval_secs</id>
         <label>Counter interval</label>
         <type>text</type>

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.xml
@@ -20,6 +20,10 @@
                     <trace>Trace</trace>
                 </OptionValues>
             </log_level>
+            <carp_depend_on type="VirtualIPField">
+                <type>carp</type>
+                <key>mvc</key>
+            </carp_depend_on>
             <counters_interval_secs type="IntegerField">
                 <Default>0</Default>
                 <Required>Y</Required>

--- a/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/rc.conf.d
+++ b/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/rc.conf.d
@@ -1,3 +1,4 @@
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 {# The daemon refuses to start with no reflector to run, so "enabled" must mean the same thing here as
    in netflector_enabled(): the service is on AND at least one entry is on. Keying only on the global
    switch would arm a service whose generated configuration has no [reflectors.*] table at all. #}
@@ -15,4 +16,17 @@
 netflector_enable="YES"
 {% else %}
 netflector_enable="NO"
+{% endif %}
+{# The rc script gates on a vhid, not on the model's VIP uuid. The interface goes with it because the
+   same vhid can run on several interfaces as unrelated groups. #}
+{% if helpers.exists('OPNsense.Netflector.general.carp_depend_on') and OPNsense.Netflector.general.carp_depend_on != '' %}
+{%   if helpers.exists('virtualip.vip') %}
+{%     for vip in helpers.toList('virtualip.vip') %}
+{%       if vip['@uuid'] == OPNsense.Netflector.general.carp_depend_on and vip.mode == 'carp' %}
+netflector_carp_vhid="{{ vip.vhid }}"
+netflector_carp_interface="{{ physical_interface(vip.interface) }}"
+{%         break %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {% endif %}

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -1,4 +1,4 @@
-.Dd July 18, 2026
+.Dd August 1, 2026
 .Dt NETFLECTOR 8
 .Os
 .Sh NAME
@@ -142,6 +142,19 @@ The service reads
 from
 .Xr rc.conf 5
 for the configuration path.
+.Pp
+On a
+.Xr carp 4
+failover pair, both nodes reflecting would send two copies of every relayed
+packet.
+.Va netflector_carp_vhid
+confines the service to the node holding that virtual host ID: start is
+refused unless the group is in the MASTER state.
+The check runs at start only; a later failover does not stop a running
+service.
+.Va netflector_carp_interface
+scopes the check to the interface carrying the group, needed only when the
+same vhid runs on more than one interface.
 .Sh DIAGNOSTICS
 The counter summary, logged periodically when enabled and on
 .Dv SIGUSR1 ,
@@ -168,6 +181,7 @@ does not cover.
 Times the interface was destroyed and recreated, and its capture re-bound.
 .El
 .Sh SEE ALSO
+.Xr carp 4 ,
 .Xr netflector.toml 5 ,
 .Xr rc.conf 5 ,
 .Xr daemon 8 ,


### PR DESCRIPTION
Confine the reflector to the HA node holding a selected CARP virtual IP: both nodes reflecting puts two copies of every relayed packet on the segment, and two DIAL proxies rewrite the same device's LOCATION to different authorities.

Two layers: an rc.conf gate (`netflector_carp_vhid` / `netflector_carp_interface`) checked in precmd, and a CARP syshook that starts/stops the service on failover. The syshook alone is not enough: it only fires on a transition, so booting after CARP has settled to BACKUP would leave the backup node reflecting. The gate also works on plain FreeBSD without the OPNsense machinery. The model stores the VIP's uuid (`VirtualIPField`, key `mvc`); the template resolves it to vhid + interface. Both halves are matched: the same vhid on another interface is an unrelated group.

Testing: verified on OPNsense 26.7 and 26.1.2 VMs, GUI-driven on both (dropdown -> model -> rendered rc.conf.d). Syshook matrix (own group MASTER/BACKUP, same vhid on another interface, another vhid, INIT, dependency unset) via direct invocation and via the real devd path with forced state transitions; boot-gate refusal while genuinely BACKUP; `carp_is_master` cases against canned ifconfig output.