### PR TITLE
opnsense: stop netflector when its CARP virtual IP is deleted

### DIFF
--- a/dist/opnsense/net/netflector/src/etc/rc.syshook.d/carp/20-netflector
+++ b/dist/opnsense/net/netflector/src/etc/rc.syshook.d/carp/20-netflector
@@ -43,8 +43,10 @@ use OPNsense\Interfaces\Vip;
 $subsystem = $argv[1] ?? '';
 $type = $argv[2] ?? '';
 
-/* INIT is a transient on the way to MASTER or BACKUP; acting on it would start and stop needlessly. */
-if (!in_array($type, ['MASTER', 'BACKUP'], true) || strpos($subsystem, '@') === false) {
+/* INIT is not only the transient on the way to MASTER or BACKUP: it is also where a group ends up
+ * when its virtual IP is deleted, which is the moment reflection has to stop. It means "not MASTER"
+ * either way, so it is paired with BACKUP here. */
+if (!in_array($type, ['MASTER', 'BACKUP', 'INIT'], true) || strpos($subsystem, '@') === false) {
     exit(0);
 }
 
@@ -60,6 +62,13 @@ require_once('config.inc');
 require_once('util.inc');
 require_once('interfaces.inc');
 
+/* Stopping a service that is not running reports a failure, which reads as a fault of ours.
+ * BACKUP and INIT both arrive routinely while it is already stopped. */
+function netflector_running()
+{
+    return mwexecf('/usr/local/etc/rc.d/netflector %s', ['status'], true) === 0;
+}
+
 /* carp_depend_on holds the VIP's uuid; the event carries "<vhid>@<interface>", so resolve one to the
  * other. Both halves are compared: the same vhid can run on several interfaces as unrelated groups. */
 $group = null;
@@ -69,10 +78,29 @@ foreach ((new Vip())->vip->iterateItems() as $uuid => $vip) {
         break;
     }
 }
-if ($group === null || $group !== $subsystem) {
+
+/* The VIP was deleted or is no longer carp, so this node's role is unknowable. Stop rather than
+ * leave it reflecting, which on a pair is what the dependency exists to prevent. */
+if ($group === null) {
+    $running = netflector_running();
+    log_msg(sprintf(
+        'carp_depend_on names no CARP virtual IP; %s',
+        $running ? 'stopping netflector' : 'netflector is not running'
+    ), LOG_ERR);
+    if ($running) {
+        mwexecf('/usr/local/etc/rc.d/netflector %s', ['stop']);
+    }
+    exit(0);
+}
+
+if ($group !== $subsystem) {
     exit(0);
 }
 
 $action = $type === 'MASTER' ? 'start' : 'stop';
+if ($action === 'stop' && !netflector_running()) {
+    exit(0);
+}
+
 log_msg(sprintf('CARP %s is %s, running netflector %s', $subsystem, $type, $action));
 mwexecf('/usr/local/etc/rc.d/netflector %s', [$action]);

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
@@ -78,6 +78,16 @@ class Netflector extends BaseModel
             }
         }
 
+        // Checked even when the field was not edited: what invalidates it is deleting the virtual IP
+        // on another page, so it goes stale without anyone touching this form.
+        $depends_on = (string)$this->general->carp_depend_on;
+        if ($depends_on !== '' && !$this->carpVipExists($depends_on)) {
+            $messages->appendMessage(new Message(
+                gettext('The selected CARP virtual IP no longer exists.'),
+                'netflector.general.carp_depend_on'
+            ));
+        }
+
         // Nothing enabled is a legal configuration, not an error: the rc.conf.d template arms the
         // service only when the switch is on AND an entry is on, so Apply stops the daemon and the
         // status widget reads "disabled". Rejecting it here instead would mean the last reflector
@@ -171,6 +181,21 @@ class Netflector extends BaseModel
                 $ref . '.wol_ports'
             ));
         }
