### PR TITLE
Rate-limit recurring warns behind a log_rate! macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ four reflected protocols, in any mix; the DIAL proxy then layers onto SSDP.
 - [Platform support](#platform-support)
 - [Run](#run): [privileges](#runtime-privileges), [Docker](#run-in-docker), [MikroTik](#on-mikrotik-routeros), [FreeBSD/OPNsense packages](#install-on-freebsd-and-opnsense)
 - [Configuration](#configuration): [env vars](#environment-variables), [`macs`](#the-macs-field), [`address_family`](#address_family), [per-protocol behavior](#per-protocol-behavior), [DIAL](#dial), [duplicate detection](#duplicate-detection)
+- [Diagnostics](#diagnostics)
 - [Developing](#developing)
 - [License](#license)
 
@@ -54,8 +55,11 @@ Configuration comes from a TOML file, from environment variables, or from both. 
 the file is read and merged with any `NETFLECTOR_*` environment variables; with **no argument** the
 configuration comes entirely from the environment (see [Environment variables](#environment-variables)).
 The process logs to stderr with UTC timestamps, shuts down cleanly on `SIGINT` / `SIGTERM`, and on
-`SIGUSR1` dumps the per-interface [packet counters](#configuration) and a memory report to the log on
-demand (regardless of `counters_interval_secs`).
+`SIGUSR1` dumps the per-interface [packet counters](#diagnostics) and a memory report to the log on
+demand (regardless of `counters_interval_secs`). Warnings whose cause can recur per packet (a failing
+send, an oversized frame) are logged at most once per minute; occurrences inside the window are
+counted and reported by the next logged warning as `(N suppressed)`; the counters carry the exact
+volumes.
 
 | Option | |
 | --- | --- |
@@ -225,7 +229,8 @@ pkg install os-netflector
 `config.toml` contains optional top-level settings plus at least one reflector entry. Entries are tables
 under `reflectors`, keyed by name (`[reflectors.<name>]`, the name being the label used in logs), each
 describing one `source_if` → `target_if` bridge that enables one or more of the protocols. The
-top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_interval_secs`:
+top-level settings are `log_level`, `debug_memory_interval_secs`, and `counters_interval_secs` (the
+summaries the latter enables are described under [Diagnostics](#diagnostics)):
 
 ```toml
 log_level = "info"                 # optional; one of off | error | warn | info | debug | trace (default: info)
@@ -436,6 +441,23 @@ share at least one device, or when either omits its MAC filter (any device). Add
 handle the same IP version: an `ipv4`-only and an `ipv6`-only entry never overlap, while `default`/`dual`
 overlap with either. Entries that differ in interface, MAC, address family (or WoL ports), or that
 enable *different* protocols, coexist.
+
+## Diagnostics
+
+With `counters_interval_secs` set (and on `SIGUSR1`), one summary line per interface reports its
+non-zero counters:
+
+```
+counters eth0: recoveries=1; mDNS query reflected=42 skipped=10; SSDP search reflected=5 dropped=1; filtered=2; oversized=3
+```
+
+Per message type: `reflected` (re-emitted on the other interface), `skipped` (right protocol, wrong
+direction for this leg - normal, this is the loop prevention working), `dropped` (should have been
+reflected but was not: a send error, a resource cap, or the link-local suppression) and `stalled`
+(the egress had no source address of the packet's family yet). Interface-wide: `filtered`
+(unrecognized traffic on the group), `oversized` (received frames too large to forward) and
+`recoveries` (the interface was destroyed and recreated, and its capture re-bound). `netflector(8)`
+carries the full definitions.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ search reply whose `LOCATION` names one, a WSD message whose `XAddrs` all name o
 is valid only on the link it came from, so the relayed message would advertise endpoints the other
 segment can never reach. One routable address among them lets the message through. A `LOCATION` the
 DIAL proxy rewrote is exempt: it names netflector's own listener on the egress interface, reachable
-from that link even when the interface's address is itself link-local. Suppressed messages tally as
+from that link even when the interface's address is itself link-local. Suppressed messages count as
 `dropped` and log at debug level.
 
 netflector reads untagged Ethernet frames carrying IPv4 or IPv6 UDP. VLAN-tagged frames and IPv6

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -156,6 +156,10 @@ service.
 scopes the check to the interface carrying the group, needed only when the
 same vhid runs on more than one interface.
 .Sh DIAGNOSTICS
+A warning whose cause can recur per packet (a failing send, an oversized
+frame) is logged at most once per minute; occurrences inside the window are
+counted, and the next logged one reports them as
+.Ql (N suppressed) .
 The counter summary, logged periodically when enabled and on
 .Dv SIGUSR1 ,
 tallies per interface what happened to each packet, by message type
@@ -178,6 +182,8 @@ Not a message
 .Nm
 handles: unrecognized traffic on the group, or an address family the entry
 does not cover.
+.It Sy oversized
+Received frames too large to forward, dropped before parsing.
 .It Sy recoveries
 Times the interface was destroyed and recreated, and its capture re-bound.
 .El

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -162,7 +162,7 @@ counted, and the next logged one reports them as
 .Ql (N suppressed) .
 The counter summary, logged periodically when enabled and on
 .Dv SIGUSR1 ,
-tallies per interface what happened to each packet, by message type
+counts per interface what happened to each packet, by message type
 .Pq e.g. Ql mDNS query reflected=42 skipped=10; filtered=2 :
 .Bl -tag -width "recoveries"
 .It Sy reflected

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -181,7 +181,7 @@ impl Capture {
         false
     }
 
-    /// The oversized-frame drops since the last call, resetting the tally: the dispatcher folds
+    /// The oversized-frame drops since the last call, resetting the count: the dispatcher folds
     /// them into the interface's counter row after each drain.
     pub(crate) fn take_oversized(&mut self) -> u64 {
         std::mem::take(&mut self.oversized)

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -15,6 +15,7 @@ use libc::{c_int, c_void};
 
 use super::filter::{BpfInsn, DROP_OUTGOING_PROLOGUE, ETHERNET_UDP_FILTER};
 use crate::interface::if_index;
+use crate::logging::{WARN_WINDOW, log_rate};
 use crate::net::LinkType;
 use crate::sys::{IoStatus, socklen_of};
 
@@ -27,6 +28,9 @@ pub(crate) struct Capture {
     fd: OwnedFd,
     buf: Box<[u8]>,
     name: String,
+    /// Frames dropped for exceeding the receive buffer since the last
+    /// [`take_oversized`](Self::take_oversized) drain.
+    oversized: u64,
 }
 
 impl Capture {
@@ -72,6 +76,7 @@ impl Capture {
             fd,
             buf: vec![0u8; crate::net::MAX_FRAME_LEN].into_boxed_slice(),
             name: if_name.into(),
+            oversized: 0,
         })
     }
 
@@ -151,12 +156,17 @@ impl Capture {
             // MSG_TRUNC reports the frame's real length even past the buffer, so an
             // oversized frame is detectable (and dropped) instead of silently cut.
             if bytes > self.buf.len() {
-                // trace, not warn: per-frame drain loop, and a remote peer can flood oversized
-                // frames. A per-frame warn would break data-path-quiet and spam the log.
-                log::trace!(
-                    "dropping oversized frame: {bytes} bytes exceeds the {}-byte receive buffer",
+                // Rate-limited: this is the per-frame drain loop, and a remote peer can flood
+                // oversized frames.
+                log_rate!(
+                    log::Level::Warn,
+                    WARN_WINDOW,
+                    "{}: dropping oversized frame: {bytes} bytes exceeds the {}-byte receive \
+                     buffer",
+                    self.name,
                     self.buf.len()
                 );
+                self.oversized += 1;
                 continue;
             }
             break bytes;
@@ -169,6 +179,12 @@ impl Capture {
     #[allow(clippy::unused_self)] // uniform Capture API; the BPF backend reads self
     pub(crate) fn has_buffered(&self) -> bool {
         false
+    }
+
+    /// The oversized-frame drops since the last call, resetting the tally: the dispatcher folds
+    /// them into the interface's counter row after each drain.
+    pub(crate) fn take_oversized(&mut self) -> u64 {
+        std::mem::take(&mut self.oversized)
     }
 
     /// Inject a fully-built link-layer `frame` on this interface.

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -18,6 +18,7 @@ use libc::{c_uint, c_ulong, c_void};
 
 use super::filter::{BpfInsn, DLT_NULL_UDP_FILTER, ETHERNET_UDP_FILTER};
 use crate::libcex::bpf_wordalign;
+use crate::logging::{WARN_WINDOW, log_rate};
 use crate::net::LinkType;
 use crate::sys::IoStatus;
 
@@ -29,6 +30,9 @@ pub(crate) struct Capture {
     offset: usize,
     link_type: LinkType,
     name: String,
+    /// Frames dropped for exceeding the forwarding limit since the last
+    /// [`take_oversized`](Self::take_oversized) drain.
+    oversized: u64,
 }
 
 impl Capture {
@@ -66,6 +70,7 @@ impl Capture {
             offset: 0,
             link_type,
             name: if_name.into(),
+            oversized: 0,
         })
     }
 
@@ -137,13 +142,19 @@ impl Capture {
             self.offset = start + advance;
             match record {
                 Record::Frame(frame) => break (start + frame.start)..(start + frame.end),
-                // trace, not warn: this runs in the per-frame drain loop, and a remote peer can flood
-                // oversized frames. A per-frame warn would both break data-path-quiet and spam the
-                // operator's log. The frame is still correctly dropped.
-                Record::Oversized { datalen } => log::trace!(
-                    "dropping oversized frame: {datalen} bytes exceeds the {}-byte forwarding limit",
-                    crate::net::MAX_FRAME_LEN
-                ),
+                // Rate-limited: this is the per-frame drain loop, and a remote peer can flood
+                // oversized frames.
+                Record::Oversized { datalen } => {
+                    log_rate!(
+                        log::Level::Warn,
+                        WARN_WINDOW,
+                        "{}: dropping oversized frame: {datalen} bytes exceeds the {}-byte \
+                         forwarding limit",
+                        self.name,
+                        crate::net::MAX_FRAME_LEN
+                    );
+                    self.oversized += 1;
+                }
             }
         };
         Ok(Some(&self.buf[range]))
@@ -153,6 +164,12 @@ impl Capture {
     /// draining, since a level-triggered wait won't re-fire until new kernel data.
     pub(crate) fn has_buffered(&self) -> bool {
         self.offset < self.filled
+    }
+
+    /// The oversized-frame drops since the last call, resetting the tally: the dispatcher folds
+    /// them into the interface's counter row after each drain.
+    pub(crate) fn take_oversized(&mut self) -> u64 {
+        std::mem::take(&mut self.oversized)
     }
 
     /// Inject a fully-built link-layer `frame` on this interface.

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -166,7 +166,7 @@ impl Capture {
         self.offset < self.filled
     }
 
-    /// The oversized-frame drops since the last call, resetting the tally: the dispatcher folds
+    /// The oversized-frame drops since the last call, resetting the count: the dispatcher folds
     /// them into the interface's counter row after each drain.
     pub(crate) fn take_oversized(&mut self) -> u64 {
         std::mem::take(&mut self.oversized)

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -555,6 +555,10 @@ impl PacketDispatcher {
         if drained > 0 {
             log::trace!("fd {fd}: drained {drained} frame(s)");
         }
+        let oversized = capture.take_oversized();
+        if oversized > 0 {
+            self.table.record_oversized(ingress, oversized);
+        }
         if !self.table.restore(ingress, capture) {
             log::warn!("drain_and_route: ingress {ingress:?} vanished mid-drain; capture dropped");
         }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -225,7 +225,7 @@ struct Registration {
     handler: Option<Box<dyn PacketHandler>>,
 }
 
-/// The periodic counter-summary schedule: log every capture's tallies every `interval`. Held as an
+/// The periodic counter-summary schedule: log every capture's counts every `interval`. Held as an
 /// `Option` on the dispatcher; `None` disables reporting, and the counters accrue regardless.
 struct CounterReport {
     interval: Duration,
@@ -281,7 +281,7 @@ impl PacketDispatcher {
         }
     }
 
-    /// Enable the periodic counter summary: log each capture's tallies every `interval`, first firing
+    /// Enable the periodic counter summary: log each capture's counts every `interval`, first firing
     /// `interval` after `now`. Called from [`run`](crate::run) when the config sets a positive
     /// interval; the counters accrue regardless, so this controls only whether they are reported.
     pub(crate) fn enable_counter_report(&mut self, interval: Duration, now: Instant) {
@@ -629,7 +629,7 @@ impl PacketDispatcher {
                 }
             });
         }
-        // One packet, one tally: record the folded outcome on the ingress capture's row. The row
+        // One packet, one count: record the folded outcome on the ingress capture's row. The row
         // always exists: `route` is reached only via the drain, whose take-out guard admits only a
         // real, in-range ingress key.
         if let Some(outcome) = final_outcome {
@@ -1110,7 +1110,7 @@ mod tests {
         Ok(())
     }
 
-    // A completed recovery bumps the recoveries tally on each of the interface's capture rows.
+    // A completed recovery bumps the recoveries count on each of the interface's capture rows.
     // Unprivileged: the moved identity is faked through the test seam and the capture row is a
     // capture-less test entry (rebind_capture reports it missing, which does not fail the recovery).
     #[test]
@@ -1459,19 +1459,19 @@ mod tests {
     impl PacketDispatcher {
         /// Add a capture-less table entry so a routing test can mint a valid `CaptureKey` and
         /// exercise `route`'s record path without opening a real capture; read the row back with
-        /// [`tally`](Self::tally).
+        /// [`counts`](Self::counts).
         fn add_test_capture(&mut self) -> CaptureKey {
             self.table.add_test_capture()
         }
 
-        /// The `(reflected, skipped, dropped, stalled)` tally recorded for `ty` on `key`'s row.
-        fn tally(&self, key: CaptureKey, ty: MessageType) -> (u64, u64, u64, u64) {
+        /// The `(reflected, skipped, dropped, stalled)` count recorded for `ty` on `key`'s row.
+        fn counts(&self, key: CaptureKey, ty: MessageType) -> (u64, u64, u64, u64) {
             self.table.typed_counts(key, ty)
         }
     }
 
     // route folds every matched handler's outcome into one and records it once on the ingress row:
-    // a reflect and its mirror skip (both matching) tally a single reflect, and a handler whose filter
+    // a reflect and its mirror skip (both matching) count a single reflect, and a handler whose filter
     // misses doesn't contribute at all.
     #[test]
     #[cfg_attr(miri, ignore = "needs a real socket")]
@@ -1491,7 +1491,7 @@ mod tests {
             Filter::default(),
             Box::new(Outcomer(Outcome::Skipped(MessageType::MdnsQuery))),
         );
-        // A third handler whose filter never matches (wrong dst port) must not reach the tally.
+        // A third handler whose filter never matches (wrong dst port) must not reach the count.
         dispatcher.register(
             ingress,
             Filter {
@@ -1503,14 +1503,14 @@ mod tests {
 
         dispatcher.route(ingress, &probe_packet(b"q"), &mut reactor);
 
-        // The reflect wins the fold and is counted once; the skip is shadowed, not a second tally.
+        // The reflect wins the fold and is counted once; the skip is shadowed, not a second count.
         assert_eq!(
-            dispatcher.tally(ingress, MessageType::MdnsQuery),
+            dispatcher.counts(ingress, MessageType::MdnsQuery),
             (1, 0, 0, 0)
         );
         // The unmatched handler contributed nothing.
         assert_eq!(
-            dispatcher.tally(ingress, MessageType::SsdpSearch),
+            dispatcher.counts(ingress, MessageType::SsdpSearch),
             (0, 0, 0, 0)
         );
         Ok(())
@@ -1538,9 +1538,9 @@ mod tests {
 
         dispatcher.route(ingress, &probe_packet(b"q"), &mut reactor);
 
-        // One packet, one tally per ingress: the two reflects fold to a single reflected count.
+        // One packet, one count per ingress: the two reflects fold to a single reflected count.
         assert_eq!(
-            dispatcher.tally(ingress, MessageType::MdnsQuery),
+            dispatcher.counts(ingress, MessageType::MdnsQuery),
             (1, 0, 0, 0)
         );
         Ok(())

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -174,13 +174,15 @@ impl TypeCounters {
 }
 
 /// Every tally for one interface (capture): one [`TypeCounters`] per [`MessageType`], a type-less
-/// `filtered` count for junk, and a `recoveries` count of completed interface rebuilds (a recreated
-/// or returned interface whose captures re-bound).
+/// `filtered` count for junk, a `recoveries` count of completed interface rebuilds (a recreated
+/// or returned interface whose captures re-bound), and a type-less `oversized` count of received
+/// frames too large to forward (dropped before parsing).
 #[derive(Clone, Default)]
 pub(crate) struct CaptureCounters {
     types: [TypeCounters; MESSAGE_TYPE_COUNT],
     filtered: u64,
     recoveries: u64,
+    oversized: u64,
 }
 
 impl CaptureCounters {
@@ -200,6 +202,12 @@ impl CaptureCounters {
     /// per-packet outcome, so it leads the report line.
     pub(crate) fn record_recovery(&mut self) {
         self.recoveries += 1;
+    }
+
+    /// Tally `n` frames the capture dropped for exceeding the forwarding limit, folded in per
+    /// drain rather than per frame.
+    pub(crate) fn record_oversized(&mut self, n: u64) {
+        self.oversized += n;
     }
 
     /// This row's non-zero tallies as one line, e.g. `recoveries=1; mDNS query reflected=42
@@ -222,6 +230,9 @@ impl CaptureCounters {
         );
         if self.filtered > 0 {
             parts.push(format!("filtered={}", self.filtered));
+        }
+        if self.oversized > 0 {
+            parts.push(format!("oversized={}", self.oversized));
         }
         (!parts.is_empty()).then(|| parts.join("; "))
     }
@@ -303,6 +314,20 @@ mod tests {
         assert_eq!(c.typed(MessageType::SsdpSearch), (0, 0, 1, 1));
         assert_eq!(c.typed(MessageType::WakeOnLan), (0, 0, 0, 0));
         assert_eq!(c.filtered(), 1);
+    }
+
+    #[test]
+    fn record_oversized_counts_and_reports() {
+        let mut c = CaptureCounters::default();
+        c.record_oversized(3);
+        c.record_oversized(2);
+        // Reported on its own even with no routed packet, trailing the summary.
+        assert_eq!(c.format_nonzero().as_deref(), Some("oversized=5"));
+        c.record(Outcome::Filtered);
+        assert_eq!(
+            c.format_nonzero().as_deref(),
+            Some("filtered=1; oversized=5")
+        );
     }
 
     #[test]

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -9,7 +9,7 @@
 //! config" [`Anomalies`] for the dispatcher to log.
 //!
 //! The interface dimension is the ingress [`CaptureKey`](super::CaptureKey), which the dispatcher
-//! supplies; a [`CaptureCounters`] row per interface holds the tallies.
+//! supplies; a [`CaptureCounters`] row per interface holds the counts.
 
 use std::fmt;
 
@@ -146,7 +146,7 @@ impl Outcome {
     }
 }
 
-/// The four typed tallies for one message type on one interface.
+/// The four typed counts for one message type on one interface.
 #[derive(Clone, Copy, Default)]
 struct TypeCounters {
     reflected: u64,
@@ -156,7 +156,7 @@ struct TypeCounters {
 }
 
 impl TypeCounters {
-    /// The non-zero tallies as `reflected=.. skipped=..`, or `None` when every tally is zero (so the
+    /// The non-zero counts as `reflected=.. skipped=..`, or `None` when every count is zero (so the
     /// report omits a message type nothing has happened to).
     fn format_nonzero(&self) -> Option<String> {
         let parts: Vec<String> = [
@@ -173,7 +173,7 @@ impl TypeCounters {
     }
 }
 
-/// Every tally for one interface (capture): one [`TypeCounters`] per [`MessageType`], a type-less
+/// Every count for one interface (capture): one [`TypeCounters`] per [`MessageType`], a type-less
 /// `filtered` count for junk, a `recoveries` count of completed interface rebuilds (a recreated
 /// or returned interface whose captures re-bound), and a type-less `oversized` count of received
 /// frames too large to forward (dropped before parsing).
@@ -186,7 +186,7 @@ pub(crate) struct CaptureCounters {
 }
 
 impl CaptureCounters {
-    /// Tally one packet's folded [`Outcome`].
+    /// Count one packet's folded [`Outcome`].
     pub(crate) fn record(&mut self, outcome: Outcome) {
         match outcome {
             Outcome::Reflected(t) => self.types[t as usize].reflected += 1,
@@ -197,20 +197,20 @@ impl CaptureCounters {
         }
     }
 
-    /// Tally one completed recovery of the interface behind this row: its kernel identity was
+    /// Count one completed recovery of the interface behind this row: its kernel identity was
     /// recreated (or it returned from absent) and its captures re-bound. A lifecycle event, not a
     /// per-packet outcome, so it leads the report line.
     pub(crate) fn record_recovery(&mut self) {
         self.recoveries += 1;
     }
 
-    /// Tally `n` frames the capture dropped for exceeding the forwarding limit, folded in per
+    /// Count `n` frames the capture dropped for exceeding the forwarding limit, folded in per
     /// drain rather than per frame.
     pub(crate) fn record_oversized(&mut self, n: u64) {
         self.oversized += n;
     }
 
-    /// This row's non-zero tallies as one line, e.g. `recoveries=1; mDNS query reflected=42
+    /// This row's non-zero counts as one line, e.g. `recoveries=1; mDNS query reflected=42
     /// skipped=10; SSDP search reflected=5 dropped=1; filtered=2`. `None` when nothing has been
     /// counted, so an idle interface produces no report line.
     fn format_nonzero(&self) -> Option<String> {
@@ -238,7 +238,7 @@ impl CaptureCounters {
     }
 }
 
-/// Log one `info` line per interface with any non-zero tallies (idle interfaces stay silent). The
+/// Log one `info` line per interface with any non-zero counts (idle interfaces stay silent). The
 /// dispatcher calls this from its periodic report; the `(interface, row)` pairs come from the
 /// interface table, which owns the capture→interface-name mapping.
 pub(crate) fn log_counters<'a>(rows: impl Iterator<Item = (&'a str, &'a CaptureCounters)>) {
@@ -254,7 +254,7 @@ mod tests {
     use super::*;
 
     impl CaptureCounters {
-        /// The four typed tallies (`reflected, skipped, dropped, stalled`) for `ty`. The test reader
+        /// The four typed counts (`reflected, skipped, dropped, stalled`) for `ty`. The test reader
         /// for recorded outcomes, here and in the dispatcher's route-fold test.
         pub(crate) fn typed(&self, ty: MessageType) -> (u64, u64, u64, u64) {
             let c = self.types[ty as usize];
@@ -263,7 +263,7 @@ mod tests {
         fn filtered(&self) -> u64 {
             self.filtered
         }
-        /// This row's recovery tally. Read from the dispatcher's reconcile test through the
+        /// This row's recovery count. Read from the dispatcher's reconcile test through the
         /// interface table, hence `pub(crate)`.
         pub(crate) fn recoveries(&self) -> u64 {
             self.recoveries
@@ -347,7 +347,7 @@ mod tests {
     }
 
     #[test]
-    fn format_nonzero_summarizes_only_touched_tallies() {
+    fn format_nonzero_summarizes_only_touched_counters() {
         let mut c = CaptureCounters::default();
         assert_eq!(c.format_nonzero(), None, "an untouched row logs no line");
         c.record(Outcome::Reflected(MessageType::MdnsQuery));
@@ -355,7 +355,7 @@ mod tests {
         c.record(Outcome::Skipped(MessageType::MdnsQuery));
         c.record(Outcome::Dropped(MessageType::SsdpSearch));
         c.record(Outcome::Filtered);
-        // Only touched types and sub-tallies appear, in declaration order, then the filtered total.
+        // Only touched types and sub-counts appear, in declaration order, then the filtered total.
         assert_eq!(
             c.format_nonzero().as_deref(),
             Some("mDNS query reflected=2 skipped=1; SSDP search dropped=1; filtered=1"),

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -211,6 +211,15 @@ impl InterfaceTable {
         self.captures[capture.0 as usize].counters.record_recovery();
     }
 
+    /// Tally `n` oversized-frame drops on a capture's row (see
+    /// [`CaptureCounters::record_oversized`]). Indexed directly, like [`record`](Self::record):
+    /// the drain that produced the count holds the row's own capture.
+    pub(super) fn record_oversized(&mut self, capture: CaptureKey, n: u64) {
+        self.captures[capture.0 as usize]
+            .counters
+            .record_oversized(n);
+    }
+
     /// Each capture's `(interface name, counter row)` for the periodic report. The table owns the
     /// capture→interface-name mapping and stays log-free (the dispatcher does the logging).
     pub(super) fn counter_rows(&self) -> impl Iterator<Item = (&str, &CaptureCounters)> {

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -29,10 +29,10 @@ pub(super) struct StaleInterface {
     pub(super) cur: u32,
 }
 
-/// One capture, the interface it runs on, and its observability tallies. The `capture` is `Option`
+/// One capture, the interface it runs on, and its observability counts. The `capture` is `Option`
 /// so the drain can take it OUT and restore it; the `interface` link and `counters` stay resident,
 /// so a capture's addresses resolve and its routed outcomes still record mid-drain. `None` marks
-/// "currently draining". Never removed, so the tallies accrue for the whole run. Bundling the
+/// "currently draining". Never removed, so the counts accrue for the whole run. Bundling the
 /// counters here rather than a parallel `Vec` makes them impossible to desync: one push adds both.
 struct CaptureEntry {
     capture: Option<Capture>,
@@ -197,21 +197,21 @@ impl InterfaceTable {
         }
     }
 
-    /// Tally a routed packet's folded [`Outcome`] on `capture`'s counter row. Indexed directly:
+    /// Count a routed packet's folded [`Outcome`] on `capture`'s counter row. Indexed directly:
     /// recording is reached only from `route`, with the ingress key of a real, in-range capture (the
     /// drain's take-out guard rejects any other), so the row always exists.
     pub(super) fn record(&mut self, capture: CaptureKey, outcome: Outcome) {
         self.captures[capture.0 as usize].counters.record(outcome);
     }
 
-    /// Tally a completed recovery on a capture's row (see [`CaptureCounters::record_recovery`]).
+    /// Count a completed recovery on a capture's row (see [`CaptureCounters::record_recovery`]).
     /// Indexed directly, like [`record`](Self::record): the keys come from
     /// [`captures_of`](Self::captures_of) in the reconcile, so the row always exists.
     pub(super) fn record_recovery(&mut self, capture: CaptureKey) {
         self.captures[capture.0 as usize].counters.record_recovery();
     }
 
-    /// Tally `n` oversized-frame drops on a capture's row (see
+    /// Count `n` oversized-frame drops on a capture's row (see
     /// [`CaptureCounters::record_oversized`]). Indexed directly, like [`record`](Self::record):
     /// the drain that produced the count holds the row's own capture.
     pub(super) fn record_oversized(&mut self, capture: CaptureKey, n: u64) {
@@ -491,7 +491,7 @@ mod tests {
             key
         }
 
-        /// The `(reflected, skipped, dropped, stalled)` tally recorded for `ty` on `capture`'s row.
+        /// The `(reflected, skipped, dropped, stalled)` count recorded for `ty` on `capture`'s row.
         pub(in crate::dispatch) fn typed_counts(
             &self,
             capture: CaptureKey,
@@ -500,7 +500,7 @@ mod tests {
             self.captures[capture.0 as usize].counters.typed(ty)
         }
 
-        /// The recovery tally recorded on `capture`'s row, for the dispatcher's reconcile test.
+        /// The recovery count recorded on `capture`'s row, for the dispatcher's reconcile test.
         pub(in crate::dispatch) fn recoveries_of(&self, capture: CaptureKey) -> u64 {
             self.captures[capture.0 as usize].counters.recoveries()
         }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -12,7 +12,9 @@
 use std::cell::RefCell;
 use std::fmt::{self, Write as _};
 use std::io::Write;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use log::{LevelFilter, Log, Metadata, Record};
 
@@ -148,6 +150,65 @@ pub(crate) fn set_level(level: LogLevel) {
     log::set_max_level(LevelFilter::from(level));
 }
 
+/// Like [`log::log!`], but emits at most once per `window` (a `Duration`) per call site; a call
+/// landing inside a closed window is counted instead, and the next emitted line discloses the
+/// count as ` (N suppressed)`. The window is per call site, not per entry or interface.
+macro_rules! log_rate {
+    ($level:expr, $window:expr, $($arg:tt)+) => {{
+        static LAST: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        static SUPPRESSED: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        match $crate::logging::rate_gate(
+            &LAST,
+            &SUPPRESSED,
+            $crate::logging::monotonic_secs(),
+            $window,
+        ) {
+            Some(0) => log::log!($level, $($arg)+),
+            Some(suppressed) => log::log!(
+                $level,
+                "{} ({} suppressed)",
+                format_args!($($arg)+),
+                suppressed
+            ),
+            None => {}
+        }
+    }};
+}
+pub(crate) use log_rate;
+
+/// The decision behind [`log_rate!`]: emit now, returning how many were suppressed since the
+/// last emission, or count this one (`None`). The caller reads the clock (as [`format_record`]
+/// does), so the window arithmetic is exercisable against fixed times. Whole-second granularity:
+/// a sub-second window truncates to 0 and every call emits. `u32`, not `u64`, because armv5te (a
+/// shipped target) has no 64-bit atomics; atomics at all only because `static`s demand `Sync` -
+/// the process is single-threaded, hence `Relaxed`.
+pub(crate) fn rate_gate(
+    last: &AtomicU32,
+    suppressed: &AtomicU32,
+    now_secs: u32,
+    window: Duration,
+) -> Option<u32> {
+    // Duration is unsigned, so try_from fails only past u32::MAX s (136 years); read that as never.
+    let window_secs = u32::try_from(window.as_secs()).unwrap_or(u32::MAX);
+    let last_emit = last.load(Ordering::Relaxed);
+    if last_emit == 0 || now_secs.saturating_sub(last_emit) >= window_secs {
+        // max(1): the first call lands at elapsed 0 s, which must not read as "never".
+        last.store(now_secs.max(1), Ordering::Relaxed);
+        Some(suppressed.swap(0, Ordering::Relaxed))
+    } else {
+        suppressed.fetch_add(1, Ordering::Relaxed);
+        None
+    }
+}
+
+/// Seconds since the first call, from the monotonic clock; saturates after 136 years.
+pub(crate) fn monotonic_secs() -> u32 {
+    // A static can't hold a bare `Instant` (no const construction), so the anchor initializes
+    // lazily on first use.
+    static START: LazyLock<Instant> = LazyLock::new(Instant::now);
+    u32::try_from(START.elapsed().as_secs()).unwrap_or(u32::MAX)
+}
+
 impl From<LogLevel> for LevelFilter {
     fn from(level: LogLevel) -> Self {
         match level {
@@ -164,6 +225,28 @@ impl From<LogLevel> for LevelFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rate_gate_emits_first_then_suppresses_within_the_window() {
+        let (last, suppressed) = (AtomicU32::new(0), AtomicU32::new(0));
+        let window = Duration::from_mins(1);
+        // First call emits, with nothing suppressed - even at time 0 (the max(1) offset).
+        assert_eq!(rate_gate(&last, &suppressed, 0, window), Some(0));
+        // Inside the window: counted, not emitted.
+        assert_eq!(rate_gate(&last, &suppressed, 1, window), None);
+        assert_eq!(rate_gate(&last, &suppressed, 59, window), None);
+        // The window reopens: emit, disclosing the two suppressed calls, and the count resets.
+        assert_eq!(rate_gate(&last, &suppressed, 61, window), Some(2));
+        assert_eq!(rate_gate(&last, &suppressed, 200, window), Some(0));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "reads the real clock")]
+    fn monotonic_secs_never_decreases() {
+        let a = monotonic_secs();
+        let b = monotonic_secs();
+        assert!(b >= a);
+    }
 
     #[test]
     fn epoch_renders_as_iso() {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -176,6 +176,9 @@ macro_rules! log_rate {
 }
 pub(crate) use log_rate;
 
+/// The default window for [`log_rate!`] emissions.
+pub(crate) const WARN_WINDOW: Duration = Duration::from_mins(1);
+
 /// The decision behind [`log_rate!`]: emit now, returning how many were suppressed since the
 /// last emission, or count this one (`None`). The caller reads the clock (as [`format_record`]
 /// does), so the window arithmetic is exercisable against fixed times. Whole-second granularity:

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -26,7 +26,7 @@ use crate::logging::WARN_WINDOW;
 use crate::reactor::Reactor;
 
 /// A reflector's verdict on a captured payload, from its protocol's classifier. `Reflect`/`Skip` carry
-/// the message's own [`MessageType`] (the packet's *intrinsic* type) so the handler can tally it. See
+/// the message's own [`MessageType`] (the packet's *intrinsic* type) so the handler can count it. See
 /// [`From`] impls like `From<MdnsKind>` in each protocol reflector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Verdict {

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -17,12 +17,17 @@ pub(crate) use simple::SimpleReflector;
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 
+use std::time::Duration;
+
 use thiserror::Error;
 
 use crate::config::AddressFamily;
 use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_deferrable};
 use crate::interface::InterfaceAddresses;
 use crate::reactor::Reactor;
+
+/// The [`log_rate!`](crate::logging::log_rate) window shared by the reflectors' per-packet warns.
+const WARN_WINDOW: Duration = Duration::from_mins(1);
 
 /// A reflector's verdict on a captured payload, from its protocol's classifier. `Reflect`/`Skip` carry
 /// the message's own [`MessageType`] (the packet's *intrinsic* type) so the handler can tally it. See

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -17,17 +17,13 @@ pub(crate) use simple::SimpleReflector;
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 
-use std::time::Duration;
-
 use thiserror::Error;
 
 use crate::config::AddressFamily;
 use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_deferrable};
 use crate::interface::InterfaceAddresses;
+use crate::logging::WARN_WINDOW;
 use crate::reactor::Reactor;
-
-/// The [`log_rate!`](crate::logging::log_rate) window shared by the reflectors' per-packet warns.
-const WARN_WINDOW: Duration = Duration::from_mins(1);
 
 /// A reflector's verdict on a captured payload, from its protocol's classifier. `Reflect`/`Skip` carry
 /// the message's own [`MessageType`] (the packet's *intrinsic* type) so the handler can tally it. See

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -12,6 +12,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
+use crate::logging::log_rate;
 use crate::net::tcp::TcpSocket;
 use crate::reactor::{Arena, Handler, HandlerKey, Key, Reactor, ReadyEvent};
 
@@ -81,9 +82,6 @@ pub(super) struct DialDeviceProxy {
     /// The device's REST endpoint, learned (and re-learned) from a description response's `Application-URL`;
     /// `None` until the first description fetch reveals it. REST connections proxy here.
     rest_endpoint: Option<SocketAddrV4>,
-    /// When saturation was last reported, so it repeats at [`CAP_WARN_INTERVAL`] rather than per
-    /// rejected client.
-    last_cap_warn: Option<Instant>,
     conns: Arena<Connection>,
 }
 
@@ -105,7 +103,6 @@ impl DialDeviceProxy {
             desc_endpoint,
             rest,
             rest_endpoint: None,
-            last_cap_warn: None,
             conns: Arena::new(),
         }
     }
@@ -145,17 +142,12 @@ impl DialDeviceProxy {
             }
         };
         if self.conns.iter().count() >= MAX_CONNECTIONS {
-            let now = Instant::now();
-            if self
-                .last_cap_warn
-                .is_none_or(|t| now - t >= CAP_WARN_INTERVAL)
-            {
-                self.last_cap_warn = Some(now);
-                log::warn!(
-                    "dial: connection cap ({MAX_CONNECTIONS}) reached for {}; dropping new clients",
-                    self.desc_endpoint
-                );
-            }
+            log_rate!(
+                log::Level::Warn,
+                CAP_WARN_INTERVAL,
+                "dial: connection cap ({MAX_CONNECTIONS}) reached for {}; dropping new clients",
+                self.desc_endpoint
+            );
             return None; // `client` drops here, closing it
         }
         Some(client)

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -17,12 +17,13 @@ use crate::dispatch::{
     CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, RegistrationKey,
 };
 use crate::interface::{InterfaceAddresses, Ipv6Scope};
+use crate::logging::log_rate;
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
 use crate::net::port_reservation::PortReservation;
 use crate::reactor::Reactor;
 
-use super::{ReplyRewrite, Verdict, egress_sources};
+use super::{ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
 
 /// In-flight session cap, so a burst of searchers can't exhaust ephemeral ports or registrations. At
 /// the cap a new search is dropped (no live session is evicted early).
@@ -115,7 +116,9 @@ impl PacketHandler for ResponseReflector {
                 Outcome::Reflected(self.message_type)
             }
             Err(e) => {
-                log::warn!(
+                log_rate!(
+                    log::Level::Warn,
+                    WARN_WINDOW,
                     "{}: cannot reflect response to searcher {}: {e}",
                     self.name,
                     self.searcher
@@ -204,7 +207,9 @@ impl SearchReflector {
         message_type: MessageType,
     ) -> Result<Session, Outcome> {
         if self.sessions.len() >= MAX_SESSIONS {
-            log::warn!(
+            log_rate!(
+                log::Level::Warn,
+                WARN_WINDOW,
                 "{}: dropping search from {}: {MAX_SESSIONS} sessions in flight (cap)",
                 self.name,
                 packet.source
@@ -212,7 +217,9 @@ impl SearchReflector {
             return Err(Outcome::Dropped(message_type));
         }
         let Some(searcher_mac) = packet.src_mac else {
-            log::warn!(
+            log_rate!(
+                log::Level::Warn,
+                WARN_WINDOW,
                 "{}: cannot reflect search from {}: frame has no source MAC to reply to",
                 self.name,
                 packet.source
@@ -234,7 +241,9 @@ impl SearchReflector {
         let reservation = match PortReservation::create(our_addr, target_ifindex) {
             Ok(reservation) => reservation,
             Err(e) => {
-                log::warn!(
+                log_rate!(
+                    log::Level::Warn,
+                    WARN_WINDOW,
                     "{}: port reservation for searcher {} failed: {e}",
                     self.name,
                     packet.source
@@ -350,7 +359,9 @@ impl PacketHandler for SearchReflector {
                     Outcome::Reflected(message_type)
                 }
                 Err(e) => {
-                    log::warn!(
+                    log_rate!(
+                        log::Level::Warn,
+                        WARN_WINDOW,
                         "{}: cannot reflect search from {} to {}: {e}",
                         self.name,
                         packet.source,
@@ -380,7 +391,9 @@ impl PacketHandler for SearchReflector {
             }
             Err(e) => {
                 // Roll back the response registration just made; the reservation drops with `session`.
-                log::warn!(
+                log_rate!(
+                    log::Level::Warn,
+                    WARN_WINDOW,
                     "{}: cannot reflect search from {} to {}: {e}",
                     self.name,
                     packet.source,

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -7,10 +7,11 @@
 //! (per-searcher sessions), so they use the shared `SearchReflector` instead.
 
 use crate::dispatch::{CaptureKey, Outcome, PacketDispatcher, PacketHandler};
+use crate::logging::log_rate;
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
 
-use super::{NoRewrite, ReplyRewrite, Verdict, egress_sources};
+use super::{NoRewrite, ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
 
 /// One direction of one multicast-discovery protocol: re-emits each accepted message captured on its
 /// ingress onto `egress`, to the message's own destination (the dispatcher's filter pins that to the
@@ -135,7 +136,9 @@ impl PacketHandler for SimpleReflector {
                 Outcome::Reflected(message_type)
             }
             Err(e) => {
-                log::warn!(
+                log_rate!(
+                    log::Level::Warn,
+                    WARN_WINDOW,
                     "{}: cannot reflect {} from {} to {}: {e}",
                     self.name,
                     self.kind,

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -204,7 +204,10 @@ pub(crate) fn build(
         Box::new(advertisement),
     );
     // source -> target: searches (unfiltered, any source client may search); each searcher's unicast
-    // 200-OK replies route back through a per-searcher session. With `dial`, each session's reply
+    // 200-OK replies route back through a per-searcher session. The filter deliberately pins only
+    // the group and port: a search relayed by another netflector arrives from its reserved
+    // ephemeral source port, so a src_port or src_mac pin would silently break chained
+    // (router-to-router) deployments. With `dial`, each session's reply
     // rewrites the device's DIAL `LOCATION` (a fresh DialRewrite per session); else it passes through.
     let make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>> = if ssdp.dial {
         Box::new(move || Box::new(DialRewrite::new(target)) as Box<dyn ReplyRewrite>)

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -12,11 +12,12 @@ use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{
     CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, PortSet,
 };
+use crate::logging::log_rate;
 use crate::net::mac::MacSet;
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
 
-use super::{BuildError, InterfaceMap, egress_sources, missing_required_family};
+use super::{BuildError, InterfaceMap, WARN_WINDOW, egress_sources, missing_required_family};
 
 const PREFIX_LEN: usize = 6;
 const MAC_LEN: usize = 6;
@@ -76,7 +77,9 @@ impl PacketHandler for WolReflector {
                 Outcome::Reflected(MessageType::WakeOnLan)
             }
             Err(e) => {
-                log::warn!(
+                log_rate!(
+                    log::Level::Warn,
+                    WARN_WINDOW,
                     "WoL: cannot reflect packet from {} to {dst}: {e}",
                     packet.source
                 );

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -121,7 +121,9 @@ pub(crate) fn build(
         ),
     );
     // source -> target: Probe/Resolve searches (unfiltered, any source client may search); each
-    // searcher's unicast matches route back through a per-searcher session.
+    // searcher's unicast matches route back through a per-searcher session. As with SSDP, the
+    // filter deliberately pins only the group and port; a src constraint would silently break
+    // chained (router-to-router) deployments.
     dispatcher.register(
         source,
         Filter {


### PR DESCRIPTION
A warning whose cause can recur per packet used to either flood the log or hide at trace. log_rate! (logging.rs) emits at most once per window per call site; in-window occurrences are counted and the next emitted line discloses them as "(N suppressed)". The gate arithmetic lives in a testable rate_gate fn; the window argument is typed Duration at the fn boundary.

Migrated onto it: the DIAL connection-cap warn (deleting the hand-rolled last_cap_warn field), the reflectors' per-packet send-failure warns plus the session-cap and no-source-MAC drops, and the capture backends' oversized-frame drops - previously trace-only and invisible to the counters. Those drops now also count: each capture keeps a running count the dispatcher folds into the interface's row per drain, reported as a type-less "oversized" field in the summary. The multicast joiner's reported flag stays: it is edge-triggered episode reporting (fail/still-failing/recovered) with a recovery line a time window cannot express.

Also: the counter fields are now documented in a README Diagnostics section and the man page (incl. oversized and the once-per-minute rate statement), the tally/count vocabulary is unified on "count", and the SSDP/WSD search-ingress filters carry a comment stating why their src fields deliberately stay unconstrained.

Testing: rate_gate's window life-cycle against fixed times; the oversized counter's record/format path; full lib suite, clippy -D warnings and rustdoc on macOS and Linux; mandoc warning+style layers on the man page.