### PR TITLE
docs: split development and release docs out of the README

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,26 @@
+# Markdown feeds no build or lint, but the ruleset still requires a green
+# "Success" on every PR, so this posts one.
+#
+# One of four path-filtered pipelines that must partition the tree: every PR
+# that keeps all four fires at least one, and each reports the required check
+# "Success" (duplicate names are all-must-pass, proven in PR #103).
+name: Docs CI
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      # The pipeline itself: changing it runs it.
+      - '.github/workflows/ci-docs.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  success:
+    name: Success
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Nothing to validate
+        run: 'true'

--- a/.github/workflows/ci-opnsense.yml
+++ b/.github/workflows/ci-opnsense.yml
@@ -2,8 +2,8 @@
 # real converted OPNsense of each supported series. publish-plugin runs this
 # before packaging.
 #
-# One of three path-filtered pipelines that must partition the tree: every PR
-# that keeps all three fires at least one, and each reports the required check
+# One of four path-filtered pipelines that must partition the tree: every PR
+# that keeps all four fires at least one, and each reports the required check
 # "Success" (duplicate names are all-must-pass, proven in PR #103).
 name: OPNsense CI
 

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -2,8 +2,8 @@
 # a ports committer would. publish-daemon runs this before packaging; code
 # changes are covered by ci.yml's from-source port build.
 #
-# One of three path-filtered pipelines that must partition the tree: every PR
-# that keeps all three fires at least one, and each reports the required check
+# One of four path-filtered pipelines that must partition the tree: every PR
+# that keeps all four fires at least one, and each reports the required check
 # "Success" (duplicate names are all-must-pass, proven in PR #103).
 name: Port CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,21 @@
 name: CI
 
-# The code pipeline: everything except the two dist/ subtrees, which have
-# their own pipelines (ci-port.yml, ci-opnsense.yml).
+# The code pipeline: everything except the two dist/ subtrees and markdown,
+# which have their own pipelines (ci-port.yml, ci-opnsense.yml, ci-docs.yml).
 on:
   pull_request:
     paths-ignore:
       - 'dist/freebsd/**'
       - 'dist/opnsense/**'
+      # Markdown feeds no build or lint; ci-docs.yml posts the required check.
+      - '**/*.md'
       # A sibling pipeline fires on each of these instead; the publish flows
       # consume them too. A PR that deletes a sibling workflow and touches
       # only ignored paths fires nothing and stays blocked; workflow_dispatch
       # ci.yml unsticks it.
       - '.github/workflows/ci-port.yml'
       - '.github/workflows/ci-opnsense.yml'
+      - '.github/workflows/ci-docs.yml'
       - 'ci/freebsd14-opnsense.env'
       - 'ci/freebsd15-opnsense.env'
       - 'ci/freebsd-port-package.sh'

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -48,7 +48,7 @@ with debug symbols) and fails the run on any leak, leaked fd, or memcheck error.
 with `--show-netflector-logs`, and leaves resources behind on failure with `--keep-on-failure`.
 
 The `native` backend runs the same cases without Docker, as root: network namespaces + veth pairs on
