### PR TITLE
reflector: suppress messages advertising only link-local addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,15 @@ mDNS is relayed as pure multicast. A querier that asks for a unicast answer (the
 from an ephemeral source port) is answered off the group, and that answer is not relayed; SSDP and WSD
 instead proxy each searcher's unicast reply.
 
+Messages that advertise only link-local addresses (`169.254.0.0/16`, `fe80::/10`) are dropped rather
+than relayed: an mDNS response whose A/AAAA records are all link-local, an SSDP advertisement or
+search reply whose `LOCATION` names one, a WSD message whose `XAddrs` all name one. Such an address
+is valid only on the link it came from, so the relayed message would advertise endpoints the other
+segment can never reach. One routable address among them lets the message through. A `LOCATION` the
+DIAL proxy rewrote is exempt: it names netflector's own listener on the egress interface, reachable
+from that link even when the interface's address is itself link-local. Suppressed messages tally as
+`dropped` and log at debug level.
+
 netflector reads untagged Ethernet frames carrying IPv4 or IPv6 UDP. VLAN-tagged frames and IPv6
 extension headers are not parsed, so configure the VLAN as its own interface (`vlan10`, `em0.10`) and
 name that as the entry's `source_if` / `target_if` rather than the trunk.

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -59,6 +59,19 @@ MDNS_QUERY_HEX = "00000000000100000000000074657374"
 MDNS_RESPONSE_HEX = "00008400000100010000000074657374"
 # 8 bytes: below the 12-byte DNS-header minimum, so classify() returns None and drops it.
 MDNS_SHORT_QUERY_HEX = "0000000000010000"
+# Well-formed responses for the link-local suppression: QR+AA header, ANCOUNT=2, both answers under
+# the name "x." (each record: 3-byte name, TYPE, IN, TTL 120, RDLENGTH, rdata). A response is
+# suppressed only when every A/AAAA it carries is link-local; one routable address rescues it.
+MDNS_RESPONSE_MIXED_HEX = (
+    "000084000000000200000000"  # header
+    "01780000010001000000780004a9fe0102"  # A x. -> 169.254.1.2 (link-local)
+    "01780000010001000000780004c0a80909"  # A x. -> 192.168.9.9 (routable)
+)
+MDNS_RESPONSE_LINK_LOCAL_HEX = (
+    "000084000000000200000000"  # header
+    "01780000010001000000780004a9fe0102"  # A x. -> 169.254.1.2
+    "017800001c0001000000780010fe800000000000000000000000000001"  # AAAA x. -> fe80::1
+)
 # --- SSDP (UPnP discovery, HTTPU): multicast group 239.255.255.250 / ff02::c on UDP 1900. ---
 SSDP_GROUP_V4 = "239.255.255.250"
 SSDP_GROUP_V6 = "ff02::c"
@@ -91,6 +104,22 @@ SSDP_NOTIFY_HEX = (
     "HOST: 239.255.255.250:1900\r\n"
     "NT: upnp:rootdevice\r\n"
     "NTS: ssdp:alive\r\n\r\n"
+).encode().hex()
+# LOCATION variants for the link-local suppression: an advertisement whose LOCATION names a
+# link-local literal is suppressed; a routable literal reflects.
+SSDP_NOTIFY_ROUTABLE_LOCATION_HEX = (
+    "NOTIFY * HTTP/1.1\r\n"
+    "HOST: 239.255.255.250:1900\r\n"
+    "NT: upnp:rootdevice\r\n"
+    "NTS: ssdp:alive\r\n"
+    "LOCATION: http://192.168.9.9:1900/desc.xml\r\n\r\n"
+).encode().hex()
+SSDP_NOTIFY_LINK_LOCAL_LOCATION_HEX = (
+    "NOTIFY * HTTP/1.1\r\n"
+    "HOST: 239.255.255.250:1900\r\n"
+    "NT: upnp:rootdevice\r\n"
+    "NTS: ssdp:alive\r\n"
+    "LOCATION: http://169.254.9.9:1900/desc.xml\r\n\r\n"
 ).encode().hex()
 # A search response that strayed onto the group: neither M-SEARCH nor NOTIFY, so netflector
 # classifies it as non-SSDP and drops it.
@@ -142,6 +171,35 @@ WSD_HELLO_HEX = (
     "<d:Types>dn:NetworkVideoTransmitter</d:Types><d:MetadataVersion>1</d:MetadataVersion>"
     "</d:Hello></s:Body></s:Envelope>"
 ).encode().hex()
