### PR TITLE
docs: correct what the docs promise about behavior

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -16,8 +16,9 @@ cargo build --release  # optimized binary at target/release/netflector
 ```
 
 The release profile enables LTO, a single codegen unit, and symbol stripping for a small footprint
-(the binary targets embedded ARM). The only dependencies are
-`thiserror`, `serde`, `toml`, `log`, and `libc`; cargo fetches them, no system packages needed.
+(the binary targets embedded ARM). The only crate dependencies are
+`thiserror`, `serde`, `toml`, `log`, and `libc`; cargo fetches them. Beyond a C linker (Xcode command
+line tools, `build-essential`, or the base system on FreeBSD) no system packages are needed.
 
 ### Docker build
 
@@ -94,5 +95,6 @@ CI runs the unit suite on Ubuntu 24.04 (amd64 and arm64, both glibc and the ship
 macOS 15, FreeBSD 14 and 15 (amd64 and arm64, cross-compiled on the runner and executed in QEMU VMs), and
 the cross-compiled `linux/arm/v7` and `linux/arm/v5` builds whose suites run under QEMU, each in both
 debug and release. `clippy` and the rustdoc link gate run per target. The e2e suite runs on the
-Docker backend for both image arches (plus a Valgrind memcheck job) and natively on linux amd64/arm64
-(glibc and musl), armv7/armv5 (daemon under qemu-user), and FreeBSD amd64/arm64.
+Docker backend on amd64 and arm64 (plus a Valgrind memcheck job) and natively on linux amd64/arm64
+(glibc and musl), armv7/armv5 (daemon under qemu-user), and FreeBSD amd64/arm64. The armv7 and armv5
+images are covered by the native lanes rather than the Docker ones.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Configuration comes from a TOML file, from environment variables, or from both. 
 the file is read and merged with any `NETFLECTOR_*` environment variables; with **no argument** the
 configuration comes entirely from the environment (see [Environment variables](#environment-variables)).
 The process logs to stderr with UTC timestamps, shuts down cleanly on `SIGINT` / `SIGTERM`, and on
-`SIGUSR1` dumps the per-interface [packet counters](#configuration) to the log on demand (regardless of
-`counters_interval_secs`).
+`SIGUSR1` dumps the per-interface [packet counters](#configuration) and a memory report to the log on
+demand (regardless of `counters_interval_secs`).
 
 | Option | |
 | --- | --- |
@@ -163,7 +163,7 @@ docker run -d --name netflector --restart unless-stopped \
 The `arm64`, `arm/v7`, and `arm/v5` variants let netflector run on the router itself through the
 RouterOS *Container* feature, bridging two of the router's VLANs without a separate host. Since it has
 to see both segments, give the container **two `veth` interfaces, one bridged into each VLAN**, and name
-them as the entry's `source_if` / `target_if`:
+them as the entry's `source_if` / `target_if`. Two veths on one container needs RouterOS 7.20 or newer:
 
 ```toml
 [reflectors.livingroom-tv]
