### PR TITLE
ci: fail fast on FreeBSD guest panics and keep their crash summaries

### DIFF
--- a/.github/workflows/build-daemon-pkgs.yml
+++ b/.github/workflows/build-daemon-pkgs.yml
@@ -93,3 +93,6 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash

--- a/.github/workflows/ci-opnsense.yml
+++ b/.github/workflows/ci-opnsense.yml
@@ -157,6 +157,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   # The aggregate the ruleset requires: green only when every job above is.
   # Without !cancelled() a failed job would skip this one, and a skipped

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -117,13 +117,13 @@ jobs:
           ci/freebsd-vm.sh run 'mandoc -T lint -W style /usr/local/share/man/man8/netflector.8.gz /usr/local/share/man/man5/netflector.toml.5.gz'
       # The port's binary is the one configuration no other lane executes end to end: release
       # profile, dynamically linked, built by the ports framework from the release tarball. Run
-      # the full native e2e suite against the INSTALLED binary before deinstalling it.
+      # the full native e2e suite against the INSTALLED binary before deinstalling it. The suite
+      # comes from the extracted tarball (WRKSRC), not the working tree: HEAD cases may assert
+      # behavior the release predates (HEAD code with HEAD suite is ci.yml's from-source build).
       - name: Native e2e against the installed port binary
         run: |
           ci/freebsd-vm.sh run 'pkg install -y python3'
-          ci/freebsd-vm.sh run 'mkdir -p /root/netflector'
-          ci/freebsd-vm.sh push e2e /root/netflector/
-          ci/freebsd-vm.sh run 'cd /root/netflector && python3 e2e/run.py --backend native --binary /usr/local/bin/netflector'
+          ci/freebsd-vm.sh run 'cd $(make -C /usr/ports/net/netflector -V WRKSRC) && python3 e2e/run.py --backend native --binary /usr/local/bin/netflector'
       - name: Deinstall
         run: |
           ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make deinstall'

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -130,6 +130,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   # The aggregate the ruleset requires: green only when every job above is.
   # Without !cancelled() a failed job would skip this one, and a skipped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   # The native e2e suite on a real FreeBSD kernel: epair segments, every participant in its own
   # vnet jail -- the BPF capture/inject and PF_ROUTE monitor paths end to end, which no Linux lane
@@ -230,6 +233,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   # The port built from this commit's source instead of the pinned release
   # tarball: crates regenerated from the working tree's Cargo.lock, the tarball
@@ -311,6 +317,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   # The e2e suite with netflector under Valgrind memcheck (the runtime-valgrind image: a glibc release
   # binary with debug symbols). run.py --valgrind SIGTERMs the daemon per case so Valgrind runs its leak

--- a/.github/workflows/pkg-deploy.yml
+++ b/.github/workflows/pkg-deploy.yml
@@ -168,6 +168,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   gate:
     name: Gate on OPNsense ${{ matrix.opnsense }}
@@ -244,6 +247,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   push:
     name: Push the snapshot

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -149,6 +149,9 @@ jobs:
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
 
   build-daemon:
     needs: [guard, verify-ci]

--- a/ci/freebsd-ssh-runner.sh
+++ b/ci/freebsd-ssh-runner.sh
@@ -9,8 +9,14 @@ set -euo pipefail
 
 VM_DIR=${FREEBSD_VM_DIR:-$HOME/.freebsd-vm}
 SSH_PORT=${FREEBSD_VM_SSH_PORT:-2222}
+# Keepalives: a guest kernel panic reboots the VM without resetting slirp's
+# host-side TCP, so a session blocked in read (a running test binary) would
+# sit silent until the job budget; four missed 15s probes end it in ~1 minute
+# instead. ConnectTimeout bounds new connections against a frozen guest the
+# same way.
 SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-    -o LogLevel=ERROR -i "$VM_DIR/id_ed25519")
+    -o LogLevel=ERROR -o ServerAliveInterval=15 -o ServerAliveCountMax=4
+    -o ConnectTimeout=10 -i "$VM_DIR/id_ed25519")
 
 bin=$1
 shift

--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -13,6 +13,7 @@
 #   ci/freebsd-vm.sh push SRC... DEST   copy files/dirs to DEST in the VM
 #   ci/freebsd-vm.sh pull SRC DEST      copy a file/dir from the VM to DEST
 #   ci/freebsd-vm.sh console   dump the serial console (boot diagnostics)