+
+
+# A Hello carrying the given XAddrs, for the link-local suppression: suppressed only when every
+# XAddrs URI names a link-local literal. (WSD_HELLO_HEX above has no XAddrs at all and must keep
+# reflecting; resolution then happens via Resolve.)
+def wsd_hello_with_xaddrs(xaddrs: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
+        ' xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"'
+        ' xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">'
+        "<s:Header>"
+        "<a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Hello</a:Action>"
+        "<a:MessageID>urn:uuid:hello-0002</a:MessageID>"
+        "<a:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>"
+        "</s:Header>"
+        "<s:Body><d:Hello>"
+        "<a:EndpointReference><a:Address>urn:uuid:camera-0001</a:Address></a:EndpointReference>"
+        "<d:Types>dn:NetworkVideoTransmitter</d:Types>"
+        f"<d:XAddrs>{xaddrs}</d:XAddrs>"
+        "<d:MetadataVersion>1</d:MetadataVersion>"
+        "</d:Hello></s:Body></s:Envelope>"
+    ).encode().hex()
+
+
+WSD_HELLO_MIXED_XADDRS_HEX = wsd_hello_with_xaddrs(
+    "http://[fe80::1]:5357/dev http://192.168.9.9:5357/dev"
+)
+WSD_HELLO_LINK_LOCAL_XADDRS_HEX = wsd_hello_with_xaddrs("http://169.254.7.7:5357/dev")
 WSD_BYE_HEX = (
     '<?xml version="1.0" encoding="utf-8"?>'
     '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
@@ -419,6 +477,29 @@ MDNS_CASES = [
         family=6,
         direction="reverse",
     ),
+    # A routable address beside the link-local one rescues the response from suppression.
+    TestCase(
+        name="reflects_mdns_response_with_mixed_addresses",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=MDNS_RESPONSE_MIXED_HEX,
+        expect_payload_hex=MDNS_RESPONSE_MIXED_HEX,
+        group=MDNS_GROUP_V4,
+        direction="reverse",
+    ),
+    # Every address is link-local, so the response is suppressed rather than relayed.
+    TestCase(
+        name="ignores_mdns_link_local_only_response",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=MDNS_RESPONSE_LINK_LOCAL_HEX,
+        group=MDNS_GROUP_V4,
+        direction="reverse",
+    ),
     # A query sent target->source hits the target's response-only handler and is dropped.
     TestCase(
         name="ignores_mdns_query_in_response_direction",
@@ -529,6 +610,28 @@ SSDP_CASES = [
         timeout_seconds=5.0,
         send_payload_hex=SSDP_NOTIFY_HEX,
         expect_payload_hex=SSDP_NOTIFY_HEX,
+        group=SSDP_GROUP_V4,
+        direction="reverse",
+    ),
+    # A routable LOCATION literal reflects; a link-local one is suppressed rather than relayed.
+    TestCase(
+        name="reflects_ssdp_notify_with_routable_location",
+        send_port=SSDP_PORT,
+        receive_port=SSDP_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SSDP_NOTIFY_ROUTABLE_LOCATION_HEX,
+        expect_payload_hex=SSDP_NOTIFY_ROUTABLE_LOCATION_HEX,
+        group=SSDP_GROUP_V4,
+        direction="reverse",
+    ),
+    TestCase(
+        name="ignores_ssdp_link_local_location_notify",
+        send_port=SSDP_PORT,
+        receive_port=SSDP_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=SSDP_NOTIFY_LINK_LOCAL_LOCATION_HEX,
         group=SSDP_GROUP_V4,
         direction="reverse",
     ),
@@ -674,6 +777,31 @@ WSD_CASES = [
         timeout_seconds=5.0,
         send_payload_hex=WSD_BYE_HEX,
         expect_payload_hex=WSD_BYE_HEX,
+        group=WSD_GROUP_V4,
+        direction="reverse",
+    ),
+    # A routable XAddrs URI beside the link-local one rescues the Hello from suppression.
+    TestCase(
+        name="reflects_wsd_hello_with_mixed_xaddrs",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=WSD_HELLO_MIXED_XADDRS_HEX,
+        expect_payload_hex=WSD_HELLO_MIXED_XADDRS_HEX,
+        group=WSD_GROUP_V4,
+        direction="reverse",
+    ),
+    # Every XAddrs URI is link-local, so the Hello is suppressed rather than relayed.
+    TestCase(
+        name="ignores_wsd_link_local_only_xaddrs",
+        config="config-wsd.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=WSD_HELLO_LINK_LOCAL_XADDRS_HEX,
         group=WSD_GROUP_V4,
         direction="reverse",
     ),

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -167,8 +167,9 @@ Re-emitted on the other interface.
 Recognized, but arrived in a direction the entry does not relay.
 This is normal; it is also what keeps reflected packets from looping.
 .It Sy dropped
-Should have been reflected, but the re-emit failed: a send error or a
-resource cap.
+Should have been reflected, but was not: a send error, a resource cap, or a
+message advertising only link-local addresses, which the other segment could
+never reach.
 .It Sy stalled
 Should have been reflected, but the egress interface had no source address
 of the packet's family yet.

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -98,7 +98,8 @@ pub(crate) enum Outcome {
     Reflected(MessageType),
     /// Recognized, but the wrong direction for this leg: the loop-breaker, not ours to forward.
     Skipped(MessageType),
-    /// The right direction, but the re-emit failed (a send error or a resource cap).
+    /// The right direction, but not re-emitted: a send error, a resource cap, or the link-local
+    /// suppression.
     Dropped(MessageType),
     /// The right direction, but the egress has no source address of the family yet (transient).
     Stalled(MessageType),

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,6 +1,8 @@
 //! The wire layer: on-the-wire packet formats. Link-layer framing, IP/UDP
 //! checksums, building and parsing frames.
 
+use std::net::IpAddr;
+
 mod checksum;
 pub(crate) mod frame;
 pub(crate) mod http;
@@ -54,3 +56,27 @@ pub(crate) const MAX_FRAME_LEN: usize = 2048;
 /// IPv4, and fixed at 40 since the builders emit no extension headers) plus UDP.
 pub(crate) const MAX_UDP_PAYLOAD_LEN: usize =
     MAX_FRAME_LEN - (ETHERNET_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE);
+
+/// Whether `ip` is link-local (IPv4 `169.254.0.0/16`, IPv6 `fe80::/10`).
+pub(crate) fn is_link_local(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_link_local(),
+        IpAddr::V6(v6) => v6.is_unicast_link_local(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_local_covers_both_families_and_nothing_routable() {
+        assert!(is_link_local("169.254.7.9".parse().unwrap()));
+        assert!(is_link_local("fe80::1".parse().unwrap()));
+        assert!(!is_link_local("192.168.1.1".parse().unwrap()));
+        assert!(!is_link_local("2001:db8::1".parse().unwrap()));
+        // Adjacent special ranges don't leak in: loopback and unique-local are not link-local.
+        assert!(!is_link_local("127.0.0.1".parse().unwrap()));
+        assert!(!is_link_local("fd00::1".parse().unwrap()));
+    }
+}

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -4,7 +4,7 @@
 
 pub(crate) mod framing;
 
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4};
 
 /// A parsed HTTP authority plus the byte span (`offset`/`len`) of its `host[:port]` text within the
 /// source value, so a caller splices a replacement over exactly that span. HTTP/DIAL rewrites are
@@ -50,6 +50,32 @@ pub(crate) fn parse_authority(value: &[u8], bare: bool) -> Option<Authority> {
         offset: auth_offset,
         len,
     })
+}
+
+/// The host of an `http://` / `https://` URL as an IP address, or `None` for a hostname or a
+/// non-URL value. Unlike [`parse_authority`] it reads both schemes and both families; a bracketed
+/// IPv6 host may carry a zone suffix (`%` or URL-encoded `%25`), cut before the parse.
+pub(crate) fn url_host_ip(url: &[u8]) -> Option<IpAddr> {
+    let rest = strip_prefix_ignore_ascii_case(url, b"http://")
+        .or_else(|| strip_prefix_ignore_ascii_case(url, b"https://"))?;
+    if let Some(v6) = rest.strip_prefix(b"[") {
+        let host = &v6[..v6.iter().position(|&b| b == b']')?];
+        let host = &host[..host.iter().position(|&b| b == b'%').unwrap_or(host.len())];
+        return std::str::from_utf8(host)
+            .ok()?
+            .parse::<Ipv6Addr>()
+            .ok()
+            .map(IpAddr::V6);
+    }
+    let host = &rest[..rest
+        .iter()
+        .position(|&b| matches!(b, b':' | b'/' | b'?' | b'#' | b' ' | b'\t' | b'\r'))
+        .unwrap_or(rest.len())];
+    std::str::from_utf8(host)
+        .ok()?
+        .parse::<Ipv4Addr>()
+        .ok()
+        .map(IpAddr::V4)
 }
 
 /// `line` with `prefix` removed if it begins with it (ASCII case-insensitive), else `None`.
@@ -100,6 +126,66 @@ mod tests {
         let a = parse_authority(b"http://10.0.0.7#frag", false).unwrap();
         assert_eq!(a.endpoint, "10.0.0.7:80".parse().unwrap());
         assert_eq!(a.len, "10.0.0.7".len());
+    }
+
+    #[test]
+    fn url_host_ip_reads_both_schemes_and_families() {
+        assert_eq!(
+            url_host_ip(b"http://169.254.1.2:8080/desc.xml"),
+            Some("169.254.1.2".parse().unwrap())
+        );
+        assert_eq!(
+            url_host_ip(b"https://192.168.0.2:5357/x"),
+            Some("192.168.0.2".parse().unwrap())
+        );
+        assert_eq!(
+            url_host_ip(b"HTTP://10.0.0.7"),
+            Some("10.0.0.7".parse().unwrap())
+        );
+        assert_eq!(
+            url_host_ip(b"http://[fe80::1]:5357/a"),
+            Some("fe80::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn url_host_ip_terminates_at_query_or_fragment() {
+        // A pathless URL with a query or fragment, as in the parse_authority case above.
+        assert_eq!(
+            url_host_ip(b"http://169.254.1.2?token=x"),
+            Some("169.254.1.2".parse().unwrap())
+        );
+        assert_eq!(
+            url_host_ip(b"http://10.0.0.7#frag"),
+            Some("10.0.0.7".parse().unwrap())
+        );
+        // With a port, the port ends at the same delimiters; the host is unaffected.
+        assert_eq!(
+            url_host_ip(b"http://10.0.0.7:8008?token=x"),
+            Some("10.0.0.7".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn url_host_ip_cuts_an_ipv6_zone_before_the_parse() {
+        // WSDAPI advertises zoned link-local XAddrs; both the raw and the URL-encoded percent cut.
+        assert_eq!(
+            url_host_ip(b"http://[fe80::1%25eth0]:5357/a"),
+            Some("fe80::1".parse().unwrap())
+        );
+        assert_eq!(
+            url_host_ip(b"http://[fe80::1%eth0]/a"),
+            Some("fe80::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn url_host_ip_rejects_hostnames_and_non_urls() {
+        assert_eq!(url_host_ip(b"http://printer.local:80/x"), None);
+        assert_eq!(url_host_ip(b"urn:uuid:1234"), None);
+        assert_eq!(url_host_ip(b"http://"), None);
+        assert_eq!(url_host_ip(b"http://[fe80::1"), None); // unclosed bracket
+        assert_eq!(url_host_ip(b""), None);
     }
 
     #[test]

--- a/src/net/mdns.rs
+++ b/src/net/mdns.rs
@@ -1,6 +1,8 @@
 //! mDNS wire constants and the query/response classifier that acts as the reflector's directional gate.
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use super::is_link_local;
 
 /// RFC 6762.
 pub(crate) const MDNS_PORT: u16 = 5353;
@@ -26,6 +28,11 @@ const DNS_HEADER_LEN: usize = 12;
 /// The high byte of the flags field (header offset 2); the QR bit is its top bit.
 const FLAGS_HIGH: usize = 2;
 const QR_BIT: u8 = 0x80;
+/// The header's four section-count fields, by offset.
+const QDCOUNT_AT: usize = 4;
+const ANCOUNT_AT: usize = 6;
+const NSCOUNT_AT: usize = 8;
+const ARCOUNT_AT: usize = 10;
 
 /// Classify a payload by the QR bit of its fixed 12-byte DNS header. `None` when the payload is too
 /// short to hold that header; that is anomalous on the dedicated mDNS group, so the caller surfaces
@@ -39,6 +46,83 @@ pub(crate) fn classify(payload: &[u8]) -> Option<MdnsKind> {
     } else {
         MdnsKind::Query
     })
+}
+
+/// The A / AAAA record types (RFC 1035 §3.4.1 / RFC 3596 §2.1).
+const TYPE_A: u16 = 1;
+const TYPE_AAAA: u16 = 28;
+
+/// Whether the message carries at least one A/AAAA record and every one is link-local. Callers
+/// apply it to responses only: a query's records are known-answer cache state, not an
+/// advertisement. No address records, a routable address, or malformation all read as `false`.
+pub(crate) fn advertises_only_link_local(payload: &[u8]) -> bool {
+    only_link_local_records(payload).unwrap_or(false)
+}
+
+/// The record walk behind [`advertises_only_link_local`]: `None` on truncation or an undefined
+/// label type.
+fn only_link_local_records(payload: &[u8]) -> Option<bool> {
+    if payload.len() < DNS_HEADER_LEN {
+        return None;
+    }
+    let count = |at: usize| usize::from(u16::from_be_bytes([payload[at], payload[at + 1]]));
+    let mut at = DNS_HEADER_LEN;
+    // The question section leads and carries no rdata; walk over it to reach the records.
+    for _ in 0..count(QDCOUNT_AT) {
+        at = skip_name(payload, at)?;
+        at += 4; // QTYPE + QCLASS
+    }
+    // Answer + authority + additional: address records may sit in any of them.
+    let mut saw_address = false;
+    for _ in 0..count(ANCOUNT_AT) + count(NSCOUNT_AT) + count(ARCOUNT_AT) {
+        // A record is its name, 10 fixed bytes - TYPE(2) CLASS(2) TTL(4) RDLENGTH(2) - and then
+        // RDLENGTH bytes of rdata (RFC 1035 §4.1.3). Only TYPE and RDLENGTH are read here; an
+        // A / AAAA rdata is the bare address.
+        at = skip_name(payload, at)?;
+        let fixed = payload.get(at..at + 10)?;
+        let rtype = u16::from_be_bytes([fixed[0], fixed[1]]);
+        let rdlength = usize::from(u16::from_be_bytes([fixed[8], fixed[9]]));
+        at += 10;
+        let rdata = payload.get(at..at + rdlength)?;
+        at += rdlength;
+        let ip: IpAddr = match (rtype, rdata.len()) {
+            (TYPE_A, 4) => {
+                Ipv4Addr::from(<[u8; 4]>::try_from(rdata).expect("length checked")).into()
+            }
+            (TYPE_AAAA, 16) => {
+                Ipv6Addr::from(<[u8; 16]>::try_from(rdata).expect("length checked")).into()
+            }
+            // Any other type, or an A/AAAA whose rdata is not address-sized, holds no address.
+            _ => continue,
+        };
+        if !is_link_local(ip) {
+            return Some(false);
+        }
+        saw_address = true;
+    }
+    Some(saw_address)
+}
+
+/// Advance past the (possibly compressed) domain name at `at`, returning the offset just after it.
+/// `None` on truncation or an undefined label type.
+fn skip_name(payload: &[u8], mut at: usize) -> Option<usize> {
+    loop {
+        let len = *payload.get(at)?;
+        // A name is a run of labels, and each label's first byte tags its type in the top two bits
+        // (RFC 1035 §3.1 / §4.1.4): 00 = a plain length (1-63) followed by that many bytes, with
+        // length 0 ending the name; 11 = a 2-byte compression pointer, which ends the name in
+        // place (the target holds the rest, so the record's fixed fields follow the 2 bytes, and
+        // skipping never chases it); 01 / 10 = extension types that never shipped.
+        match len {
+            0 => return Some(at + 1),
+            1..=0x3f => at += 1 + usize::from(len),
+            0xc0..=0xff => {
+                payload.get(at + 1)?;
+                return Some(at + 2);
+            }
+            _ => return None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -137,5 +221,101 @@ mod tests {
         assert_eq!(classify(&MDNS_QUERY_PTR_LINKLOCAL), Some(MdnsKind::Query));
         assert_eq!(classify(&MDNS_RESPONSE_BONJOUR), Some(MdnsKind::Response));
         assert_eq!(classify(&MDNS_RESPONSE_RAOP), Some(MdnsKind::Response));
+    }
+
+    /// A response whose answer section holds `records`, each `(rtype, rdata)` under the name `x.`,
+    /// IN class, TTL 120.
+    fn response_with_records(records: &[(u16, &[u8])]) -> Vec<u8> {
+        let mut m = vec![0u8; DNS_HEADER_LEN];
+        m[FLAGS_HIGH] = QR_BIT;
+        m[ANCOUNT_AT + 1] =
+            u8::try_from(records.len()).expect("test record count fits ANCOUNT's low byte");
+        for (rtype, rdata) in records {
+            m.extend_from_slice(&[0x01, b'x', 0x00]);
+            m.extend_from_slice(&rtype.to_be_bytes());
+            m.extend_from_slice(&[0x00, 0x01]);
+            m.extend_from_slice(&[0, 0, 0, 120]);
+            m.extend_from_slice(&u16::try_from(rdata.len()).unwrap().to_be_bytes());
+            m.extend_from_slice(rdata);
+        }
+        m
+    }
+
+    const A_LINK_LOCAL: (u16, &[u8]) = (TYPE_A, &[169, 254, 1, 2]);
+    const A_ROUTABLE: (u16, &[u8]) = (TYPE_A, &[192, 168, 1, 9]);
+    const AAAA_LINK_LOCAL: (u16, &[u8]) = (
+        TYPE_AAAA,
+        &[0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+    );
+    const AAAA_ROUTABLE: (u16, &[u8]) = (
+        TYPE_AAAA,
+        &[0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+    );
+    const TXT: (u16, &[u8]) = (16, b"vers=1");
+
+    #[test]
+    fn suppresses_only_when_every_address_is_link_local() {
+        assert!(advertises_only_link_local(&response_with_records(&[
+            A_LINK_LOCAL
+        ])));
+        assert!(advertises_only_link_local(&response_with_records(&[
+            AAAA_LINK_LOCAL
+        ])));
+        assert!(advertises_only_link_local(&response_with_records(&[
+            A_LINK_LOCAL,
+            AAAA_LINK_LOCAL
+        ])));
+        // One routable address of either family rescues the message: the client can use it.
+        assert!(!advertises_only_link_local(&response_with_records(&[
+            A_LINK_LOCAL,
+            A_ROUTABLE
+        ])));
+        assert!(!advertises_only_link_local(&response_with_records(&[
+            AAAA_LINK_LOCAL,
+            AAAA_ROUTABLE
+        ])));
+        // Other record types don't veto: a bundled advertisement (PTR/SRV/TXT beside the
+        // addresses) whose only addresses are link-local is exactly the dead-service case.
+        assert!(advertises_only_link_local(&response_with_records(&[
+            TXT,
+            A_LINK_LOCAL
+        ])));
+        // No address records at all is not an advertisement of dead endpoints.
+        assert!(!advertises_only_link_local(&response_with_records(&[TXT])));
+        assert!(!advertises_only_link_local(&response_with_records(&[])));
+    }
+
+    #[test]
+    fn suppression_skips_names_with_compression_pointers() {
+        // Second record's name is a pointer to the first's (offset 12): the walker must step the
+        // 2-byte pointer, not chase it.
+        let mut m = response_with_records(&[A_LINK_LOCAL]);
+        m[ANCOUNT_AT + 1] = 2;
+        m.extend_from_slice(&[0xc0, 0x0c]);
+        m.extend_from_slice(&TYPE_A.to_be_bytes());
+        m.extend_from_slice(&[0x00, 0x01, 0, 0, 0, 120, 0x00, 0x04, 169, 254, 3, 4]);
+        assert!(advertises_only_link_local(&m));
+    }
+
+    #[test]
+    fn a_malformed_message_is_never_suppressed() {
+        // Truncated rdata: the record claims 4 bytes and the payload ends.
+        let mut m = response_with_records(&[A_LINK_LOCAL]);
+        m.truncate(m.len() - 2);
+        assert!(!advertises_only_link_local(&m));
+        // An undefined label type (0x40) aborts the walk.
+        let mut m = response_with_records(&[A_LINK_LOCAL]);
+        m[DNS_HEADER_LEN] = 0x40;
+        assert!(!advertises_only_link_local(&m));
+        assert!(!advertises_only_link_local(b""));
+    }
+
+    #[test]
+    fn real_responses_with_a_routable_address_are_not_suppressed() {
+        // Bonjour: fe80:: AAAA + routable A + global AAAA (mixed); RAOP: one routable A.
+        assert!(!advertises_only_link_local(&MDNS_RESPONSE_BONJOUR));
+        assert!(!advertises_only_link_local(&MDNS_RESPONSE_RAOP));
+        // The reverse-PTR query carries no address records.
+        assert!(!advertises_only_link_local(&MDNS_QUERY_PTR_LINKLOCAL));
     }
 }

--- a/src/net/ssdp.rs
+++ b/src/net/ssdp.rs
@@ -4,7 +4,9 @@ pub(crate) mod dial;
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use crate::net::http::strip_prefix_ignore_ascii_case;
+use crate::net::http::{strip_prefix_ignore_ascii_case, url_host_ip};
+
+use super::is_link_local;
 
 /// The SSDP UDP port (`UPnP` Device Architecture).
 pub(crate) const SSDP_PORT: u16 = 1900;
@@ -47,6 +49,14 @@ pub(crate) fn classify(payload: &[u8]) -> Option<SsdpKind> {
     } else {
         None
     }
+}
+
+/// Whether the message's `LOCATION` names a link-local IP literal. An absent `LOCATION` (a
+/// `byebye`), a hostname, or a routable literal reads as `false`.
+pub(crate) fn advertises_only_link_local(payload: &[u8]) -> bool {
+    dial::dial_location_value(payload)
+        .and_then(url_host_ip)
+        .is_some_and(is_link_local)
 }
 
 /// MX is clamped to `[1, 5]` seconds (`UPnP` Device Architecture 2.0).
@@ -187,6 +197,22 @@ mod tests {
 
     /// Real NOTIFY `ssdp:byebye` off a Canon EOS 6D going to sleep (airmtp `ssdp.py`).
     const NOTIFY_BYEBYE_CANON: &str = "NOTIFY * HTTP/1.1\r\nHost: 239.255.255.250:1900\r\nNT: urn:schemas-canon-com:service:ICPO-SmartPhoneEOSSystemService:1\r\nNTS: ssdp:byebye\r\nUSN: uuid:00000000-0000-0000-0001-2C9EFCD137BE::urn:schemas-canon-com:service:ICPO-SmartPhoneEOSSystemService:1\r\n\r\n";
+
+    #[test]
+    fn suppresses_only_a_link_local_location() {
+        assert!(advertises_only_link_local(
+            b"NOTIFY * HTTP/1.1\r\nNTS: ssdp:alive\r\nLOCATION: http://169.254.9.9:1900/d.xml\r\n\r\n"
+        ));
+        assert!(advertises_only_link_local(
+            b"HTTP/1.1 200 OK\r\nLOCATION: http://[fe80::1]:8080/d.xml\r\n\r\n"
+        ));
+        // Routable, hostname, or no LOCATION at all (a byebye): reflect as usual.
+        assert!(!advertises_only_link_local(NOTIFY_ALIVE_SONY.as_bytes()));
+        assert!(!advertises_only_link_local(
+            b"NOTIFY * HTTP/1.1\r\nLOCATION: http://printer.local/d.xml\r\n\r\n"
+        ));
+        assert!(!advertises_only_link_local(NOTIFY_BYEBYE_CANON.as_bytes()));
+    }
 
     #[test]
     fn classifies_real_on_the_wire_messages() {

--- a/src/net/wsd.rs
+++ b/src/net/wsd.rs
@@ -6,6 +6,10 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+use crate::net::http::url_host_ip;
+
+use super::is_link_local;
+
 /// WSD runs SOAP-over-UDP on port 3702, re-emitted at TTL 1. The re-emit is a single hop onto the
 /// egress link, matching the link scope of the groups it serves.
 pub(crate) const WSD_PORT: u16 = 3702;
@@ -38,10 +42,41 @@ pub(crate) fn classify(payload: &[u8]) -> Option<WsdKind> {
 }
 
 /// The final `/`-delimited segment of the first `Action` element's URI (the WS-Addressing message
-/// type), or `None` when there is no such element. Walks the payload element by element so the match is
-/// scoped to the `Action` tag: tolerant of the namespace prefix (`a:` / `wsa:` / none) and of tag
-/// attributes (ONVIF sends `mustUnderstand`), and never fooled by the token appearing in the body.
+/// type), or `None` when there is no such element.
 fn action_segment(payload: &[u8]) -> Option<&[u8]> {
+    let (uri, _) = element_text(payload, b"Action")?;
+    uri.rsplit(|&b| b == b'/').next().filter(|s| !s.is_empty())
+}
+
+/// Whether the message's `XAddrs` (the device's transport addresses) hold at least one IP-literal
+/// URI and every one is link-local. A hostname or unparseable URI, a routable literal, or no
+/// `XAddrs` at all reads as `false`.
+pub(crate) fn advertises_only_link_local(payload: &[u8]) -> bool {
+    // Every XAddrs element counts: a ProbeMatches carries one per ProbeMatch.
+    let mut saw_ip = false;
+    let mut rest = payload;
+    while let Some((text, after)) = element_text(rest, b"XAddrs") {
+        for uri in text.split(|b: &u8| b.is_ascii_whitespace()) {
+            if uri.is_empty() {
+                continue;
+            }
+            match url_host_ip(uri) {
+                Some(ip) if is_link_local(ip) => saw_ip = true,
+                // A routable literal, a hostname, or an unparseable URI: not provably dead.
+                _ => return false,
+            }
+        }
+        rest = after;
+    }
+    saw_ip
+}
+
+/// The trimmed text content of the first element named `local_name` (ASCII-case-insensitive, any
+/// namespace prefix), with the remainder after that content, or `None` when no such element opens.
+/// Walks the payload element by element so a match is scoped to the tag: tolerant of the prefix
+/// (`a:` / `wsa:` / none) and of tag attributes (ONVIF sends `mustUnderstand`), and never fooled by
+/// the token appearing in body text.
+fn element_text<'a>(payload: &'a [u8], local_name: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
     let mut rest = payload;
     while let Some(open) = rest.iter().position(|&b| b == b'<') {
         rest = &rest[open + 1..];
@@ -53,7 +88,7 @@ fn action_segment(payload: &[u8]) -> Option<&[u8]> {
         if matches!(tag.first().copied(), Some(b'/' | b'?' | b'!')) {
             continue;
         }
-        // A self-closed element (`<a:Action/>`) has no text content, so there is no URI to read.
+        // A self-closed element (`<a:Action/>`) has no text content.
         if tag.last() == Some(&b'/') {
             continue;
         }
@@ -63,10 +98,9 @@ fn action_segment(payload: &[u8]) -> Option<&[u8]> {
             .next()
             .unwrap_or(tag);
         let local = name.rsplit(|&b| b == b':').next().unwrap_or(name);
-        if local.eq_ignore_ascii_case(b"Action") {
+        if local.eq_ignore_ascii_case(local_name) {
             let end = rest.iter().position(|&b| b == b'<').unwrap_or(rest.len());
-            let uri = rest[..end].trim_ascii();
-            return uri.rsplit(|&b| b == b'/').next().filter(|s| !s.is_empty());
+            return Some((rest[..end].trim_ascii(), &rest[end..]));
         }
     }
     None
@@ -375,6 +409,71 @@ urn:schemas-xmlsoap-org:ws:2005:04:discovery
     </wsd:ResolveMatches>
 </soap:Body>
 </soap:Envelope>"#;
+
+    /// A Hello body carrying the given `XAddrs` text.
+    fn hello_with_xaddrs(xaddrs: &str) -> Vec<u8> {
+        format!(
+            "<s:Envelope><s:Header><a:Action>http://x/Hello</a:Action></s:Header>\
+             <s:Body><d:Hello><d:XAddrs>{xaddrs}</d:XAddrs></d:Hello></s:Body></s:Envelope>"
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn suppresses_only_all_link_local_xaddrs() {
+        assert!(advertises_only_link_local(&hello_with_xaddrs(
+            "http://169.254.1.5:5357/dev"
+        )));
+        assert!(advertises_only_link_local(&hello_with_xaddrs(
+            "http://[fe80::1]:5357/a http://169.254.2.2:5357/a"
+        )));
+        // WSDAPI advertises zoned link-local XAddrs.
+        assert!(advertises_only_link_local(&hello_with_xaddrs(
+            "http://[fe80::1%25eth0]:5357/a"
+        )));
+        // One routable address, a hostname, or an unparseable URI rescues the message.
+        assert!(!advertises_only_link_local(&hello_with_xaddrs(
+            "http://[fe80::1]:5357/a http://192.168.1.5:5357/a"
+        )));
+        assert!(!advertises_only_link_local(&hello_with_xaddrs(
+            "http://169.254.1.5:5357/a http://printer.local:5357/a"
+        )));
+        assert!(!advertises_only_link_local(&hello_with_xaddrs("")));
+    }
+
+    #[test]
+    fn every_xaddrs_element_counts() {
+        // A ProbeMatches carries one XAddrs per ProbeMatch: all must be link-local to suppress.
+        let two = |first: &str, second: &str| {
+            format!(
+                "<s:Body><d:ProbeMatch><d:XAddrs>{first}</d:XAddrs></d:ProbeMatch>\
+                 <d:ProbeMatch><d:XAddrs>{second}</d:XAddrs></d:ProbeMatch></s:Body>"
+            )
+            .into_bytes()
+        };
+        assert!(advertises_only_link_local(&two(
+            "http://169.254.1.5:5357/a",
+            "http://[fe80::2]:5357/b"
+        )));
+        assert!(!advertises_only_link_local(&two(
+            "http://169.254.1.5:5357/a",
+            "http://10.0.0.2:5357/b"
+        )));
+    }
+
+    #[test]
+    fn messages_without_xaddrs_are_not_suppressed() {
+        // Resolution then happens via Resolve; there is no advertised endpoint to judge.
+        assert!(!advertises_only_link_local(HELLO_OASIS_2009.as_bytes()));
+        assert!(!advertises_only_link_local(b""));
+        // Real replies carrying routable XAddrs (http and https).
+        assert!(!advertises_only_link_local(
+            PROBEMATCHES_ONVIF_UNIVIEW.as_bytes()
+        ));
+        assert!(!advertises_only_link_local(
+            RESOLVEMATCHES_MS_WSDAPI.as_bytes()
+        ));
+    }
 
     #[test]
     fn classifies_real_on_the_wire_messages() {

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -40,17 +40,19 @@ pub(crate) enum Verdict {
 }
 
 /// Transforms a datagram's payload before it is re-emitted: the SSDP DIAL `LOCATION` rewrite, applied
-/// on both the advertisement direction and each search session's reply. The returned slice is either
-/// `payload` verbatim or a rewrite held in the implementor's own reused scratch. The `Fn` traits can't
-/// express that lending signature, which is why this is a trait rather than a closure.
+/// on both the advertisement direction and each search session's reply. Returns the rewrite, held in
+/// the implementor's own reused scratch, or `None` to forward `payload` verbatim; the caller also
+/// reads `None` as "still advertising the device's own addresses" for the link-local suppression.
+/// The `Fn` traits can't express that lending signature, which is why this is a trait rather than a
+/// closure.
 pub(crate) trait ReplyRewrite {
     fn rewrite<'a>(
         &'a mut self,
-        payload: &'a [u8],
+        payload: &[u8],
         egress: CaptureKey,
         dispatcher: &mut PacketDispatcher,
         reactor: &mut Reactor,
-    ) -> &'a [u8];
+    ) -> Option<&'a [u8]>;
 }
 
 /// The identity transform: forward the payload verbatim. A ZST for the reflectors (mDNS, WSD, and SSDP
@@ -60,12 +62,12 @@ pub(crate) struct NoRewrite;
 impl ReplyRewrite for NoRewrite {
     fn rewrite<'a>(
         &'a mut self,
-        payload: &'a [u8],
+        _payload: &[u8],
         _egress: CaptureKey,
         _dispatcher: &mut PacketDispatcher,
         _reactor: &mut Reactor,
-    ) -> &'a [u8] {
-        payload
+    ) -> Option<&'a [u8]> {
+        None
     }
 }
 

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -14,7 +14,10 @@ use std::net::SocketAddr;
 
 use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{Filter, IpSet, MessageType, PacketDispatcher};
-use crate::net::mdns::{MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT, MDNS_TTL, MdnsKind, classify};
+use crate::net::mdns::{
+    MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT, MDNS_TTL, MdnsKind, advertises_only_link_local,
+    classify,
+};
 
 use super::{
     BuildError, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
@@ -118,14 +121,19 @@ pub(crate) fn build(
             src_mac: reflector.macs.clone(),
             ..Filter::default()
         },
-        Box::new(SimpleReflector::new(
-            source,
-            "mDNS",
-            "response",
-            MDNS_PORT,
-            MDNS_TTL,
-            response_verdict,
-        )),
+        Box::new(
+            SimpleReflector::new(
+                source,
+                "mDNS",
+                "response",
+                MDNS_PORT,
+                MDNS_TTL,
+                response_verdict,
+            )
+            // A response whose A/AAAA records are all link-local advertises endpoints the source
+            // side can never reach; queries carry no advertisement, so only this leg checks.
+            .with_suppress(advertises_only_link_local),
+        ),
     );
     log::info!(
         "mDNS reflector \"{}\": {} <-> {}",

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -59,6 +59,8 @@ struct ResponseReflector {
     message_type: MessageType,
     ttl: u8,
     reply: Box<dyn ReplyRewrite>,
+    /// The link-local suppression check for untouched replies (see [`SearchReflector::suppress`]).
+    suppress: fn(&[u8]) -> bool,
 }
 
 impl PacketHandler for ResponseReflector {
@@ -80,9 +82,21 @@ impl PacketHandler for ResponseReflector {
             );
             return Outcome::Stalled(self.message_type);
         }
-        let payload = self
+        let rewritten = self
             .reply
             .rewrite(packet.payload, self.egress, dispatcher, reactor);
+        // A rewritten reply is exempt; the why lives at `SimpleReflector::on_packet`'s gate.
+        if rewritten.is_none() && (self.suppress)(packet.payload) {
+            log::debug!(
+                "{}: suppressing response from {} to searcher {}: advertises only link-local \
+                 addresses",
+                self.name,
+                packet.source,
+                self.searcher
+            );
+            return Outcome::Dropped(self.message_type);
+        }
+        let payload = rewritten.unwrap_or(packet.payload);
         match dispatcher.send_udp(
             self.egress,
             self.searcher,
@@ -141,6 +155,9 @@ pub(crate) struct SearchReflector {
     window: fn(&[u8]) -> Duration,
     /// Mints a fresh reply transform per session (its own scratch, for a rewriting protocol).
     make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>>,
+    /// The protocol's `advertises_only_link_local` check, handed to each session's
+    /// [`ResponseReflector`]: an untouched reply it flags is dropped rather than reflected.
+    suppress: fn(&[u8]) -> bool,
     sessions: Vec<Session>,
 }
 
@@ -156,6 +173,7 @@ impl SearchReflector {
         classify: fn(&[u8]) -> Verdict,
         window: fn(&[u8]) -> Duration,
         make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>>,
+        suppress: fn(&[u8]) -> bool,
     ) -> Self {
         Self {
             source,
@@ -167,6 +185,7 @@ impl SearchReflector {
             classify,
             window,
             make_reply,
+            suppress,
             sessions: Vec::new(),
         }
     }
@@ -240,6 +259,7 @@ impl SearchReflector {
                 message_type: self.response_type,
                 ttl: self.ttl,
                 reply: (self.make_reply)(),
+                suppress: self.suppress,
             }),
         );
         Ok(Session {
@@ -425,6 +445,7 @@ impl PacketHandler for SearchReflector {
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
     use crate::capture::Capture;
@@ -454,6 +475,7 @@ mod tests {
             always_reflect,
             fixed_window,
             Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+            |_| false,
         )
     }
 
@@ -483,6 +505,7 @@ mod tests {
                 message_type: MessageType::SsdpResponse,
                 ttl: TEST_TTL,
                 reply: Box::new(NoRewrite),
+                suppress: |_| false,
             }),
         );
         reflector.sessions.push(Session {
@@ -809,6 +832,99 @@ mod tests {
         ));
     }
 
+    /// A reply transform that replaces the payload wholesale, standing in for a DIAL rewrite that
+    /// spliced in the proxy's own listener.
+    struct ReplaceRewrite;
+
+    impl ReplyRewrite for ReplaceRewrite {
+        fn rewrite<'a>(
+            &'a mut self,
+            _: &[u8],
+            _: CaptureKey,
+            _: &mut PacketDispatcher,
+            _: &mut Reactor,
+        ) -> Option<&'a [u8]> {
+            Some(b"REWRITTEN")
+        }
+    }
+
+    /// A reply for a `ResponseReflector` with the given transform and suppression check, plus the
+    /// dispatcher/reactor it runs against, over a real loopback egress (`None` = skip, no
+    /// `CAP_NET_RAW`).
+    fn reply_over_loopback(
+        reply: Box<dyn ReplyRewrite>,
+        suppress: fn(&[u8]) -> bool,
+    ) -> Option<(ResponseReflector, PacketDispatcher, Reactor)> {
+        let cap = open_loopback_or_skip()?;
+        let mut dispatcher = PacketDispatcher::new();
+        let egress = dispatcher
+            .add_capture(cap)
+            .expect("add the loopback capture");
+        let reactor = Reactor::new().expect("reactor");
+        let reflector = ResponseReflector {
+            searcher: "127.0.0.1:4000".parse().unwrap(),
+            searcher_mac: MacAddr::from([0x02, 0, 0, 0, 0, 1]),
+            egress,
+            name: "TEST",
+            message_type: MessageType::SsdpResponse,
+            ttl: TEST_TTL,
+            reply,
+            suppress,
+        };
+        Some((reflector, dispatcher, reactor))
+    }
+
+    fn reply_packet() -> Packet<'static> {
+        Packet {
+            source: "127.0.0.1:1900".parse().unwrap(),
+            dest: "127.0.0.1:4000".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: None,
+            payload: b"HTTP/1.1 200 OK\r\n\r\n",
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn suppression_drops_an_untouched_reply() {
+        // The Dropped outcome proves the early return: a completed loopback send would be Reflected.
+        let Some((mut reflector, mut dispatcher, mut reactor)) =
+            reply_over_loopback(Box::new(NoRewrite), |_| true)
+        else {
+            return;
+        };
+        assert_eq!(
+            reflector.on_packet(&reply_packet(), &mut dispatcher, &mut reactor),
+            Outcome::Dropped(MessageType::SsdpResponse)
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_rewritten_reply_is_exempt_from_suppression() {
+        // The rewrite spliced in our own egress-side listener, reachable from that link whatever
+        // its address class, so the gate must not even be consulted. The tracking fn (would-be
+        // suppressing) proves it: a fn pointer can't capture, hence the static.
+        static SUPPRESS_CONSULTED: AtomicBool = AtomicBool::new(false);
+        fn tracking_suppress(_: &[u8]) -> bool {
+            SUPPRESS_CONSULTED.store(true, Ordering::Relaxed);
+            true
+        }
+        let Some((mut reflector, mut dispatcher, mut reactor)) =
+            reply_over_loopback(Box::new(ReplaceRewrite), tracking_suppress)
+        else {
+            return;
+        };
+        let outcome = reflector.on_packet(&reply_packet(), &mut dispatcher, &mut reactor);
+        assert!(
+            !SUPPRESS_CONSULTED.load(Ordering::Relaxed),
+            "the gate ran on a rewritten reply"
+        );
+        // And the exempt reply completed the reflect: it was sent, not merely spared the gate.
+        assert_eq!(outcome, Outcome::Reflected(MessageType::SsdpResponse));
+    }
+
     /// Open a loopback capture, or `None` (skip) without `CAP_NET_RAW`. A real capture gives the target
     /// a resolvable address, so `make_session` can succeed.
     fn open_loopback_or_skip() -> Option<Capture> {
@@ -846,6 +962,7 @@ mod tests {
             always_reflect,
             fixed_window,
             Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+            |_| false,
         );
         let before = dispatcher.registration_count();
         let packet = Packet {

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -29,6 +29,8 @@ pub(crate) struct SimpleReflector {
     classify: fn(&[u8]) -> Verdict,
     /// Transforms the payload before re-emit; [`NoRewrite`] (the default) forwards verbatim.
     rewrite: Box<dyn ReplyRewrite>,
+    /// The link-local suppression check for payloads `rewrite` left untouched (default: none).
+    suppress: fn(&[u8]) -> bool,
 }
 
 impl SimpleReflector {
@@ -48,6 +50,7 @@ impl SimpleReflector {
             ttl,
             classify,
             rewrite: Box::new(NoRewrite),
+            suppress: |_| false,
         }
     }
 
@@ -55,6 +58,13 @@ impl SimpleReflector {
     /// the payload is forwarded verbatim.
     pub(crate) fn with_rewrite(mut self, rewrite: Box<dyn ReplyRewrite>) -> Self {
         self.rewrite = rewrite;
+        self
+    }
+
+    /// Drop (rather than re-emit) any payload `suppress` flags: the protocol's
+    /// `advertises_only_link_local` check.
+    pub(crate) fn with_suppress(mut self, suppress: fn(&[u8]) -> bool) -> Self {
+        self.suppress = suppress;
         self
     }
 }
@@ -94,9 +104,23 @@ impl PacketHandler for SimpleReflector {
             return Outcome::Stalled(message_type);
         }
 
-        let payload = self
+        let rewritten = self
             .rewrite
             .rewrite(packet.payload, self.egress, dispatcher, reactor);
+
+        // A rewritten payload is exempt: the rewrite inserts netflector's own egress-side listener,
+        // reachable from the egress link even when that interface's address is itself link-local.
+        // Only an untouched payload still advertises the far link's addresses.
+        if rewritten.is_none() && (self.suppress)(packet.payload) {
+            log::debug!(
+                "{}: suppressing {} from {}: advertises only link-local addresses",
+                self.name,
+                self.kind,
+                packet.source
+            );
+            return Outcome::Dropped(message_type);
+        }
+        let payload = rewritten.unwrap_or(packet.payload);
 
         match dispatcher.send_udp_group(self.egress, packet.dest, self.src_port, self.ttl, payload)
         {
@@ -121,5 +145,116 @@ impl PacketHandler for SimpleReflector {
                 Outcome::Dropped(message_type)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+    use crate::capture::Capture;
+    use crate::dispatch::MessageType;
+
+    /// Open a loopback capture, or `None` (skip) without `CAP_NET_RAW`. A real capture gives the
+    /// egress a source address, so `on_packet` reaches the suppression gate.
+    fn open_loopback_or_skip() -> Option<Capture> {
+        match Capture::open(crate::interface::LOOPBACK_IFACE) {
+            Ok(cap) => Some(cap),
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skip: no CAP_NET_RAW to open a loopback capture ({e})");
+                None
+            }
+            Err(e) => panic!("unexpected loopback capture open failure: {e}"),
+        }
+    }
+
+    fn reflect_all(_: &[u8]) -> Verdict {
+        Verdict::Reflect(MessageType::MdnsResponse)
+    }
+
+    /// A reflector with the given transform and suppression check, plus the dispatcher/reactor it
+    /// runs against, over a real loopback egress (`None` = skip, no `CAP_NET_RAW`).
+    fn reflector_over_loopback(
+        rewrite: Box<dyn ReplyRewrite>,
+        suppress: fn(&[u8]) -> bool,
+    ) -> Option<(SimpleReflector, PacketDispatcher, Reactor)> {
+        let cap = open_loopback_or_skip()?;
+        let mut dispatcher = PacketDispatcher::new();
+        let egress = dispatcher
+            .add_capture(cap)
+            .expect("add the loopback capture");
+        let reactor = Reactor::new().expect("reactor");
+        let reflector = SimpleReflector::new(egress, "TEST", "response", 5353, 255, reflect_all)
+            .with_rewrite(rewrite)
+            .with_suppress(suppress);
+        Some((reflector, dispatcher, reactor))
+    }
+
+    fn group_packet() -> Packet<'static> {
+        Packet {
+            source: "127.0.0.1:5353".parse().unwrap(),
+            dest: "224.0.0.251:5353".parse().unwrap(),
+            ttl: 255,
+            dst_mac: None,
+            src_mac: None,
+            payload: b"response",
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_suppressed_payload_is_dropped_before_the_send() {
+        // The Dropped outcome proves the early return: a completed loopback send would be Reflected.
+        let Some((mut reflector, mut dispatcher, mut reactor)) =
+            reflector_over_loopback(Box::new(NoRewrite), |_| true)
+        else {
+            return;
+        };
+        assert_eq!(
+            reflector.on_packet(&group_packet(), &mut dispatcher, &mut reactor),
+            Outcome::Dropped(MessageType::MdnsResponse)
+        );
+    }
+
+    /// A rewrite that replaces the payload wholesale, standing in for a DIAL rewrite that spliced
+    /// in the proxy's own listener.
+    struct ReplaceRewrite;
+
+    impl ReplyRewrite for ReplaceRewrite {
+        fn rewrite<'a>(
+            &'a mut self,
+            _: &[u8],
+            _: CaptureKey,
+            _: &mut PacketDispatcher,
+            _: &mut Reactor,
+        ) -> Option<&'a [u8]> {
+            Some(b"REWRITTEN")
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_rewritten_payload_is_exempt_from_suppression() {
+        // The rewrite spliced in our own egress-side listener, reachable from that link whatever
+        // its address class, so the gate must not even be consulted. The tracking fn (would-be
+        // suppressing) proves it: a fn pointer can't capture, hence the static.
+        static SUPPRESS_CONSULTED: AtomicBool = AtomicBool::new(false);
+        fn tracking_suppress(_: &[u8]) -> bool {
+            SUPPRESS_CONSULTED.store(true, Ordering::Relaxed);
+            true
+        }
+        let Some((mut reflector, mut dispatcher, mut reactor)) =
+            reflector_over_loopback(Box::new(ReplaceRewrite), tracking_suppress)
+        else {
+            return;
+        };
+        let outcome = reflector.on_packet(&group_packet(), &mut dispatcher, &mut reactor);
+        assert!(
+            !SUPPRESS_CONSULTED.load(Ordering::Relaxed),
+            "the gate ran on a rewritten payload"
+        );
+        // And the exempt payload completed the reflect: it was sent, not merely spared the gate.
+        assert_eq!(outcome, Outcome::Reflected(MessageType::MdnsResponse));
     }
 }

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -16,7 +16,7 @@ use crate::interface::InterfaceAddresses;
 use crate::net::MAX_UDP_PAYLOAD_LEN;
 use crate::net::ssdp::{
     MSEARCH_MX_DEFAULT, SSDP_GROUP_V4, SSDP_GROUP_V6_LINK_LOCAL, SSDP_GROUP_V6_SITE_LOCAL,
-    SSDP_PORT, SSDP_TTL, SsdpKind, classify, parse_msearch_mx,
+    SSDP_PORT, SSDP_TTL, SsdpKind, advertises_only_link_local, classify, parse_msearch_mx,
 };
 use crate::net::uninit_buf::UninitBuf;
 use crate::reactor::Reactor;
@@ -51,15 +51,15 @@ impl DialRewrite {
 
 impl ReplyRewrite for DialRewrite {
     /// Rewrite a target→source SSDP datagram's DIAL `LOCATION` to a source-side description proxy, into
-    /// the reused scratch. Returns the rewritten slice on success, else `payload` (forward verbatim).
+    /// the reused scratch. Returns the rewritten slice, or `None` to forward `payload` verbatim.
     /// `egress` is the source capture the datagram reflects onto.
     fn rewrite<'a>(
         &'a mut self,
-        payload: &'a [u8],
+        payload: &[u8],
         egress: CaptureKey,
         dispatcher: &mut PacketDispatcher,
         reactor: &mut Reactor,
-    ) -> &'a [u8] {
+    ) -> Option<&'a [u8]> {
         let (Some(source), Some(target)) = (
             dispatcher
                 .egress_addrs(egress)
@@ -68,7 +68,7 @@ impl ReplyRewrite for DialRewrite {
                 .egress_addrs(self.target)
                 .and_then(InterfaceAddresses::v4),
         ) else {
-            return payload; // a family the proxy can't bridge yet
+            return None; // a family the proxy can't bridge yet
         };
         let (ctx, target_iface) = dispatcher.dial_context(self.target);
         let placement = ProxyPlacement {
@@ -80,9 +80,9 @@ impl ReplyRewrite for DialRewrite {
         };
         self.scratch.clear();
         if rewrite_location(ctx, reactor, payload, placement, &mut self.scratch) {
-            self.scratch.filled()
+            Some(self.scratch.filled())
         } else {
-            payload
+            None
         }
     }
 }
@@ -177,6 +177,8 @@ pub(crate) fn build(
     let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();
     // target -> source: advertisements (a stateless re-emit), optionally filtered to the configured
     // device's MAC. With `dial`, the reflected `LOCATION` is rewritten to a source-side proxy.
+    // A NOTIFY whose LOCATION names a link-local address advertises an endpoint the source side
+    // can never reach.
     let advertisement = SimpleReflector::new(
         source,
         "SSDP",
@@ -184,7 +186,8 @@ pub(crate) fn build(
         SSDP_PORT,
         SSDP_TTL,
         advertisement_verdict,
-    );
+    )
+    .with_suppress(advertises_only_link_local);
     let advertisement = if ssdp.dial {
         advertisement.with_rewrite(Box::new(DialRewrite::new(target)))
     } else {
@@ -225,6 +228,8 @@ pub(crate) fn build(
             search_verdict,
             search_window,
             make_reply,
+            // Each session's 200 OK reply is gated the same way as the NOTIFY leg.
+            advertises_only_link_local,
         )),
     );
     log::info!(

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 
 use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{Filter, IpSet, MessageType, PacketDispatcher};
-use crate::net::wsd::{WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT, WSD_TTL, WsdKind, classify};
+use crate::net::wsd::{
+    WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT, WSD_TTL, WsdKind, advertises_only_link_local, classify,
+};
 
 use super::{
     BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
@@ -104,14 +106,19 @@ pub(crate) fn build(
             src_mac: reflector.macs.clone(),
             ..Filter::default()
         },
-        Box::new(SimpleReflector::new(
-            source,
-            "WSD",
-            "announcement",
-            WSD_PORT,
-            WSD_TTL,
-            announcement_verdict,
-        )),
+        Box::new(
+            SimpleReflector::new(
+                source,
+                "WSD",
+                "announcement",
+                WSD_PORT,
+                WSD_TTL,
+                announcement_verdict,
+            )
+            // A Hello whose XAddrs are all link-local advertises endpoints the source side can
+            // never reach.
+            .with_suppress(advertises_only_link_local),
+        ),
     );
     // source -> target: Probe/Resolve searches (unfiltered, any source client may search); each
     // searcher's unicast matches route back through a per-searcher session.
@@ -132,6 +139,8 @@ pub(crate) fn build(
             search_verdict,
             window,
             Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+            // Each session's ProbeMatches / ResolveMatches reply is gated the same way.
+            advertises_only_link_local,
         )),
     );
     log::info!(


### PR DESCRIPTION
Drop rather than relay a message whose advertised addresses are all link-local (mDNS A/AAAA rdata, SSDP LOCATION, WSD XAddrs): an entry's interfaces always differ, so such endpoints are unreachable from the egress side and the device shows up discovered but dead. One routable address lets the message through; unparseable payloads reflect as usual. A payload the DIAL rewrite replaced is exempt - the rewritten LOCATION names netflector's own listener on the egress link, reachable there even when that interface's address is itself link-local. ReplyRewrite now returns Option<&[u8]>; None (forward verbatim) doubles as the gate's exemption signal. Suppressions tally as dropped and log at debug.

Testing: unit tests over the real captured fixtures plus crafted edges (compression pointers, truncation, mixed families, non-address record types); loopback-capture tests for the gate and the rewrite exemption; 6 new e2e cases (mixed reflected verbatim, link-local-only suppressed, per protocol), full docker suite 63/63; clippy, fmt and rustdoc clean on host and Linux.