### PR TITLE
opnsense: show what each reflector relays, and fix the grid's bulk toggle

### DIFF
--- a/ci/opnsense-exercise.sh
+++ b/ci/opnsense-exercise.sh
@@ -27,4 +27,7 @@ case "$verdict" in
 *) echo "the configd check action did not report ok" >&2; exit 1 ;;
 esac
 
-"$HERE"/freebsd-vm.sh run 'service netflector start && sleep 2 && service netflector status'
+# restart, not start: freebsd-vm.sh wait only waits for sshd, so the plugin can be installed while
+# the boot is still running. Whether the boot reaches its service phase before or after the plugin
+# writes rc.conf.d decides whether the daemon is already up by now, and start fails when it is.
+"$HERE"/freebsd-vm.sh run 'service netflector restart && sleep 2 && service netflector status'

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/SettingsController.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/SettingsController.php
@@ -77,7 +77,7 @@ class SettingsController extends ApiMutableModelControllerBase
      * enabling an entry can collide with an already-active one (same interface pair, overlapping
      * protocols or devices), and that pair rule lives in the model's validation.
      */
-    public function toggleReflectorAction($uuid, $enabled = null)
+    public function toggleReflectorAction($uuids, $enabled = null)
     {
         if (!$this->request->isPost()) {
             return ['result' => 'failed'];
@@ -85,20 +85,39 @@ class SettingsController extends ApiMutableModelControllerBase
 
         Config::getInstance()->lock();
         $model = $this->getModel();
-        $node = $model->getNodeByReference('reflectors.reflector.' . $uuid);
-        if ($node === null) {
-            return ['result' => 'failed'];
+
+        // The grid's "Enable selected" sends every checked row as one comma-joined request, so this
+        // takes a list like toggleBase does. Flipping is only defined for a single entry: a list has
+        // no shared previous state to flip from, which is why the grid always sends 0 or 1 with one.
+        $uuids = !empty($uuids) ? explode(',', $uuids) : [];
+        if (count($uuids) > 1 && $enabled === null) {
+            throw new UserException(
+                gettext('Toggling a list of entries needs an explicit enabled state.'),
+                gettext('Netflector')
+            );
         }
 
-        // Three cases, as toggleBase has them: an explicit 0 or 1 sets that value, no value at all flips,
-        // and anything else is a malformed request that must not touch the entry.
-        $was = (string)$node->enabled;
-        if ($enabled === '0' || $enabled === '1') {
-            $node->enabled = (string)$enabled;
-        } elseif ($enabled === null) {
-            $node->enabled = $was === '1' ? '0' : '1';
-        } else {
-            return ['result' => 'failed', 'changed' => false];
+        $changed = false;
+        $result = 'failed';
+        foreach ($uuids as $uuid) {
+            $node = $model->getNodeByReference('reflectors.reflector.' . $uuid);
+            if ($node === null) {
+                continue;
+            }
+
+            // Three cases, as toggleBase has them: an explicit 0 or 1 sets that value, no value at all
+            // flips, and anything else is a malformed request that must not touch the entry.
+            $was = (string)$node->enabled;
+            if ($enabled === '0' || $enabled === '1') {
+                $node->enabled = (string)$enabled;
+            } elseif ($enabled === null) {
+                $node->enabled = $was === '1' ? '0' : '1';
+            } else {
+                return ['result' => 'failed', 'changed' => false];
+            }
+
+            $changed = $changed || (string)$node->enabled !== $was;
+            $result = (string)$node->enabled === '1' ? 'Enabled' : 'Disabled';
         }
 
         // A UserException, not a 'failed' result: the grid has no field to hang a validation message on,
@@ -114,9 +133,6 @@ class SettingsController extends ApiMutableModelControllerBase
 
         $this->save();
 
-        return [
-            'result' => (string)$node->enabled === '1' ? 'Enabled' : 'Disabled',
-            'changed' => (string)$node->enabled !== $was,
-        ];
+        return ['result' => $result, 'changed' => $changed];
     }
 }

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/SettingsController.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/controllers/OPNsense/Netflector/Api/SettingsController.php
@@ -46,7 +46,10 @@ class SettingsController extends ApiMutableModelControllerBase
     {
         return $this->searchBase(
             'reflectors.reflector',
-            ['enabled', 'name', 'source_if', 'target_if', 'description']
+            [
+                'enabled', 'name', 'source_if', 'target_if', 'description',
+                'wol', 'mdns', 'ssdp', 'dial', 'wsd', 'address_family',
+            ]
         );
     }
 

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/models/OPNsense/Netflector/Netflector.php
@@ -184,6 +184,17 @@ class Netflector extends BaseModel
     }
 
     /**
+     * An entry by name, for a message that has to stand on its own. Falls back for the entry being
+     * added, which has no name until it is saved.
+     */
+    private static function describe($entry)
+    {
+        $name = trim((string)$entry->name);
+
+        return $name !== '' ? sprintf(gettext('"%s"'), $name) : gettext('This entry');
+    }
+
+    /**
      * Whether `$uuid` still names a CARP virtual IP. VirtualIPField offers only the ones that exist
      * when the form is drawn, but the value it stored outlives the virtual IP itself.
      */
@@ -217,15 +228,15 @@ class Netflector extends BaseModel
 
         $protocol = self::conflictingProtocol($a, $b);
         if ($protocol !== null) {
-            $other = (string)$a->name !== ''
-                ? sprintf(gettext('"%s"'), (string)$a->name)
-                : gettext('another entry');
+            // Both entries are named rather than one being "this entry": enabling several at once
+            // reports through a dialog that carries the text alone, with no field to point at.
             $messages->appendMessage(new Message(
                 sprintf(
-                    gettext('This entry would reflect %s between the same interfaces as %s, for overlapping ' .
+                    gettext('%s would reflect %s between the same interfaces as %s, for overlapping ' .
                             'devices and address families, so each packet would be reflected twice.'),
+                    self::describe($b),
                     $protocol,
-                    $other
+                    self::describe($a)
                 ),
                 $b->__reference . '.source_if'
             ));

--- a/dist/opnsense/net/netflector/src/opnsense/mvc/app/views/OPNsense/Netflector/index.volt
+++ b/dist/opnsense/net/netflector/src/opnsense/mvc/app/views/OPNsense/Netflector/index.volt
@@ -138,6 +138,15 @@
                     <th data-column-id="source_if" data-type="string">{{ lang._('Source') }}</th>
                     <th data-column-id="target_if" data-type="string">{{ lang._('Target') }}</th>
                     <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
+                    <!-- What an entry reflects, which otherwise means opening every row in turn.
+                         Read-only: the protocols constrain each other (dial needs ssdp and an
+                         IPv4-capable family), so a single cell is the wrong place to change one. -->
+                    <th data-column-id="wol" data-type="string" data-width="5em" data-formatter="boolean">{{ lang._('WoL') }}</th>
+                    <th data-column-id="mdns" data-type="string" data-width="5em" data-formatter="boolean">{{ lang._('mDNS') }}</th>
+                    <th data-column-id="ssdp" data-type="string" data-width="5em" data-formatter="boolean">{{ lang._('SSDP') }}</th>
+                    <th data-column-id="dial" data-type="string" data-width="5em" data-formatter="boolean">{{ lang._('DIAL') }}</th>
+                    <th data-column-id="wsd" data-type="string" data-width="5em" data-formatter="boolean">{{ lang._('WSD') }}</th>
+                    <th data-column-id="address_family" data-type="string" data-width="8em">{{ lang._('IP family') }}</th>
                     <th data-column-id="uuid" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 </tr>


### PR DESCRIPTION
Three changes to the Reflectors list, found while building the first.

**The bulk toggle never worked.** "Enable selected" and "Disable selected" send every checked row as a single comma-joined request, and the action read that as one identifier, found nothing under it, and returned failed: nothing happened and nothing said why. Overriding `toggleBase` to run the pair-collision validation is what dropped the list handling, so this takes it back, including core's rule that flipping is only defined for a single entry, since a list has no shared previous state to flip from. The validation that motivated the override still runs.

**The collision message never named the entry at fault.** It said "this entry", which the edit dialog makes obvious by anchoring the message to a field, but enabling several entries at once reports through a dialog carrying the text alone. It now reads `"cams" would reflect WS-Discovery between the same interfaces as "tv"…`. A new entry has no name until it is saved, so that case still says "This entry", where the dialog does point at the row.

**The grid now shows what an entry relays.** Six columns, WoL, mDNS, SSDP, DIAL, WSD and the address family, so the protocols are visible without opening every row. They come from the same search the grid already makes, widened to return those fields. Read-only on purpose: the protocols constrain each other, `dial` requiring `ssdp` and an IPv4-capable family, so a single cell is the wrong place to change one, and inline edits would also bypass the validate-before-apply path.

## Testing

On an OPNsense 26.7 VM with two reflectors, one relaying mDNS/SSDP/DIAL on `dual` and one WS-Discovery on `ipv4`:

- every field the grid asks for resolves on the model, so no column renders empty from a typo
- the collision message names both entries, verified by making the two entries collide and validating
- the bulk disable took effect on both rows, which is what surfaced the bug in the first place

The columns use core's own `boolean` formatter rather than a custom one, and the JS was syntax-checked after each change.