### PR TITLE
opnsense: let the daemon veto an Apply before it stops the service

### DIFF
--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/views/OPNsense/Netflector/index.volt
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/views/OPNsense/Netflector/index.volt
@@ -43,27 +43,53 @@
             updateServiceControlUI('netflector');
         });
 
+        // Both ways an Apply is refused end here. The lines are set as text, not markup: they carry
+        // configured values, and the daemon's own wording, back to the page.
+        function refuseApply(dfObj, lines) {
+            const body = $('<div/>');
+            $.each(lines, function(index, line) {
+                body.append($('<p/>').text(line));
+            });
+            BootstrapDialog.show({
+                type: BootstrapDialog.TYPE_DANGER,
+                title: '{{ lang._('Netflector') }}',
+                message: body,
+                buttons: [{
+                    label: '{{ lang._('Close') }}',
+                    action: function(dialog) { dialog.close(); }
+                }]
+            });
+            dfObj.reject();
+        }
+
         $("#reconfigureAct").SimpleActionButton({
             onPreAction: function() {
                 const dfObj = $.Deferred();
-                saveFormToEndpoint("/api/netflector/settings/set", 'frm_GeneralSettings', dfObj.resolve, true,
+                saveFormToEndpoint("/api/netflector/settings/set", 'frm_GeneralSettings',
+                    function() {
+                        // The model's rules mirror the daemon's and can drift from them, and the
+                        // reconfigure that follows stops the running daemon before starting the new
+                        // one. Ask the daemon about the candidate first, so a configuration it
+                        // rejects leaves the old one running instead of nothing at all.
+                        ajaxCall("/api/netflector/service/check", {}, function(data) {
+                            // Only a rejection blocks: "idle" means nothing is enabled, which has to
+                            // apply, or the last reflector could never be removed.
+                            if (data['status'] === 'failed') {
+                                refuseApply(dfObj, (data['message'] || '{{ lang._('The daemon rejected the configuration.') }}').split('\n'));
+                            } else {
+                                dfObj.resolve();
+                            }
+                        });
+                    },
+                    true,
                     function(data) {
                         let messages = [];
                         $.each(data['validations'] || {}, function(field, message) {
                             messages.push(message);
                         });
-                        BootstrapDialog.show({
-                            type: BootstrapDialog.TYPE_DANGER,
-                            title: '{{ lang._('Netflector') }}',
-                            message: messages.length
-                                ? messages.join('<br/><br/>')
-                                : '{{ lang._('The configuration could not be saved.') }}',
-                            buttons: [{
-                                label: '{{ lang._('Close') }}',
-                                action: function(dialog) { dialog.close(); }
-                            }]
-                        });
-                        dfObj.reject();
+                        refuseApply(dfObj, messages.length
+                            ? messages
+                            : ['{{ lang._('The configuration could not be saved.') }}']);
                     }
                 );
                 return dfObj;


### PR DESCRIPTION
Apply saved the form, regenerated `netflector.toml` over the live one, and left upstream's reconfigure to stop the daemon before starting it. Nothing in between asked whether the new configuration would actually load. A configuration the model accepts but the daemon rejects therefore cost both the running daemon and the file it had been running from, from a single button press.

The plugin already had every piece. `check.py` renders the configuration into a throwaway root and validates *that*, so checking never rewrites the file a restart would load, and `/api/netflector/service/check` exposes it for the Validate button. Apply simply never called it. It now does, after the save and before the reconfigure, and refuses on a rejection.

Only a rejection blocks. `check.py` also answers `idle` when nothing is enabled, which is a switched-off configuration rather than a broken one and still has to apply, or the last reflector could never be removed.

The model's rules remain a mirror of the daemon's, and this does not change that: the point is that when the mirror drifts, the drift costs a dialog instead of an outage.

Both refusal paths now build the dialog body from text nodes rather than joining strings into markup. Those messages carry configured values and the daemon's own wording, which have no business being parsed as HTML; it also renders the daemon's multi-line output properly.

## Testing

On OPNsense 26.7 (FreeBSD 15.1, aarch64), with drift simulated by a wrapper whose `--check-config` rejects everything:

- Apply showed the daemon's own message, and the daemon kept running on the same pid with its live configuration untouched, where previously the reconfigure would have stopped it and replaced the file
- with the wrapper removed, `ok` applies normally
- with every reflector disabled, `idle` applies rather than blocking

The Volt script block was extracted, its template expressions substituted, and syntax-checked with `node --check`; the check was confirmed to reject a deliberately broken copy first, since the first attempt had silently checked an empty file.