-Linux, vnet jails + epair(4) on FreeBSD -- one namespace/jail per participant either way. Build the
+Linux, vnet jails + epair(4) on FreeBSD (one namespace/jail per participant either way). Build the
 binary first; the harness never runs cargo as root:
 
 ```sh

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,0 +1,66 @@
+# Developing
+
+Working on netflector itself: the test suites, the platform-gated code, and what CI runs. For
+building and running the daemon, see the [README](README.md).
+
+## Platform-gated code
+
+The platform backends are `cfg(target_os)`-gated (rtnetlink/epoll/`AF_PACKET` on Linux,
+`getifaddrs`/kqueue/BPF on macOS and FreeBSD), so the other OS's code isn't built on the host. To
+exercise the Linux paths from a macOS/FreeBSD dev box, `./docker_test.sh` forwards to `cargo` inside a
+`rust:slim` container:
+
+```sh
+./docker_test.sh test                                  # cargo test on Linux
+./docker_test.sh clippy --all-targets -- -D warnings   # Linux lints
+```
+
+## Tests
+
+```sh
+cargo test                 # the unit suite
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo doc --no-deps --document-private-items   # the rustdoc intra-doc link gate
+```
+
+A subset of tests does privileged work (real packet capture, or binding a socket to an interface) and
+needs the same privileges netflector itself does (see
+[Runtime privileges](README.md#runtime-privileges)). Each probes for the privilege and self-skips
+cleanly when it's missing, so a default `cargo test` run is green on an under-privileged box.
+
+## End-to-end tests
+
+The end-to-end suite drives the real data path: netflector straddles two isolated network segments
+and the suite verifies traffic is reflected, multi-protocol. It runs on two backends. The default
+`docker` backend uses bridge networks and containers; it's opt-in (it builds/runs containers and
+creates temporary Docker networks):
+
+```sh
+python3 e2e/run.py                # build the image and run the full suite
+python3 e2e/run.py --valgrind     # run the daemon under Valgrind memcheck
+python3 e2e/run.py --case reflects_matching_magic_packet   # one case
+```
+
+`--valgrind` runs netflector under memcheck (the `runtime-valgrind` image: a glibc release binary
+with debug symbols) and fails the run on any leak, leaked fd, or memcheck error. The runner builds
+`netflector:e2e` by default, uses `python:3.13-alpine` for UDP-probe containers, can print netflector logs
+with `--show-netflector-logs`, and leaves resources behind on failure with `--keep-on-failure`.
+
+The `native` backend runs the same cases without Docker, as root: network namespaces + veth pairs on
+Linux, vnet jails + epair(4) on FreeBSD -- one namespace/jail per participant either way. Build the
+binary first; the harness never runs cargo as root:
+
+```sh
+cargo build --release --locked
+sudo python3 e2e/run.py --backend native --binary target/release/netflector
+```
+
+## CI
+
+CI runs the unit suite on Ubuntu 24.04 (amd64 and arm64, both glibc and the shipped static musl),
+macOS 15, FreeBSD 14 and 15 (amd64 and arm64, cross-compiled on the runner and executed in QEMU VMs), and
+the cross-compiled `linux/arm/v7` and `linux/arm/v5` builds whose suites run under QEMU, each in both
+debug and release. `clippy` and the rustdoc link gate run per target. The e2e suite runs on the
+Docker backend for both image arches (plus a Valgrind memcheck job) and natively on linux amd64/arm64
+(glibc and musl), armv7/armv5 (daemon under qemu-user), and FreeBSD amd64/arm64.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ these. The same shape serves one or a few specific devices (`macs`) or a whole n
 - [Build](#build)
 - [Run](#run): [privileges](#runtime-privileges), [Docker](#run-in-docker), [MikroTik](#on-mikrotik-routeros), [FreeBSD/OPNsense packages](#install-on-freebsd-and-opnsense)
 - [Configuration](#configuration): [env vars](#environment-variables), [`macs`](#the-macs-field), [`address_family`](#address_family), [per-protocol behavior](#per-protocol-behavior), [DIAL](#dial), [duplicate detection](#duplicate-detection)
-- [Tests](#tests)
-- [Release](#release)
+- [Developing](#developing)
 - [License](#license)
 
 ## Platform support
@@ -45,13 +44,6 @@ router that bridges the two segments.
 **FreeBSD** isn't a Docker target (Docker shares the host's Linux kernel), so each release also ships
 a standalone **static** binary for `amd64` and `arm64`, cross-built against the FreeBSD 14 base
 pinned in `ci/freebsd14.env` and running on that release or newer.
-
-CI runs the unit suite on Ubuntu 24.04 (amd64 and arm64, both glibc and the shipped static musl),
-macOS 15, FreeBSD 14 and 15 (amd64 and arm64, cross-compiled on the runner and executed in QEMU VMs), and
-the cross-compiled `linux/arm/v7` and `linux/arm/v5` builds whose suites run under QEMU, each in both
-debug and release. `clippy` and the rustdoc link gate run per target. The e2e suite runs on the
-Docker backend for both image arches (plus a Valgrind memcheck job) and natively on linux amd64/arm64
-(glibc and musl), armv7/armv5 (daemon under qemu-user), and FreeBSD amd64/arm64.
 
 ## Build
 
@@ -69,16 +61,6 @@ The release profile enables LTO, a single codegen unit, and symbol stripping for
 (the binary targets embedded ARM, so the data path avoids allocations). The only dependencies are
 `thiserror`, `serde`, `toml`, `log`, and `libc`; cargo fetches them, no system packages needed.
 
-The platform backends are `cfg(target_os)`-gated (rtnetlink/epoll/`AF_PACKET` on Linux,
-`getifaddrs`/kqueue/BPF on macOS and FreeBSD), so the other OS's code isn't built on the host. To
-exercise the Linux paths from a macOS/FreeBSD dev box, `./docker_test.sh` forwards to `cargo` inside a
-`rust:slim` container:
-
-```sh
-./docker_test.sh test                                  # cargo test on Linux
-./docker_test.sh clippy --all-targets -- -D warnings   # Linux lints
-```
-
 ### Docker build
 
 The runtime image is a single static musl binary on `scratch`: no shell, no package manager. A bare
@@ -94,11 +76,6 @@ The Dockerfile's builder runs on the build host (no QEMU) and links the cross la
 ```sh
 docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5 -t netflector .
 ```
-
-Releases take a different path (see [Release](#release)): each arch builds on its own runner and the
-digests are stitched into one manifest. amd64 and arm64 have native runners, so those layers link
-with rustc's default linker rather than cross-linking with `lld`; only armv7 and armv5, which have no
-native runner, cross-compile.
 
 ## Run
 
@@ -470,78 +447,10 @@ handle the same IP version: an `ipv4`-only and an `ipv6`-only entry never overla
 overlap with either. Entries that differ in interface, MAC, address family (or WoL ports), or that
 enable *different* protocols, coexist.
 
-## Tests
+## Developing
 
-```sh
-cargo test                 # the unit suite
-cargo clippy --all-targets -- -D warnings
-cargo fmt --check
-cargo doc --no-deps --document-private-items   # the rustdoc intra-doc link gate
-```
-
-A subset of tests does privileged work (real packet capture, or binding a socket to an interface) and
-needs the same privileges netflector itself does (see [Runtime privileges](#runtime-privileges)).
-Each probes for the privilege and self-skips cleanly when it's missing, so a default `cargo test` run is
-green on an under-privileged box.
-
-The platform backends are `cfg(target_os)`-gated, so `cargo test` on the host only exercises that OS's
-paths. `./docker_test.sh` forwards to `cargo` inside a `rust:slim` container to run the Linux paths from
-a macOS/FreeBSD dev box (e.g. `./docker_test.sh test`).
-
-### End-to-end tests
-
-The end-to-end suite drives the real data path: netflector straddles two isolated network segments
-and the suite verifies traffic is reflected, multi-protocol. It runs on two backends. The default
-`docker` backend uses bridge networks and containers; it's opt-in (it builds/runs containers and
-creates temporary Docker networks):
-
-```sh
-python3 e2e/run.py                # build the image and run the full suite
-python3 e2e/run.py --valgrind     # run the daemon under Valgrind memcheck
-python3 e2e/run.py --case reflects_matching_magic_packet   # one case
-```
-
-`--valgrind` runs netflector under memcheck (the `runtime-valgrind` image: a glibc release binary
-with debug symbols) and fails the run on any leak, leaked fd, or memcheck error. The runner builds
-`netflector:e2e` by default, uses `python:3.13-alpine` for UDP-probe containers, can print netflector logs
-with `--show-netflector-logs`, and leaves resources behind on failure with `--keep-on-failure`.
-
-The `native` backend runs the same cases without Docker, as root: network namespaces + veth pairs on
-Linux, vnet jails + epair(4) on FreeBSD -- one namespace/jail per participant either way. Build the
-binary first; the harness never runs cargo as root:
-
-```sh
-cargo build --release --locked
-sudo python3 e2e/run.py --backend native --binary target/release/netflector
-```
-
-CI runs the native suite on linux amd64/arm64 (glibc and the shipped static musl), on armv7/armv5
-with the daemon under qemu-user, and on FreeBSD amd64/arm64 in QEMU VMs.
-
-## Release
-
-The `[package]` version in `Cargo.toml` is the single source of truth: `version.sh` extracts it, and
-`release.sh` (the git tag), the published image tag, and the GitHub release name all derive from it. To
-cut a release:
-
-- Bump the version in `Cargo.toml`, refresh `Cargo.lock` (`cargo build` updates its `netflector`
-  entry; CI builds `--locked`, so a stale lockfile fails the release), and merge it to `origin/main`.
-- From a clean `main` in sync with `origin/main`, run `./release.sh`.
-
-`./release.sh` does only the local half: it prints the detected version and asks for confirmation, then
-tags `v<version>` and pushes it. Pushing the tag hands off to the `release.yml` workflow, which does
-everything else: it runs the full CI pipeline on the tagged commit and checks that the tag matches
-`Cargo.toml`, builds the per-arch binaries (Linux amd64/arm64/armv7/armv5, macOS arm64, FreeBSD
-amd64/arm64), publishes the multi-arch image to GHCR (each arch built on its own runner and stitched
-into one manifest), and creates the GitHub release
-with the binaries and their `SHA256SUMS` attached and generated notes.
-
-The OPNsense plugin releases separately: bump `PLUGIN_VERSION` in
-`dist/opnsense/net/netflector/Makefile`, merge, then run `./release-os.sh` from a clean synced `main`.
-It does the same local half and tags `os-v<version>`; the tag hands off to `publish-plugin.yml`, which
-runs the OPNsense pipeline on the tagged commit, packages the plugin for each supported FreeBSD major
-(plus the daemon when the version the port pins is not yet published) and publishes everything to the
-[package repository](https://github.com/netflector/pkg).
+[DEVELOP.md](DEVELOP.md) covers the test suites, the platform-gated code, and what CI runs.
+[RELEASE.md](RELEASE.md) covers the release and packaging process.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ It reflects four link-local protocols and layers an optional DIAL proxy on top o
   renderers (TVs, media servers) on the other.
 - **DIAL proxy** *(optional, builds on SSDP)*: a "cast to TV" device's REST API lives on its own
   segment, often unreachable from the client's (and some TVs refuse off-subnet clients); the proxy
-  bridges that gap so a client on the other segment can launch apps on it. It's
-  not a separate reflector; it augments an SSDP entry, enabled with `dial = true`. See [DIAL](#dial).
+  bridges that gap so a client on the other segment can launch apps on it. Enabled with
+  `dial = true` on an SSDP entry; see [DIAL](#dial).
 - **WS-Discovery (WSD)**: SOAP-over-UDP discovery is relayed both ways, so a client on one segment can
   discover ONVIF cameras or Windows devices (printers, scanners) on the other.
 
 Each named entry bridges one `source_if` → `target_if` interface pair and enables any combination of
-these. The same shape serves one or a few specific devices (`macs`) or a whole network (omit it).
+these.
 
 ## Contents
 
@@ -42,7 +42,7 @@ netflector runs on **Linux, macOS, and FreeBSD**.
 router that bridges the two segments.
 
 **FreeBSD** isn't a Docker target (Docker shares the host's Linux kernel), so each release also ships
-a standalone **static** binary for `amd64` and `arm64`, cross-built against the FreeBSD 14 base
+a standalone static binary for `amd64` and `arm64`, cross-built against the FreeBSD 14 base
 pinned in `ci/freebsd14.env` and running on that release or newer.
 
 ## Build
@@ -58,7 +58,7 @@ cargo build --release  # optimized binary at target/release/netflector
 ```
 
 The release profile enables LTO, a single codegen unit, and symbol stripping for a small footprint
