### PR TITLE
ci: harden the publish path's tag handling and key continuity

### DIFF
--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -145,6 +145,16 @@ jobs:
           mkdir signed
           ci/freebsd-vm.sh pull /repo signed/opnsense
           ci/freebsd-vm.sh pull /tmp/repo.pub signed/netflector-pkg.pub
+          # Clients pin the published key, so a replaced signing secret locks every existing
+          # install out of updates. The gate below verifies the catalogue against the key just
+          # derived from that secret and so passes either way; only comparing against what is
+          # already published catches it. Deliberate rotation means removing the published key in
+          # netflector/pkg first, which is the point: it cannot happen as a side effect.
+          if [ -f pkg-repo/netflector-pkg.pub ] \
+            && ! cmp -s pkg-repo/netflector-pkg.pub signed/netflector-pkg.pub; then
+            echo "::error::signing key does not match the published netflector-pkg.pub"
+            exit 1
+          fi
           # upload-artifact rejects ':' in any file path inside the artifact,
           # and the tree directories are ABI-named (FreeBSD:14:amd64); a tar
           # crosses the boundary intact.

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -37,13 +37,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Verify the tag and compare daemon versions
         id: decide
+        # Through the environment, not interpolated into the script: a tag name is attacker-chosen
+        # text and git permits quotes and semicolons in one, which would otherwise be shell here.
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          tag='${{ github.ref_name }}'
           plugin=$(sed -n 's/^PLUGIN_VERSION=[[:space:]]*//p' dist/opnsense/net/netflector/Makefile)
-          if [ "$tag" != "os-v${plugin}" ]; then
-            echo "tag ${tag} does not match PLUGIN_VERSION ${plugin}" >&2
+          if [ "$TAG" != "os-v${plugin}" ]; then
+            echo "tag ${TAG} does not match PLUGIN_VERSION ${plugin}" >&2
             exit 1
           fi
+          echo "$plugin" | grep -qxE '[0-9]+\.[0-9]+\.[0-9]+' \
+            || { echo "PLUGIN_VERSION ${plugin} is not a three-part version" >&2; exit 1; }
           port=$(sed -n 's/^DISTVERSION=[[:space:]]*//p' dist/freebsd/net/netflector/Makefile)
           revision=$(sed -n 's/^PORTREVISION=[[:space:]]*//p' dist/freebsd/net/netflector/Makefile)
           if [ -n "$revision" ] && [ "$revision" != 0 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
     needs: verify-ci
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    # tag-check has already required the tag to equal v<Cargo.toml version>, but the asset names
+    # below still take it through the environment rather than into the script text.
+    env:
+      ASSET: netflector-${{ github.ref_name }}-${{ matrix.variant }}
     strategy:
       fail-fast: true
       matrix:
@@ -145,12 +149,12 @@ jobs:
       - name: Stage binary
         run: |
           mkdir -p dist
-          cp "target/${{ matrix.target }}/release/netflector" "dist/netflector-${{ github.ref_name }}-${{ matrix.variant }}"
+          cp "target/${{ matrix.target }}/release/netflector" "dist/${ASSET}"
 
       - name: Verify static linking (Linux)
         if: runner.os == 'Linux'
         run: |
-          bin="dist/netflector-${{ github.ref_name }}-${{ matrix.variant }}"
+          bin="dist/${ASSET}"
           file "$bin"
           # The static binary has no shared-library deps (the invariant that matters), but PIE-ness
           # varies -- musl x86_64 is static-pie, the ARM targets and FreeBSD are plain static -- so
@@ -161,7 +165,7 @@ jobs:
       - name: Verify system-only linking (macOS)
         if: runner.os == 'macOS'
         run: |
-          bin="dist/netflector-${{ github.ref_name }}-${{ matrix.variant }}"
+          bin="dist/${ASSET}"
           otool -L "$bin"
           # macOS has no static linking; the invariant that matters is the same one the Linux
           # check enforces: no dependencies beyond the OS (nothing from Homebrew or the
@@ -273,8 +277,12 @@ jobs:
       - name: Which shared tags may move
         id: ord
         run: |
-          newest=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          line=$(git tag --list "${GITHUB_REF_NAME%.*}.*" --sort=-v:refname | head -1)
+          # Strict three-part tags only. `v*` also matches a prerelease or a typo like v9.9.9-rc1,
+          # and -v:refname would sort one of those above the real newest, so a correct release
+          # would then decline to move the tags it owns.
+          releases() { git tag --list "$1" --sort=-v:refname | grep -xE 'v[0-9]+\.[0-9]+\.[0-9]+'; }
+          newest=$(releases 'v*' | head -1)
+          line=$(releases "${GITHUB_REF_NAME%.*}.*" | head -1)
           echo "latest=$([ "$GITHUB_REF_NAME" = "$newest" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "minor=$([ "$GITHUB_REF_NAME" = "$line" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Three findings from the external review, all in the release and publish path. None is reachable today; each closes a way a future change could make it reachable.

**A tag name reached the shell before it was validated.** publish-plugin interpolated `${{ github.ref_name }}` into the very step meant to check it, and git permits quotes and semicolons in a tag name, so the guard's own syntax could be rewritten before it ran. It now arrives through `env:`. Every other workflow was swept for the pattern: release.yml had four more, already gated (`binaries` needs `verify-ci` needs `tag-check`, which requires the tag to equal `v$(./version.sh)`), but they take the same route now so the pattern is uniform. `PLIST_FILES`-style `with:` blocks are left alone: `path:` is not a shell context. PLUGIN_VERSION also has to look like a three-part version before anything is built from it.

**A stray tag could stop a real release moving its aliases.** The newest-release probe matched any `v*`, so a prerelease or typo outranks a real release under `-v:refname`. Verified against the real tag list: with `v9.9.9-rc1` present, that is what `head -1` returns, so a correct `v0.14.0` would decline to move `:latest`, the `major.minor` tag and GitHub's Latest marker. Now filtered to strict three-part tags.

**Signing-key continuity was self-trusted.** pkg-deploy derives the public key from the current secret, gates the catalogue with that same derived key, then publishes it, so a replaced secret passes while every client pinned to the old key silently stops updating. The sign job already checks out netflector/pkg, so comparing against the published key needs no new machinery. Deliberate rotation now means removing the published key first, which is the point: it cannot happen as a side effect of a routine publish.

## Testing

Both new patterns exercised against real and adversarial input. PLUGIN_VERSION accepts `0.1.4`/`10.20.30` and rejects `1.2.3.4`, `0.1.4abc`, `0x.1.4`, `1.2`, `0.1.4; rm -rf /`, empty and leading-space. The release-tag filter accepts `v0.14.0`/`v10.20.30` and rejects `v9.9.9-rc1`, `v1.2`, `v1.2.3.4`, trailing space and `xv1.2.3`; against the repo's actual tags it still selects v0.14.0 as both newest and head of its line. actionlint with shellcheck reports nothing new.

The key-continuity check only runs during a publish, so it is reviewed rather than executed here.