### PR TITLE
Surface MTU mismatches instead of dropping silently

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -381,7 +381,9 @@ impl PacketDispatcher {
     /// (taken-out) or out-of-range capture is a logged drop, not an error and never UB.
     pub(crate) fn send(&self, egress: CaptureKey, frame: &[u8]) -> io::Result<()> {
         if let Some(capture) = self.table.capture(egress) {
-            capture.send(frame)
+            capture.send(frame).map_err(|e| {
+                oversize_context(e, capture.if_name(), frame.len(), self.table.mtu_of(egress))
+            })
         } else {
             log::warn!("egress {egress:?} unavailable (drained or unknown); frame dropped");
             Ok(())
@@ -1010,6 +1012,20 @@ impl Handler for PacketDispatcher {
             ControlEvent::Dump => log_counters(self.table.counter_rows()),
         }
     }
+}
+
+/// Re-word an `EMSGSIZE` send failure to name the frame, the interface, and its MTU (as of the
+/// interface's last resolution); the bare "Message too long" names none of them. Any other error
+/// passes through.
+fn oversize_context(e: io::Error, if_name: &str, frame_len: usize, mtu: Option<u32>) -> io::Error {
+    if e.raw_os_error() != Some(libc::EMSGSIZE) {
+        return e;
+    }
+    let mtu = mtu.map_or_else(String::new, |mtu| format!(" (MTU {mtu})"));
+    io::Error::new(
+        e.kind(),
+        format!("a frame of {frame_len} bytes exceeds what {if_name}{mtu} can carry"),
+    )
 }
 
 #[cfg(test)]
@@ -1988,5 +2004,34 @@ mod tests {
         let mut dispatcher = PacketDispatcher::new();
         let group = IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251));
         assert!(dispatcher.join_group(CaptureKey(9999), group).is_ok());
+    }
+
+    #[test]
+    fn oversize_context_rewords_only_emsgsize() {
+        // The reworded message is the feature: it must name the frame length, the interface, and
+        // the MTU when known.
+        let e = oversize_context(
+            io::Error::from_raw_os_error(libc::EMSGSIZE),
+            "vxlan0",
+            1500,
+            Some(1370),
+        );
+        let text = e.to_string();
+        assert!(
+            text.contains("1500") && text.contains("vxlan0") && text.contains("1370"),
+            "{text}"
+        );
+        // The custom message costs the errno representation (std's `io::Error` carries one or the
+        // other, never both). Deliberate: nothing matches on EMSGSIZE downstream, and the message
+        // is the only surface an operator sees.
+        assert_eq!(e.raw_os_error(), None);
+        // Any other error passes through untouched: its message is the plain strerror text, and
+        // it keeps its errno (rewording builds a custom error, whose `raw_os_error` is `None`).
+        let other = oversize_context(io::Error::from_raw_os_error(libc::ENETDOWN), "x0", 9, None);
+        assert_eq!(
+            other.to_string(),
+            io::Error::from_raw_os_error(libc::ENETDOWN).to_string()
+        );
+        assert_eq!(other.raw_os_error(), Some(libc::ENETDOWN));
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -388,6 +388,11 @@ impl PacketDispatcher {
         }
     }
 
+    /// The MTU of the interface behind `capture`, as of its last resolution.
+    pub(crate) fn interface_mtu(&self, capture: CaptureKey) -> Option<u32> {
+        self.table.mtu_of(capture)
+    }
+
     /// The current source addresses of the interface behind `egress`, for a reflector
     /// building a frame. `InterfaceAddresses` is `Copy`, so a caller reads out the fields it
     /// needs.

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -159,6 +159,14 @@ impl InterfaceTable {
         self.addrs(self.interface_of(capture)?)
     }
 