-(the binary targets embedded ARM, so the data path avoids allocations). The only dependencies are
+(the binary targets embedded ARM). The only dependencies are
 `thiserror`, `serde`, `toml`, `log`, and `libc`; cargo fetches them, no system packages needed.
 
 ### Docker build
@@ -323,8 +323,8 @@ rejected at startup.
 
 ### The `macs` field
 
-`macs` is an optional list naming the device(s) an entry is scoped to, coherently across WoL, mDNS,
-SSDP, and WSD, because a device's NIC MAC is both the target of its Wake-on-LAN magic packet and the L2
+`macs` is an optional list naming the device(s) an entry is scoped to. One field covers WoL, mDNS,
+SSDP, and WSD because a device's NIC MAC is both the target of its Wake-on-LAN magic packet and the L2
 source of its mDNS/SSDP/WSD advertisements. A single device is just a one-entry list
 (`macs = ["B0:37:95:C5:60:BE"]`); list several to scope one entry to a set of devices
 (`macs = ["B0:37:95:C5:60:BE", "C4:9D:8F:11:22:33"]`). Below, "the allow-set" means the configured
@@ -349,7 +349,7 @@ requires both; `"ipv4"` / `"ipv6"` use only one. It applies to every protocol th
 mDNS, SSDP, and WSD are bidirectional, so a handled family must have a source address on **both**
 interfaces (the target re-emits relayed queries/searches, the source re-emits relayed
 responses/advertisements).
