### PR TITLE
port: install a sample configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ It reflects four link-local protocols and layers an optional DIAL proxy on top o
 - **WS-Discovery (WSD)**: SOAP-over-UDP discovery is relayed both ways, so a client on one segment can
   discover ONVIF cameras or Windows devices (printers, scanners) on the other.
 
-Each named entry bridges one `source_if` → `target_if` interface pair and enables any combination of
-these.
+Each named entry bridges one `source_if` → `target_if` interface pair and enables one or more of the
+four reflected protocols, in any mix; the DIAL proxy then layers onto SSDP.
 
 ## Contents
 
@@ -224,7 +224,7 @@ pkg install os-netflector
 
 `config.toml` contains optional top-level settings plus at least one reflector entry. Entries are tables
 under `reflectors`, keyed by name (`[reflectors.<name>]`, the name being the label used in logs), each
-describing one `source_if` → `target_if` bridge that enables any combination of the protocols. The
+describing one `source_if` → `target_if` bridge that enables one or more of the protocols. The
 top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_interval_secs`:
 
 ```toml

--- a/dist/freebsd/net/netflector/Makefile
+++ b/dist/freebsd/net/netflector/Makefile
@@ -42,10 +42,12 @@ CARGO_CRATES=	equivalent-1.0.2 \
 		winnow-1.0.3
 
 PLIST_FILES=	bin/netflector \
+		"@sample etc/netflector.toml.sample" \
 		share/man/man5/netflector.toml.5.gz \
 		share/man/man8/netflector.8.gz
 
 post-install:
+	${INSTALL_DATA} ${FILESDIR}/netflector.toml.sample ${STAGEDIR}${PREFIX}/etc
 	${INSTALL_MAN} ${WRKSRC}/man/netflector.8 ${STAGEDIR}${PREFIX}/share/man/man8
 	${INSTALL_MAN} ${WRKSRC}/man/netflector.toml.5 ${STAGEDIR}${PREFIX}/share/man/man5
 

--- a/dist/freebsd/net/netflector/files/netflector.toml.sample
+++ b/dist/freebsd/net/netflector/files/netflector.toml.sample
@@ -1,0 +1,33 @@
+# netflector configuration; netflector.toml(5) documents every key.
+#
+# Nothing below is enabled, so the daemon refuses to start until you uncomment an entry and name
+# your own interfaces. Check your work with
+# `netflector --check-config /usr/local/etc/netflector.toml`.
+
+# off, error, warn, info, debug, or trace. trace is compiled out and behaves as debug.
+#log_level = "info"
+
+# Seconds between per-interface packet-counter summaries in the log. 0 disables them.
+#counters_interval_secs = 0
+
+# One entry per interface pair, named by its label in the log. Clients on source_if discover and
+# reach the devices on target_if; the other direction is not exposed, so add a second entry to
+# reverse it.
+#[reflectors.tv]
+#source_if = "em0"
+#target_if = "em1"
+#
+# Limit the entry to these devices on target_if. Omit for the whole segment.
+#macs = ["b0:37:95:c5:60:be"]
+#
+# At least one of wol, mdns, ssdp and wsd, in any mix. All default false.
+#wol = true                         # Wake-on-LAN magic packets
+#mdns = true                        # Bonjour, AirPlay
+#ssdp = true                        # UPnP, DLNA
+#wsd = true                         # WS-Discovery: ONVIF cameras, Windows printers
+#
+# dial layers onto ssdp rather than standing alone, and DIAL is IPv4-only.
+#dial = true                        # cast-to-TV app launch
+#
+#wol_ports = [7, 9]                 # only with wol
+#address_family = "default"         # default, dual, ipv4, or ipv6

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -20,7 +20,7 @@ Each entry exposes the devices on its
 .Ic target_if
 to the clients on its
 .Ic source_if ,
-for any combination of the protocols; the other direction is not exposed.
+for one or more of the protocols; the other direction is not exposed.
 No IP addresses appear anywhere in the configuration; interfaces are named,
 and their addresses are resolved at runtime.
 An unknown key, at the top level or in an entry, is rejected at startup.


### PR DESCRIPTION
`pkg install netflector` left nothing to start from: the rc service refuses without `/usr/local/etc/netflector.toml`, and the port shipped no template. Verified on a FreeBSD 15 VM before the change, where a fresh install has neither the config nor a sample.

`@sample` installs `netflector.toml.sample` and copies it to `netflector.toml` when that is absent. Everything in it is commented out, deliberately: an uncommented sample would pass `--check-config` (which never opens an interface) and then start a daemon aimed at `em0`/`em1`, failing confusingly at runtime. Commented, a premature start fails in precmd with `must define at least one reflector`, which names exactly what to do.

It lives in `files/` rather than the repository root because the port builds `GH_TAGNAME=v0.14.0`, so anything added to the repo would not reach the package until the next release.

The second commit corrects a claim the sample inherited from the docs: the README said twice and the man page once that an entry enables "any combination" of the protocols. Four combinations are rejected, and `dial` is not one of the protocols at all.

No `PORTREVISION` bump, so this publishes nothing on merge; the sample ships with the next port release.

## Testing

On an OPNsense 26.7 VM (FreeBSD 15.1, aarch64), against a package built with the exact new plist line:

- fresh install materialises both `netflector.toml.sample` and `netflector.toml`
- `service netflector start` fails with `must define at least one reflector` / `refusing to start: ... is not valid`
- uncommenting the entry with the box's real interfaces gives `config ok: 1 reflector` and a running daemon
- `pkg which` confirms only the `.sample` is package-owned; deinstall keeps an edited `netflector.toml` and removes an untouched one

Also checked the sample is valid TOML and that fully uncommenting it validates. `@sample` needs the ports Keywords directory at `pkg create` time, which the real port build has; the test used the upstream `sample.ucl` fetched from FreeBSD cgit.