@@ -178,8 +178,10 @@ wsd       = true         # enable WS-Discovery, disabled by default
 ```
 
 On RouterOS, setting the container's environment variables is usually easier than mounting a file: the
-entry above becomes `NETFLECTOR_TV_SOURCE_IF=veth-lan`, `NETFLECTOR_TV_TARGET_IF=veth-iot`,
-`NETFLECTOR_TV_MACS=B0:37:95:C5:60:BE`, `NETFLECTOR_TV_WOL=true`, and so on (see
+entry above becomes `NETFLECTOR_TV_NAME=livingroom-tv`, `NETFLECTOR_TV_SOURCE_IF=veth-lan`,
+`NETFLECTOR_TV_TARGET_IF=veth-iot`, `NETFLECTOR_TV_MACS=B0:37:95:C5:60:BE`,
+`NETFLECTOR_TV_WOL=true`, and so on. The tag names the entry unless `NAME` overrides it, so without
+that first variable the reflector is called `tv` (see
 [Environment variables](#environment-variables)). To use the file instead, mount it to
 `/etc/netflector/config.toml` and set that path as the container's command argument. For the RouterOS
 side (enabling container mode, creating the `veth`s, and attaching each to its VLAN), see MikroTik's
@@ -303,8 +305,9 @@ devices:
   and WSD the same filter scopes the proxied unicast replies: only the allow-set's responses are
   carried back to a searcher.
 
-Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP/WSD reflect all
-traffic in both directions.
+Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP/WSD relay
+every device's traffic rather than a chosen set (only the message kinds the corresponding direction
+allows, per the table below).
 
 ### `address_family`
 
@@ -324,11 +327,11 @@ interface loses its address and brought back up once both can send it again.
 
 netflector watches the kernel for interface address and lifecycle changes (a `NETLINK_ROUTE`
 socket on Linux, a `PF_ROUTE` socket on the BSDs) and adapts at runtime, without a restart. mDNS,
-SSDP, and WSD bring a family up (joining its multicast group(s) and installing its capture
-registrations) once that family becomes
+SSDP, and WSD bring a family up (joining its multicast group(s)) once that family becomes
 reflectable (a source address for it is present on **both** interfaces), and tear it down when either
-interface loses the address; the family resumes automatically when the address returns. WoL keeps its
-captures installed and instead checks reachability per packet, so it has nothing to join or leave.
+interface loses the address; the family resumes automatically when the address returns. Capture
+registrations stay installed throughout; what changes is the group membership and whether the egress
+can source the family. WoL has no group to join and instead checks reachability per packet.
 Either way, a best-effort IPv6 family that had no address at startup begins reflecting as soon as one
 appears. Gaining a family logs at `info`; losing a *required* family logs at `error`, an optional one at
 `info`. The monitor is best-effort: if it cannot start, netflector logs a warning and runs without
@@ -358,8 +361,19 @@ the periodic reconcile (up to ~30 s).
 WoL matching requires the magic-packet sequence (six `0xFF` bytes followed by the target MAC repeated 16
 times) at the start of the UDP payload; trailing bytes such as a SecureOn password are ignored when
 matching and forwarded as-is. mDNS responses include unsolicited announcements (so they flow
-target→source too); mDNS/SSDP/WSD datagrams are re-emitted verbatim to the same group (SSDP at hop limit 2, WSD at 1).
-A site-local SSDP group (`ff05::c`) is sourced from a routable address, not the interface's link-local.
+target→source too); mDNS/SSDP/WSD datagrams are re-emitted verbatim to the same group (mDNS at hop
+limit 255, SSDP at 2, WSD at 1).
+A site-local SSDP group (`ff05::c`) is sourced from a routable address when the interface has one. With
+only a link-local address it is sourced from that, which still reaches the attached segment but will
+not cross a router.
+
+mDNS is relayed as pure multicast. A querier that asks for a unicast answer (the QU bit, or a query
+from an ephemeral source port) is answered off the group, and that answer is not relayed; SSDP and WSD
+instead proxy each searcher's unicast reply.
+
+netflector reads untagged Ethernet frames carrying IPv4 or IPv6 UDP. VLAN-tagged frames and IPv6
+extension headers are not parsed, so configure the VLAN as its own interface (`vlan10`, `em0.10`) and
+name that as the entry's `source_if` / `target_if` rather than the trunk.
 
 For SSDP, multicast reflection delivers **passive** discovery: devices' periodic `NOTIFY ssdp:alive`
 advertisements reach the source segment so clients see them. **Active** discovery works end to end as

--- a/dist/opnsense/net/netflector/Makefile
+++ b/dist/opnsense/net/netflector/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		netflector
-PLUGIN_VERSION=		0.1.3
+PLUGIN_VERSION=		0.1.4
 PLUGIN_COMMENT=		Reflect link-local service discovery between interfaces
 PLUGIN_MAINTAINER=	sergii@bogomolov.io
 PLUGIN_WWW=			https://github.com/netflector/netflector

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/forms/general.xml
@@ -24,6 +24,6 @@
         <id>netflector.general.counters_interval_secs</id>
         <label>Counter interval</label>
         <type>text</type>
-        <help><![CDATA[Seconds between per-interface packet-counter summaries in the log. 0 disables them.]]></help>
+        <help><![CDATA[Seconds between per-interface packet-counter summaries in the log, up to one day. 0 disables them.]]></help>
     </field>
 </form>

--- a/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/netflector.toml
+++ b/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/netflector.toml
@@ -9,7 +9,7 @@ counters_interval_secs = {{ OPNsense.Netflector.general.counters_interval_secs|d
 {#     The GUI stores OPNsense's logical names (lan, opt1); the daemon needs the device (vtnet0). #}
 {#     Every switch is written out, false and "default" included: the file states what the GUI
        showed, so a later change to a daemon default cannot silently flip a plugin user. Only
-       wol_ports and macs may be absent -- there absence is itself the setting (the daemon's
+       wol_ports and macs may be absent (their absence is itself the setting: the daemon's
        default ports; all devices). #}
 [reflectors.{{ entry.name }}]
 source_if = "{{ physical_interface(entry.source_if) }}"

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -96,9 +96,9 @@ is enabled.
 Enable mDNS reflection.
 Boolean, default
 .Cm false .
-Relaying is multicast only: a querier that requests a unicast answer, by setting the
-QU bit or by asking from an ephemeral source port, is answered off the group, and that
-answer is not relayed.
+Relaying is multicast only: a querier that requests a unicast answer, by
+setting the QU bit or by asking from an ephemeral source port, is answered off
+the group, and that answer is not relayed.
 .It Ic ssdp
 Enable SSDP reflection.
 Boolean, default

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -96,6 +96,9 @@ is enabled.
 Enable mDNS reflection.
 Boolean, default
 .Cm false .
+Relaying is multicast only: a querier that requests a unicast answer, by setting the
+QU bit or by asking from an ephemeral source port, is answered off the group, and that
+answer is not relayed.
 .It Ic ssdp
 Enable SSDP reflection.
 Boolean, default

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -26,8 +26,10 @@ pub(crate) struct TcpSocket {
 }
 
 impl TcpSocket {
-    /// Listen on `addr:0`: an ephemeral port on the source interface's address (not `0.0.0.0`, so only
-    /// that subnet reaches it). Read the assigned port back with [`local_addr`](Self::local_addr).
+    /// Listen on `addr:0`: an ephemeral port on the source interface's address rather than `0.0.0.0`,
+    /// so the listener is not offered on every interface. Whether anything off that segment can still
+    /// route to the address is a routing and firewall question, not one the bind settles.
+    /// Read the assigned port back with [`local_addr`](Self::local_addr).
     ///
     /// # Errors
     /// Propagates the socket / `setsockopt` / `bind` / `listen` syscall failure.


### PR DESCRIPTION
An independent external review found places where the documentation overstates or omits what the code does. Each was re-verified against current code before the text was changed:

- mDNS relays multicast only, so a QU or ephemeral-port querier's unicast answer is never relayed. This was in the module docs and nowhere a user would look; now in the README and netflector.toml(5).
- Site-scope SSDP (`ff05::c`) falls back to a link-local source when the interface has no routable address. The README claimed it never does. Documented rather than changed: the fallback is deliberate and the target segment is attached, so the send still reaches its audience, it just will not cross a router.
- Omitting `macs` drops the MAC filter, not the per-protocol direction rules.
- `SIGUSR1` also dumps a memory report.
- Capture registrations outlive an address change; what goes up and down is the group membership.
- VLAN-tagged frames and IPv6 extension headers are not parsed, so a VLAN must be its own interface rather than the trunk.
- Two veths on one RouterOS container needs 7.20+, and the environment example was missing the `NAME` that makes the entry `livingroom-tv` rather than `tv`.
- mDNS's hop limit 255, a C linker being required, armv7/v5 e2e running natively rather than on Docker, the plugin's counter-interval cap, and a template typo.

A `TcpSocket::listen` comment claimed binding to an address means only that subnet can reach the listener; reachability is a routing and firewall question.

PLUGIN_VERSION 0.1.4, since the template and form are packaged content. The port is untouched, so this publishes nothing on merge.

Verified: mandoc -W warning clean on both pages, cargo fmt/clippy/doc clean.