+    }
+
+    /**
+     * Whether `$uuid` still names a CARP virtual IP. VirtualIPField offers only the ones that exist
+     * when the form is drawn, but the value it stored outlives the virtual IP itself.
+     */
+    private function carpVipExists($uuid)
+    {
+        foreach ((new \OPNsense\Interfaces\Vip())->vip->iterateItems() as $key => $vip) {
+            if ($key === $uuid && (string)$vip->mode === 'carp') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/rc.conf.d
+++ b/dist/opnsense/net/netflector/src/opnsense/service/templates/OPNsense/Netflector/rc.conf.d
@@ -19,14 +19,23 @@ netflector_enable="NO"
 {% endif %}
 {# The rc script gates on a vhid, not on the model's VIP uuid. The interface goes with it because the
    same vhid can run on several interfaces as unrelated groups. #}
+{% set group = [] %}
 {% if helpers.exists('OPNsense.Netflector.general.carp_depend_on') and OPNsense.Netflector.general.carp_depend_on != '' %}
 {%   if helpers.exists('virtualip.vip') %}
 {%     for vip in helpers.toList('virtualip.vip') %}
 {%       if vip['@uuid'] == OPNsense.Netflector.general.carp_depend_on and vip.mode == 'carp' %}
-netflector_carp_vhid="{{ vip.vhid }}"
-netflector_carp_interface="{{ physical_interface(vip.interface) }}"
+{%         do group.append(vip) %}
 {%         break %}
 {%       endif %}
 {%     endfor %}
+{%   endif %}
+{%   if group %}
+netflector_carp_vhid="{{ group[0].vhid }}"
+netflector_carp_interface="{{ physical_interface(group[0].interface) }}"
+{%   else %}
+{#   Rendering nothing would leave the gate inert and reflect anyway. A vhid no group can ever be
+     named refuses instead, and reads as the sentinel it is in the rc script's warning. #}
+# carp_depend_on names no CARP virtual IP; refusing to start rather than reflecting on both nodes.
+netflector_carp_vhid="unknown"
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
The CARP dependency shipped in 0.1.3 failed open. Deleting the virtual IP it names left every guard inert, so the node went on reflecting: exactly the double-reflection the dependency exists to prevent, reached by an ordinary action on another page.

Three defects, found by walking the deletion through the GUI rather than reading the code:

**The template rendered no gate.** With the dependency unresolvable the loop matched nothing and emitted neither `netflector_carp_vhid` nor `netflector_carp_interface`, so the rc script had nothing to check and started the daemon. It now renders `netflector_carp_vhid="unknown"`, which no group can match, and says why in the generated file. The refusal reads `CARP vhid unknown is not MASTER here` rather than naming a number that looks real.

**The syshook ignored INIT.** INIT is not only the transient on the way to MASTER or BACKUP, it is also where a group ends up when its virtual IP is deleted, which is precisely when reflection has to stop. Confirmed in the log: deleting the VIP logs `carp: 7@vtnet0: MASTER -> INIT`. INIT is now paired with BACKUP as "not MASTER", as core's ppp hook pairs them, so a deletion stops the daemon immediately instead of waiting for someone to press Apply. A dependency that resolves to nothing stops it too, rather than exiting quietly.

**Nothing told the operator.** `VirtualIPField` only offers virtual IPs that exist when the form is drawn, but the value it stored outlives the virtual IP, so the model now reports a stale dependency against its own field instead of leaving Apply to fail with only a restart error.

A helper keeps every stop conditional on the service actually running: BACKUP and INIT both arrive routinely while it is stopped, and an unconditional stop logs a failure that reads like a fault of ours.

No `PLUGIN_VERSION` bump; this rides with the other queued plugin work.

## Testing

On OPNsense 26.7 (FreeBSD 15.1, aarch64), with the virtual IP deleted through the GUI rather than the API:

- deletion alone stopped the daemon, logging `carp_depend_on names no CARP virtual IP; stopping netflector`
- the Netflector form reported "The selected CARP virtual IP no longer exists." against the CARP field
- a stale gate naming the old vhid still refuses, so failing closed does not depend on the template having regenerated
- normal MASTER/BACKUP failover, and the no-dependency case, are unchanged

Also checked that the sentinel cannot collide: `carp_is_master` returns false for it with and without an interface scope, while real vhids still match, and that the template's list-append is required, since a `{% set %}` rebound inside a Jinja loop is discarded at `endfor`.