### PR TITLE
reflector: refuse macs on a target link that carries no MACs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,10 @@ devices:
 - **mDNS / SSDP / WSD** relay, in the target→source direction, only frames whose L2 source MAC is in the
   allow-set (exposing just those devices); the source→target direction is never MAC-filtered. For SSDP
   and WSD the same filter scopes the proxied unicast replies: only the allow-set's responses are
-  carried back to a searcher.
+  carried back to a searcher. Because the filter reads the frame's L2 source, these protocols refuse
+  `macs` at startup when the target link carries no MAC addresses (a BSD `DLT_NULL` link such as a
+  loopback or an L3 tunnel) - it could never match. WoL is unaffected: it matches the MAC inside the
+  magic packet's payload.
 
 Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP/WSD relay
 every device's traffic rather than a chosen set (only the message kinds the corresponding direction

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -68,7 +68,12 @@ Optional list of MAC addresses limiting the entry to specific devices on
 only the listed devices are reflected or woken, across every protocol the
 entry enables.
 Omit it to cover the whole segment.
-An empty list is rejected.
+An empty list is rejected, as is a list on an mDNS/SSDP/WSD entry whose
+.Ic target_if
+link carries no MAC addresses (a
+.Dv DLT_NULL
+link): the frame-source filter could never match there.
+Wake-on-LAN is unaffected; it matches the address inside the magic packet.
 .It Ic address_family
 .Cm default
 (the default) attempts both families, requires IPv4, and treats IPv6 as

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -23,6 +23,8 @@ use crate::config::AddressFamily;
 use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_deferrable};
 use crate::interface::InterfaceAddresses;
 use crate::logging::WARN_WINDOW;
+use crate::net::LinkType;
+use crate::net::mac::MacSet;
 use crate::reactor::Reactor;
 
 /// A reflector's verdict on a captured payload, from its protocol's classifier. `Reflect`/`Skip` carry
@@ -126,6 +128,27 @@ pub(crate) enum BuildError {
     /// bidirectional reflector (mDNS/SSDP/WSD) the named interface may be the source or the target.
     #[error("interface \"{interface}\" cannot send {family}, required by the reflector")]
     RequiredFamilyUnavailable { interface: String, family: IpFamily },
+    /// A `macs` filter on a target whose link framing carries no MAC addresses: it would match
+    /// nothing, silently discarding every device-side packet.
+    #[error("macs can never match on interface \"{0}\": its link carries no MAC addresses")]
+    MacsUnmatchable(String),
+}
+
+/// Refuse a `macs` filter on a target whose link framing carries no MAC addresses:
+/// [`Filter`](crate::dispatch::Filter)'s MAC fields never match a `DLT_NULL` frame. `WoL` never
+/// calls this: it matches the MAC inside the magic packet's payload, not the frame's.
+fn require_macs_matchable(
+    dispatcher: &PacketDispatcher,
+    macs: Option<&MacSet>,
+    target: CaptureKey,
+    target_if: &str,
+) -> Result<(), BuildError> {
+    if macs.is_some()
+        && matches!(dispatcher.link_type(target), Some(link) if link != LinkType::Ethernet)
+    {
+        return Err(BuildError::MacsUnmatchable(target_if.to_owned()));
+    }
+    Ok(())
 }
 
 /// Whether `egress` currently has a source address of `dst`'s family, which `send_udp_group` needs