+    /// The MTU of the interface behind `capture`, as of its last resolution.
+    pub(super) fn mtu_of(&self, capture: CaptureKey) -> Option<u32> {
+        self.entries
+            .get(self.interface_of(capture)?.0 as usize)?
+            .interface
+            .mtu
+    }
+
     /// A shared borrow of a present capture, for [`send`](super::PacketDispatcher::send).
     pub(super) fn capture(&self, capture: CaptureKey) -> Option<&Capture> {
         self.captures.get(capture.0 as usize)?.capture.as_ref()

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -139,6 +139,10 @@ pub(crate) struct Interface {
     pub(crate) name: String,
     pub(crate) ifindex: u32,
     pub(crate) addrs: InterfaceAddresses,
+    /// The MTU as of the last [`refresh`](Self::refresh), `None` when unreadable. Deliberately
+    /// outside [`InterfaceAddresses`]: that struct's equality drives the refresh diffing, and a
+    /// bare MTU change must not read as an address change (which clears sessions).
+    pub(crate) mtu: Option<u32>,
 }
 
 impl Interface {
@@ -152,6 +156,7 @@ impl Interface {
             name: name.to_owned(),
             ifindex: if_index(name).unwrap_or(0),
             addrs: InterfaceAddresses::default(),
+            mtu: None,
         };
         iface.refresh()?;
         Ok(iface)
@@ -168,10 +173,14 @@ impl Interface {
     /// Propagates a resolution syscall failure.
     pub(crate) fn refresh(&mut self) -> io::Result<AddressChange> {
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        let addrs = self::getifaddrs::resolve(&self.name)?;
+        let (addrs, mtu) = self::getifaddrs::resolve(&self.name)?;
         #[cfg(target_os = "linux")]
-        let addrs = self::rtnetlink::resolve(&self.name, self.ifindex)?;
-        log::debug!("{}: resolved {addrs}", self.name);
+        let (addrs, mtu) = self::rtnetlink::resolve(&self.name, self.ifindex)?;
+        self.mtu = mtu;
+        match mtu {
+            Some(mtu) => log::debug!("{}: resolved {addrs}, mtu {mtu}", self.name),
+            None => log::debug!("{}: resolved {addrs}, mtu unreadable", self.name),
+        }
         // Both v6 transitions are logged (the `let`s run before the `||`), and either folds into the
         // single `v6` change bit, since no caller distinguishes the two v6 sources.
         let v6 = log_field_change(&self.name, "IPv6", self.addrs.v6, addrs.v6);
@@ -494,5 +503,22 @@ mod tests {
         crate::logging::set_level(crate::config::LogLevel::Trace);
         let addrs = Interface::open(&iface).expect("open failed").addrs;
         eprintln!("resolved {iface}: {addrs}");
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "resolves a real interface")]
+    fn resolves_loopback_mtu() {
+        // The loopback MTU is a stable per-OS constant, so pin it exactly: this doubles as the
+        // layout canary for the `if_data` read (a wrong field offset yields a counter or zero,
+        // never this value). No privileges are needed on any OS.
+        #[cfg(target_os = "linux")]
+        const LOOPBACK_MTU: u32 = 65536;
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        const LOOPBACK_MTU: u32 = 16384;
+        let mtu = Interface::open(LOOPBACK_IFACE)
+            .unwrap()
+            .mtu
+            .expect("loopback has an MTU");
+        assert_eq!(mtu, LOOPBACK_MTU);
     }
 }

--- a/src/interface/getifaddrs.rs
+++ b/src/interface/getifaddrs.rs
@@ -13,13 +13,21 @@ use libc::c_int;
 use super::{InterfaceAddresses, V6Pick, v6_rank};
 use crate::net::mac::MacAddr;
 
-/// Resolve `if_name`'s current source addresses in one `getifaddrs` pass.
+/// What an `AF_LINK` entry's `ifa_data` points at: the interface's `if_data`. libc binds it for
+/// FreeBSD; libcex fills apple's until libc ships it.
+#[cfg(target_os = "freebsd")]
+type LinkData = libc::if_data;
+#[cfg(target_os = "macos")]
+type LinkData = crate::libcex::IfData;
+
+/// Resolve `if_name`'s current source addresses (plus the interface MTU) in one `getifaddrs`
+/// pass.
 ///
 /// # Errors
 /// Returns an error if `getifaddrs` fails or the v6 flag socket can't open; an unknown
 /// interface (or one with no addresses yet) yields an all-absent [`InterfaceAddresses`],
 /// as does a host with no IPv6 stack.
-pub(super) fn resolve(if_name: &str) -> io::Result<InterfaceAddresses> {
+pub(super) fn resolve(if_name: &str) -> io::Result<(InterfaceAddresses, Option<u32>)> {
     // One socket for the per-v6 `SIOCGIFAFLAG_IN6` ioctl.
     let v6_sock = inet6_socket()?;
 
@@ -32,6 +40,7 @@ pub(super) fn resolve(if_name: &str) -> io::Result<InterfaceAddresses> {
 
     let mut addrs = InterfaceAddresses::default();
     let mut v6_pick = V6Pick::default();
+    let mut mtu: Option<u32> = None;
     let mut node = head;
     while !node.is_null() {
         // SAFETY: `node` points at a live list entry owned by `head`, valid until
@@ -72,6 +81,10 @@ pub(super) fn resolve(if_name: &str) -> io::Result<InterfaceAddresses> {
                     None => log::trace!("{if_name}: link layer carries no mac"),
                 }
                 addrs.mac = mac;
+                if !ifa.ifa_data.is_null() {
+                    // SAFETY: an `AF_LINK` entry's non-null `ifa_data` points at the `if_data`.
+                    mtu = Some(unsafe { (*ifa.ifa_data.cast::<LinkData>()).ifi_mtu });
+                }
             }
             libc::AF_INET6 => {
                 // SAFETY: family is `AF_INET6`, so `ifa_addr` points at a `sockaddr_in6`.
@@ -100,7 +113,7 @@ pub(super) fn resolve(if_name: &str) -> io::Result<InterfaceAddresses> {
 
     // SAFETY: `head` came from the matching `getifaddrs` and has not been freed yet.
     unsafe { libc::freeifaddrs(head) };
-    Ok(addrs)
+    Ok((addrs, mtu))
 }
 
 /// The IPv4 address of an `AF_INET` `sockaddr`.

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -66,18 +66,22 @@ pub(super) fn read_at<T>(buf: &[u8], off: usize) -> Option<T> {
 
 /// Resolve interface `ifindex`'s current source addresses with two netlink dumps:
 /// `RTM_GETADDR` for v4/v6 (flag-filtered, link-local > ULA > global) and `RTM_GETLINK` for
-/// the MAC. `if_name` is for tracing only; the dumps are filtered by `ifindex`. A `0`
+/// the MAC and MTU. `if_name` is for tracing only; the dumps are filtered by `ifindex`. A `0`
 /// `ifindex` (the caller's "unknown interface" sentinel) skips the dumps.
 ///
 /// # Errors
 /// Returns an error if a netlink socket, request, or reply fails.
-pub(super) fn resolve(if_name: &str, ifindex: u32) -> io::Result<InterfaceAddresses> {
+pub(super) fn resolve(
+    if_name: &str,
+    ifindex: u32,
+) -> io::Result<(InterfaceAddresses, Option<u32>)> {
     if ifindex == 0 {
-        return Ok(InterfaceAddresses::default());
+        return Ok((InterfaceAddresses::default(), None));
     }
 
     let sock = netlink_socket()?;
     let mut addrs = InterfaceAddresses::default();
+    let mut mtu = None;
 
     let mut v6_pick = V6Pick::default();
     // SAFETY: a zeroed `ifaddrmsg` (an all-integer POD) is a valid `AF_UNSPEC` address-dump
@@ -100,11 +104,11 @@ pub(super) fn resolve(if_name: &str, ifindex: u32) -> io::Result<InterfaceAddres
         libc::RTM_NEWLINK,
         link_req,
         |msg| {
-            scan_link(msg, if_name, ifindex, &mut addrs);
+            scan_link(msg, if_name, ifindex, &mut addrs, &mut mtu);
         },
     )?;
 
-    Ok(addrs)
+    Ok((addrs, mtu))
 }
 
 fn netlink_socket() -> io::Result<OwnedFd> {
@@ -346,9 +350,15 @@ fn scan_addr(
     }
 }
 
-/// Parse one `RTM_NEWLINK` message; if it is `ifindex` and carries a 6-byte `IFLA_ADDRESS`,
-/// record it as the MAC. `msg` spans one netlink message.
-fn scan_link(msg: &[u8], if_name: &str, ifindex: u32, addrs: &mut InterfaceAddresses) {
+/// Parse one `RTM_NEWLINK` message; if it is `ifindex`, record its 6-byte `IFLA_ADDRESS` as the
+/// MAC and its `IFLA_MTU`. `msg` spans one netlink message.
+fn scan_link(
+    msg: &[u8],
+    if_name: &str,
+    ifindex: u32,
+    addrs: &mut InterfaceAddresses,
+    mtu: &mut Option<u32>,
+) {
     let body_at = nl_align(size_of::<libc::nlmsghdr>());
     let Some(body) = read_at::<libc::ifinfomsg>(msg, body_at) else {
         return;
@@ -364,8 +374,12 @@ fn scan_link(msg: &[u8], if_name: &str, ifindex: u32, addrs: &mut InterfaceAddre
             let mac = MacAddr::from(mac);
             log::trace!("{if_name}: mac {mac}");
             addrs.mac = Some(mac);
-            // A link has a single L2 address; the rest of the message is irrelevant.
-            return;
+        } else if attr_type == libc::IFLA_MTU
+            && let Ok(bytes) = <[u8; 4]>::try_from(data)
+        {
+            let value = u32::from_ne_bytes(bytes);
+            log::trace!("{if_name}: mtu {value}");
+            *mtu = Some(value);
         }
     }
 }
@@ -544,11 +558,29 @@ mod tests {
         let mac = [0x02, 0, 0, 0, 0, 0x2a];
         let msg = link_msg(5, &[(libc::IFLA_ADDRESS, &mac)]);
         let mut addrs = InterfaceAddresses::default();
-        scan_link(&msg, "eth0", 5, &mut addrs);
+        let mut mtu = None;
+        scan_link(&msg, "eth0", 5, &mut addrs, &mut mtu);
         assert_eq!(addrs.mac, Some(MacAddr::from(mac)));
 
         let mut other = InterfaceAddresses::default();
-        scan_link(&msg, "eth0", 6, &mut other);
+        scan_link(&msg, "eth0", 6, &mut other, &mut mtu);
         assert_eq!(other.mac, None);
+    }
+
+    #[test]
+    fn scan_link_records_the_mtu_beside_the_mac() {
+        let mac = [0x02, 0, 0, 0, 0, 0x2a];
+        let msg = link_msg(
+            5,
+            &[
+                (libc::IFLA_ADDRESS, &mac),
+                (libc::IFLA_MTU, &1500u32.to_ne_bytes()),
+            ],
+        );
+        let mut addrs = InterfaceAddresses::default();
+        let mut mtu = None;
+        scan_link(&msg, "eth0", 5, &mut addrs, &mut mtu);
+        assert_eq!(addrs.mac, Some(MacAddr::from(mac)));
+        assert_eq!(mtu, Some(1500));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ fn reflect(path: Option<&Path>) -> Result<()> {
     let mut dispatcher = PacketDispatcher::new();
     let interfaces = open_captures(&config, &mut dispatcher)?;
     for reflector in &config.reflectors {
+        log_mtu_info(reflector, &interfaces, &dispatcher);
         crate::reflector::wol::build(reflector, &interfaces, &mut dispatcher)
             .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
         crate::reflector::mdns::build(reflector, &interfaces, &mut dispatcher)
@@ -172,6 +173,47 @@ fn open_captures(config: &Config, dispatcher: &mut PacketDispatcher) -> Result<I
         }
     }
     Ok(interfaces)
+}
+
+/// Log an entry's MTU topology: an interface whose MTU exceeds [`net::MAX_MTU`] (netflector
+/// reflects nothing larger regardless of the other side), and an unequal pair whose smaller side
+/// bounds what crosses. Info, never warn: an actual oversize drop warns at the send, with the
+/// frame and MTU in hand; here it is only a possibility.
+fn log_mtu_info(
+    reflector: &config::Reflector,
+    interfaces: &InterfaceMap,
+    dispatcher: &PacketDispatcher,
+) {
+    let (source_if, target_if) = (reflector.source_if.as_str(), reflector.target_if.as_str());
+    let (Ok(source_key), Ok(target_key)) =
+        (interfaces.require(source_if), interfaces.require(target_if))
+    else {
+        return; // the protocol builders surface the unknown-interface error
+    };
+    let (Some(source), Some(target)) = (
+        dispatcher.interface_mtu(source_key),
+        dispatcher.interface_mtu(target_key),
+    ) else {
+        return;
+    };
+    let ceiling = u32::try_from(net::MAX_MTU).expect("the MTU ceiling fits a u32");
+    for (if_name, mtu) in [(source_if, source), (target_if, target)] {
+        if mtu > ceiling {
+            log::info!(
+                "{}: {if_name} MTU {mtu} exceeds the {ceiling}-byte ceiling; larger \
+                 packets are not reflected",
+                reflector.name.as_str(),
+            );
+        }
+    }
+    if source != target && source.min(target) <= ceiling {
+        log::info!(
+            "{}: MTU mismatch: {source_if} has {source}, {target_if} has {target}; packets larger \
+             than {} bytes cannot cross toward the smaller side and are dropped",
+            reflector.name.as_str(),
+            source.min(target),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/libcex.rs
+++ b/src/libcex.rs
@@ -10,6 +10,8 @@
 
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod bpf_device;
+#[cfg(target_os = "macos")]
+mod if_data;
 mod multicast;
 #[cfg(target_os = "linux")]
 mod netlink;
@@ -22,6 +24,8 @@ pub(crate) use self::bpf_device::bpf_wordalign;
 // via `bpf_wordalign`), so re-export it only for tests.
 #[cfg(all(test, any(target_os = "macos", target_os = "freebsd")))]
 pub(crate) use self::bpf_device::BPF_ALIGN;
+#[cfg(target_os = "macos")]
+pub(crate) use self::if_data::IfData;
 pub(crate) use self::multicast::{GroupReq, MCAST_JOIN_GROUP};
 #[cfg(target_os = "linux")]
 pub(crate) use self::netlink::nl_align;

--- a/src/libcex/if_data.rs
+++ b/src/libcex/if_data.rs
@@ -1,0 +1,45 @@
+//! Apple's `<net/if_var.h>` `struct if_data`, which `getifaddrs` hangs off every `AF_LINK`
+//! entry's `ifa_data`. libc binds it for FreeBSD but not apple (only the sysctl-side
+//! `if_data64`, whose field order this matches).
+
+use libc::c_uchar;
+
+/// Field names follow the header for a future libc submission; the resolver reads only
+/// `ifi_mtu`. `ifi_lastchange` is `timeval32` on 64-bit userland (the only apple target shipped).
+#[repr(C)]
+#[allow(clippy::struct_field_names)] // the header's own `ifi_` prefix, kept for the submission
+pub(crate) struct IfData {
+    pub(crate) ifi_type: c_uchar,
+    pub(crate) ifi_typelen: c_uchar,
+    pub(crate) ifi_physical: c_uchar,
+    pub(crate) ifi_addrlen: c_uchar,
+    pub(crate) ifi_hdrlen: c_uchar,
+    pub(crate) ifi_recvquota: c_uchar,
+    pub(crate) ifi_xmitquota: c_uchar,
+    pub(crate) ifi_unused1: c_uchar,
+    pub(crate) ifi_mtu: u32,
+    pub(crate) ifi_metric: u32,
+    pub(crate) ifi_baudrate: u32,
+    pub(crate) ifi_ipackets: u32,
+    pub(crate) ifi_ierrors: u32,
+    pub(crate) ifi_opackets: u32,
+    pub(crate) ifi_oerrors: u32,
+    pub(crate) ifi_collisions: u32,
+    pub(crate) ifi_ibytes: u32,
+    pub(crate) ifi_obytes: u32,
+    pub(crate) ifi_imcasts: u32,
+    pub(crate) ifi_omcasts: u32,
+    pub(crate) ifi_iqdrops: u32,
+    pub(crate) ifi_noproto: u32,
+    pub(crate) ifi_recvtiming: u32,
+    pub(crate) ifi_xmittiming: u32,
+    pub(crate) ifi_lastchange: libc::timeval32,
+    pub(crate) ifi_unused2: u32,
+    pub(crate) ifi_hwassist: u32,
+    pub(crate) ifi_reserved1: u32,
+    pub(crate) ifi_reserved2: u32,
+}
+
+const _: () = assert!(size_of::<IfData>() == 96);
+// The one field the resolver reads, pinned by offset so a transcription slip can't shift it.
+const _: () = assert!(std::mem::offset_of!(IfData, ifi_mtu) == 8);

--- a/src/net.rs
+++ b/src/net.rs
@@ -57,6 +57,11 @@ pub(crate) const MAX_FRAME_LEN: usize = 2048;
 pub(crate) const MAX_UDP_PAYLOAD_LEN: usize =
     MAX_FRAME_LEN - (ETHERNET_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE);
 
+/// The largest interface MTU whose full-size packets still fit [`MAX_FRAME_LEN`] once framed (an
+/// MTU counts L3 bytes; the frame adds the link header). Ethernet is the binding case; a
+/// `DLT_NULL` link's 4-byte header leaves a little more room, accepted as slack.
+pub(crate) const MAX_MTU: usize = MAX_FRAME_LEN - ETHERNET_HEADER_SIZE;
+
 /// Whether `ip` is link-local (IPv4 `169.254.0.0/16`, IPv6 `fe80::/10`).
 pub(crate) fn is_link_local(ip: IpAddr) -> bool {
     match ip {


### PR DESCRIPTION
An entry bridging interfaces of unequal MTU silently drops the largest packets toward the smaller side: nothing fragments a raw injection, so the kernel rejects an over-MTU frame whole. Two commits make that visible. The resolvers now read the MTU where they already stand (IFLA_MTU in the RTM_GETLINK dump on Linux, if_data off the AF_LINK getifaddrs entry on the BSDs) and store it on Interface - deliberately outside InterfaceAddresses, whose equality drives the refresh diffing and must not see a bare MTU change as an address change. Startup logs each entry's MTU picture at info: a mismatch (naming both interfaces and the crossing ceiling), and any interface whose MTU exceeds MAX_MTU, the largest MTU whose packets fit the daemon's 2048-byte frame ceiling. Warnings are reserved for actual drops: an EMSGSIZE send failure now reads "a frame of N bytes exceeds what IF (MTU M) can carry" instead of a bare "Message too long". Apple's libc lacks the plain if_data binding, so libcex temporarily carries a transcription (size- and offset-anchored) pending an upstream submission.

Testing: scan_link parses IFLA_MTU from a crafted message; resolves_loopback_mtu pins the exact per-OS loopback MTU through the real resolver as a layout canary; oversize_context is pure and unit-tested on both arms; clippy -D warnings, full lib suite and rustdoc on macOS and Linux, FreeBSD by CI.