-This condition is re-checked continuously at runtime (see
+The condition is re-checked at runtime (see
 [Reacting to address changes](#reacting-to-address-changes) below): a family is torn down if either
 interface loses its address and brought back up once both can send it again.
 
@@ -368,8 +368,8 @@ appears. Gaining a family logs at `info`; losing a *required* family logs at `er
 address refresh.
 
 It also survives an interface being destroyed and recreated (a fresh kernel identity, e.g. a PPPoE
-reconnect or a bridge/VLAN rebuild). Lifecycle events -- backed by a periodic reconcile, so recovery
-never depends on one notification surviving -- detect that the name's kernel identity moved; the
+reconnect or a bridge/VLAN rebuild). Lifecycle events (backed by a periodic reconcile, so recovery
+never depends on one notification surviving) detect that the name's kernel identity moved; the
 captures are then re-bound in place, addresses re-resolved, and multicast groups re-joined on the new
 interface, while its DIAL proxies are evicted to re-mint on the next advertisement. While the
 interface is absent its reflection parks (sends drop quietly, as on an address loss) and resumes when
@@ -414,7 +414,7 @@ device/printer discovery across segments.
 
 DIAL (DIscovery And Launch, the protocol behind "cast to TV" for YouTube, Netflix, etc.) lets a phone
 or laptop find a smart TV and launch an app on it. The catch: the device's description and REST
-endpoints live at its address on the **other segment**, which the client often cannot reach, and some
+endpoints live at its address on the other segment, which the client often cannot reach, and some
 devices refuse off-subnet clients outright (the DIAL spec doesn't require that, but Chromecast and
 some Samsung TVs do it). Either way a client on a different segment discovers the device but cannot
 drive it. Setting `dial = true` on an SSDP entry makes netflector bridge that gap.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Releasing
 
+Three artifacts, in order: the daemon release (tag, binaries, image), the FreeBSD daemon package,
+then the OPNsense plugin. The order matters: the package is built from the release, and the plugin
+publish validates its rendered config against the daemon package already published.
+
 ## Daemon
 
 The `[package]` version in `Cargo.toml` is the single source of truth: `version.sh` extracts it, and
@@ -21,6 +25,24 @@ For the image, each arch builds on its own runner and the digests are stitched i
 amd64 and arm64 have native runners, so those layers link with rustc's default linker rather than
 cross-linking with `lld`; only armv7 and armv5, which have no native runner, cross-compile.
 
+## FreeBSD daemon package
+
+After the release, point the port at it and regenerate the pinned hashes:
+
+```sh
+ci/port-sync.py --update <version>
+```
+
+Merge that to main. `publish-daemon.yml` fires on any push to main touching
+`dist/freebsd/net/netflector/**`, builds the port in per-ABI FreeBSD VMs, verifies the result on
+real OPNsense, and publishes the re-signed catalogue trees to the
+[package repository](https://github.com/netflector/pkg).
+
+The workflow first compares the port's `DISTVERSION` (plus `PORTREVISION`, if set) against the
+published trees and skips silently when that version is already there. So a change to the port's
+packaged content that does not come with a version change (an rc script edit, a new file) must bump
+`PORTREVISION`, or nothing is published.
+
 ## OPNsense plugin
 
 The OPNsense plugin releases separately: bump `PLUGIN_VERSION` in
@@ -29,3 +51,8 @@ It does the same local half and tags `os-v<version>`; the tag hands off to `publ
 runs the OPNsense pipeline on the tagged commit, packages the plugin for each supported FreeBSD major
 (plus the daemon when the version the port pins is not yet published) and publishes everything to the
 [package repository](https://github.com/netflector/pkg).
+
+A plugin content or metadata change ships only with a `PLUGIN_VERSION` bump: the publish is
+tag-driven and the workflow refuses a tag that does not match `PLUGIN_VERSION`, so without a bump
+there is no new tag to cut. `PLUGIN_REVISION` is no substitute; `release-os.sh` tags
+`os-v<version>` and a revision is not part of that version.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+# Releasing
+
+## Daemon
+
+The `[package]` version in `Cargo.toml` is the single source of truth: `version.sh` extracts it, and
+`release.sh` (the git tag), the published image tag, and the GitHub release name all derive from it. To
+cut a release:
+
+- Bump the version in `Cargo.toml`, refresh `Cargo.lock` (`cargo build` updates its `netflector`
+  entry; CI builds `--locked`, so a stale lockfile fails the release), and merge it to `origin/main`.
+- From a clean `main` in sync with `origin/main`, run `./release.sh`.
+
+`./release.sh` does only the local half: it prints the detected version and asks for confirmation, then
+tags `v<version>` and pushes it. Pushing the tag hands off to the `release.yml` workflow, which does
+everything else: it runs the full CI pipeline on the tagged commit and checks that the tag matches
+`Cargo.toml`, builds the per-arch binaries (Linux amd64/arm64/armv7/armv5, macOS arm64, FreeBSD
+amd64/arm64), publishes the multi-arch image to GHCR, and creates the GitHub release
+with the binaries and their `SHA256SUMS` attached and generated notes.
+
+For the image, each arch builds on its own runner and the digests are stitched into one manifest.
+amd64 and arm64 have native runners, so those layers link with rustc's default linker rather than
+cross-linking with `lld`; only armv7 and armv5, which have no native runner, cross-compile.
+
+## OPNsense plugin
+
+The OPNsense plugin releases separately: bump `PLUGIN_VERSION` in
+`dist/opnsense/net/netflector/Makefile`, merge, then run `./release-os.sh` from a clean synced `main`.
+It does the same local half and tags `os-v<version>`; the tag hands off to `publish-plugin.yml`, which
+runs the OPNsense pipeline on the tagged commit, packages the plugin for each supported FreeBSD major
+(plus the daemon when the version the port pins is not yet published) and publishes everything to the
+[package repository](https://github.com/netflector/pkg).


### PR DESCRIPTION
The README keeps what a user of the daemon needs: install, run, configure. Tests, platform-gated-code notes, and the CI matrix move to DEVELOP.md; the release process to RELEASE.md. Three paragraphs that said the same thing twice across sections fold into one on the way.

RELEASE.md also gains the package half of the process, which existed only in workflow comments: the port re-pin (`ci/port-sync.py --update`), the publish-daemon path trigger, and the two version-bump traps (an unbumped `PORTREVISION` skips the publish silently; an unbumped `PLUGIN_VERSION` leaves no tag to cut).

A wording pass on top: dash asides to parentheses, duplicated clauses cut, two decorative bolds dropped; no content changes.

Verified: every README anchor resolves, no references left to the removed sections, and the cumulative diff was snapshot-compared across the history edits so the split lost no content.