@@ -219,6 +242,49 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use super::*;
+    use crate::capture::Capture;
+    use crate::interface::LOOPBACK_IFACE;
+    use crate::net::mac::MacAddr;
+
+    /// Open a loopback capture, or `None` (skip) without `CAP_NET_RAW`.
+    fn open_loopback_or_skip() -> Option<Capture> {
+        match Capture::open(LOOPBACK_IFACE) {
+            Ok(cap) => Some(cap),
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skip: no CAP_NET_RAW to open a loopback capture ({e})");
+                None
+            }
+            Err(e) => panic!("unexpected loopback capture open failure: {e}"),
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn macs_matchability_follows_the_target_link_framing() {
+        let Some(cap) = open_loopback_or_skip() else {
+            return;
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let target = dispatcher
+            .add_capture(cap)
+            .expect("add the loopback capture");
+        // No filter configured: nothing to refuse, whatever the framing.
+        assert_eq!(
+            require_macs_matchable(&dispatcher, None, target, LOOPBACK_IFACE),
+            Ok(())
+        );
+        let macs = MacSet::from(MacAddr::from([2, 0, 0, 0, 0, 1]));
+        let result = require_macs_matchable(&dispatcher, Some(&macs), target, LOOPBACK_IFACE);
+        // Linux frames loopback as Ethernet, so MACs match there; the BSDs' loopback is
+        // `DLT_NULL`, the framing the check refuses.
+        #[cfg(target_os = "linux")]
+        assert_eq!(result, Ok(()));
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        assert_eq!(
+            result,
+            Err(BuildError::MacsUnmatchable(LOOPBACK_IFACE.to_owned()))
+        );
+    }
 
     #[test]
     fn missing_required_family_enforces_the_requires_policy() {

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -21,7 +21,7 @@ use crate::net::mdns::{
 
 use super::{
     BuildError, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
-    require_bidirectional_families,
+    require_bidirectional_families, require_macs_matchable,
 };
 
 /// mDNS's classifier kind *is* its message type: `Query`/`Response` map straight across.
@@ -81,6 +81,12 @@ pub(crate) fn build(
         reflector.address_family,
         source,
         reflector.source_if.as_str(),
+        target,
+        reflector.target_if.as_str(),
+    )?;
+    require_macs_matchable(
+        dispatcher,
+        reflector.macs.as_ref(),
         target,
         reflector.target_if.as_str(),
     )?;

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -24,7 +24,7 @@ use crate::reactor::Reactor;
 use super::dial::{ProxyPlacement, rewrite_location};
 use super::{
     BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
-    join_group_logged, require_bidirectional_families,
+    join_group_logged, require_bidirectional_families, require_macs_matchable,
 };
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
@@ -162,6 +162,12 @@ pub(crate) fn build(
         reflector.address_family,
         source,
         reflector.source_if.as_str(),
+        target,
+        reflector.target_if.as_str(),
+    )?;
+    require_macs_matchable(
+        dispatcher,
+        reflector.macs.as_ref(),
         target,
         reflector.target_if.as_str(),
     )?;

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -16,7 +16,7 @@ use crate::net::wsd::{
 
 use super::{
     BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
-    join_group_logged, require_bidirectional_families,
+    join_group_logged, require_bidirectional_families, require_macs_matchable,
 };
 
 /// WSD's classifier kind maps to its group message types. The `ProbeMatches`/`ResolveMatches` unicast
@@ -84,6 +84,12 @@ pub(crate) fn build(
         reflector.address_family,
         source,
         reflector.source_if.as_str(),
+        target,
+        reflector.target_if.as_str(),
+    )?;
+    require_macs_matchable(
+        dispatcher,
+        reflector.macs.as_ref(),
         target,
         reflector.target_if.as_str(),
     )?;


### PR DESCRIPTION
A macs filter lands as Filter.src_mac on the target-side registrations, and Filter's MAC fields never match a DLT_NULL frame - so macs on a MAC-less target (a BSD loopback or L3 tunnel) matches nothing and silently discards every device-side packet. mDNS/SSDP/WSD entries now refuse that configuration at startup with a new BuildError variant naming the interface, beside the existing required-family check. WoL is exempt: it matches the MAC inside the magic packet's payload, not the frame's. Documented in the netflector.toml.5 macs entry and the README macs section.

Testing: the check runs against a real loopback capture and asserts both platform truths - Linux's Ethernet-framed lo accepts, the BSDs' DLT_NULL lo0 refuses with the exact variant; full lib suite, clippy -D warnings, rustdoc, armv5te check, and both mandoc layers.