### PR TITLE
opnsense: offer the configuration to HA config sync

### DIFF
--- a/dist/opnsense/net/netflector/src/etc/inc/plugins.inc.d/netflector.inc
+++ b/dist/opnsense/net/netflector/src/etc/inc/plugins.inc.d/netflector.inc
@@ -61,6 +61,21 @@ function netflector_syslog()
     return ['netflector' => ['facility' => ['netflector']]];
 }
 
+function netflector_xmlrpc_sync()
+{
+    return [[
+        'description' => gettext('Netflector'),
+        'help' => gettext(
+            'Synchronize the netflector configuration to the other HA host. Include Virtual IPs as ' .
+            'well if a CARP dependency is set: it is stored as the virtual IP\'s identifier, which ' .
+            'only means anything on a host that has that virtual IP.'
+        ),
+        'id' => 'netflector',
+        'section' => 'OPNsense.Netflector',
+        'services' => ['netflector'],
+    ]];
+}
+
 function netflector_services()
 {
     $services = [];


### PR DESCRIPTION
An HA pair had to have its reflectors entered twice, once per node, with nothing keeping them in step. Registering the section makes Netflector a tick box under System: High Availability, beside the CARP dependency that already decides which node may act on the configuration.

The help text asks for Virtual IPs to be synced as well when a CARP dependency is set. That dependency stores the virtual IP's identifier rather than its address, so it only resolves on a host that has the same virtual IP.

## Testing

Two OPNsense 26.7 nodes on a shared L2 segment, which is new: the existing VMs each have their own isolated slirp network, so CARP could never elect between them and every previous test was single-node with events driven by hand. A second node was cloned and the pair joined with a QEMU socket link, giving a real broadcast domain.

On that pair, driven from the GUI:

- the configuration synced from master to backup, and the backup regenerated `netflector.toml` from **its own** interface assignments, so the logical `lan`/`wan` names resolve per node rather than shipping the master's device names
- the virtual IP's identifier survived the sync unchanged on both nodes, which is what makes the CARP dependency resolve on the backup
- with the dependency set, the master ran and the backup refused with `CARP vhid 1 is not MASTER here`, so both nodes held identical configuration and only one acted on it
- a real failover moved reflection to the surviving node and back, each transition driven by the syshook, with no window where both were reflecting

Two behaviours worth recording for whoever reads this next. A plain synchronize ships configuration only; template reload and service restart sit behind `restart_services`, which is the "Synchronize and restart all services" action. And `rc.filter_synchronize` never reads the `services` key: it iterates the peer's own service list. The key is set because every plugin sets it, not because it drives the restart.