+#   ci/freebsd-vm.sh crash     print the guest's saved panic summary, if any
 #
 # State (disk, seed, per-run ssh key, console log) lives in $FREEBSD_VM_DIR,
 # default ~/.freebsd-vm. $FREEBSD_VM_ARCH (required, no default: a guessed
@@ -50,8 +51,13 @@ SSH_PORT=${FREEBSD_VM_SSH_PORT:-2222}
 SSH_WAIT_SECS=${FREEBSD_VM_SSH_WAIT_SECS:-$WAIT_DEFAULT}
 
 # No port here: ssh wants -p, scp wants -P; each call site adds its own.
+# Keepalives: a guest kernel panic reboots the VM without resetting slirp's
+# host-side TCP, so a session blocked in read (the e2e suite) would sit silent
+# until the job budget; four missed 15s probes end it in ~1 minute instead.
+# ConnectTimeout bounds new connections against a frozen guest the same way.
 SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-    -o LogLevel=ERROR -i "$VM_DIR/id_ed25519")
+    -o LogLevel=ERROR -o ServerAliveInterval=15 -o ServerAliveCountMax=4
+    -o ConnectTimeout=10 -i "$VM_DIR/id_ed25519")
 
 # NoCloud seed for nuageinit(7), the in-base cloud-init shim the
 # BASIC-CLOUDINIT image enables. Whatever the flavor below, the seed does
@@ -244,6 +250,29 @@ pull() {
     scp -qr "${SSH_OPTS[@]}" -P "$SSH_PORT" "root@127.0.0.1:$1" "$2"
 }
 
+# A panicked guest reboots itself, and savecore(8) writes the panic summary
+# (backtrace, faulting process, dmesg tail) to /var/crash during that boot --
+# about a minute after the panic even under TCG. The wait is bounded: a guest
+# that froze without panicking never answers, and burning the first-boot ssh
+# budget (20 minutes on arm64) on a post-mortem would stall the job's real
+# diagnostics.
+crash_summary() {
+    if [ ! -f "$VM_DIR/qemu.pid" ]; then
+        echo "no crash summary: the VM was never launched"
+        return 0
+    fi
+    local deadline=$((SECONDS + 180))
+    until ssh "${SSH_OPTS[@]}" -p "$SSH_PORT" root@127.0.0.1 true 2>/dev/null; do
+        if ((SECONDS >= deadline)); then
+            echo "no crash summary: no ssh answer after 180s"
+            return 0
+        fi
+        sleep 5
+    done
+    run 'cat /var/crash/core.txt.* 2>/dev/null || echo "no crash dump in /var/crash"' ||
+        echo "no crash summary: ssh dropped while reading /var/crash"
+}
+
 case "${1:-}" in
 launch) launch ;;
 wait) wait_ssh ;;
@@ -264,8 +293,9 @@ console)
     # never got as far as launching the VM must not fail the step.
     cat "$VM_DIR/console.log" 2>/dev/null || echo "no console log: the VM was never launched"
     ;;
+crash) crash_summary ;;
 *)
-    echo "usage: $0 launch|wait|run CMD|push SRC... DEST|pull SRC DEST|console" >&2
+    echo "usage: $0 launch|wait|run CMD|push SRC... DEST|pull SRC DEST|console|crash" >&2
     exit 64
     ;;
 esac


### PR DESCRIPTION
Two lanes have now lost a guest kernel panic's evidence to the same failure mode: the panic reboots the VM, slirp keeps the host-side TCP open, and the driving ssh session blocks silently until the job budget. Diagnosed on #146's run: `ifconfig <epair> destroy` under a live daemon panicked the freebsd14-arm64 guest (NULL deref, `vm_fault failed`), savecore wrote `/var/crash/core.txt.0` during the auto-reboot, and the job showed nothing for 20 minutes.

- ssh keepalives (15s x 4) plus ConnectTimeout in both scripts' SSH_OPTS: a dead guest now fails the step in about a minute.
- New `freebsd-vm.sh crash` subcommand: waits (bounded, 180s) for the rebooted guest and prints `/var/crash/core.txt.*`; added `if: always()` after every VM console-log step across the six workflows.

Testing: bash -n and shellcheck clean (no new findings), workflow YAML validated. The panic is intermittent, so the capture path proves out on its next occurrence.