### PR TITLE
logging: do more debug/trace logging

### DIFF
--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -55,13 +55,15 @@ impl Capture {
         // Loop prevention: stop the kernel from handing us our own injected frames.
         // PACKET_IGNORE_OUTGOING (Linux 4.20+) drops them at the socket; if the kernel
         // lacks it (or user-mode QEMU rejects it), prepend an in-filter drop instead.
-        if set_ignore_outgoing(&fd).is_ok() {
-            attach_filter(&fd, &ETHERNET_UDP_FILTER)?;
-        } else {
-            log::info!(
-                "PACKET_IGNORE_OUTGOING unavailable; dropping our own frames in the BPF filter"
-            );
-            attach_filter(&fd, &drop_outgoing_filter())?;
+        match set_ignore_outgoing(&fd) {
+            Ok(()) => attach_filter(&fd, &ETHERNET_UDP_FILTER)?,
+            Err(e) => {
+                log::info!(
+                    "PACKET_IGNORE_OUTGOING unavailable ({e}); dropping our own frames in the \
+                     BPF filter"
+                );
+                attach_filter(&fd, &drop_outgoing_filter())?;
+            }
         }
 
         // Bind with ETH_P_ALL to start capturing. The filter is already installed, so

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -634,6 +634,14 @@ impl PacketDispatcher {
         // real, in-range ingress key.
         if let Some(outcome) = final_outcome {
             self.table.record(ingress, outcome);
+        } else {
+            // The one drop no counter covers: past the kernel filter but matching no
+            // registration (e.g. a reply outliving its search session's registration).
+            log::trace!(
+                "no registration matched {} -> {} on {ingress:?}",
+                packet.source,
+                packet.dest
+            );
         }
     }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -158,6 +158,10 @@ impl Interface {
             addrs: InterfaceAddresses::default(),
             mtu: None,
         };
+        match iface.ifindex {
+            0 => log::debug!("{name}: no kernel ifindex (interface absent)"),
+            i => log::debug!("{name}: ifindex {i}"),
+        }
         iface.refresh()?;
         Ok(iface)
     }

--- a/src/interface/interface_monitor/route.rs
+++ b/src/interface/interface_monitor/route.rs
@@ -96,7 +96,12 @@ pub(super) fn for_each_change(buf: &[u8], on_change: &mut impl FnMut(InterfaceEv
                 ANNOUNCE_INDEX_OFFSET,
                 InterfaceEvent::Link as fn(u32) -> InterfaceEvent,
             )),
-            _ => None,
+            _ => {
+                // PF_ROUTE is unfiltered, so every routing message on the system lands here;
+                // this is the only trail of what a drain actually saw.
+                log::trace!("interface monitor: ignoring routing message type {msg_type}");
+                None
+            }
         };
         if let Some((index_offset, event)) = hit
             && msglen >= index_offset + 2

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -76,6 +76,7 @@ pub(super) fn resolve(
     ifindex: u32,
 ) -> io::Result<(InterfaceAddresses, Option<u32>)> {
     if ifindex == 0 {
+        log::debug!("{if_name}: no kernel ifindex; skipping the address dump");
         return Ok((InterfaceAddresses::default(), None));
     }
 
@@ -262,6 +263,14 @@ fn walk_dump(buf: &[u8], reply_type: u16, on_msg: &mut impl FnMut(&[u8])) -> Dum
         if len < size_of::<libc::nlmsghdr>()
             || offset.checked_add(len).is_none_or(|end| end > buf.len())
         {
+            // Not a normal end (that's the `while` running out): a message claims an impossible
+            // length, so the datagram's remaining addresses are lost. The monitor twins warn on
+            // this; here the next refresh re-reads everything, so debug suffices.
+            log::debug!(
+                "netlink dump walk stopped at offset {offset}: len {len}, buffer {} B \
+                 (truncated or malformed); remaining messages skipped",
+                buf.len()
+            );
             break;
         }
         match hdr.nlmsg_type {
@@ -326,13 +335,17 @@ fn scan_addr(
         return;
     };
     if family == libc::AF_INET {
+        let Ok(octets) = <[u8; 4]>::try_from(bytes) else {
+            return;
+        };
+        let v4 = Ipv4Addr::from(octets);
         // First usable address wins: skip a tentative/deprecated/DAD-failed v4 (the same
         // IFA_F_UNUSABLE mask the v6 branch applies) so it is never chosen as the reflection source.
-        if addrs.v4.is_none()
-            && flags & IFA_F_UNUSABLE == 0
-            && let Ok(octets) = <[u8; 4]>::try_from(bytes)
-        {
-            let v4 = Ipv4Addr::from(octets);
+        if flags & IFA_F_UNUSABLE != 0 {
+            log::trace!("{if_name}: v4 {v4} flags {flags:#06x} -> filtered");
+        } else if addrs.v4.is_some() {
+            log::trace!("{if_name}: v4 {v4} (ignored; already have one)");
+        } else {
             log::trace!("{if_name}: v4 {v4}");
             addrs.v4 = Some(v4);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,10 @@ fn reflect(path: Option<&Path>) -> Result<()> {
 
     // Resolve the log level first from a minimal read of env + file, so the full parse below
     // logs at the configured verbosity (see resolve_log_level).
-    logging::set_level(config::resolve_log_level(toml_text.as_deref(), &env)?);
+    let level = config::resolve_log_level(toml_text.as_deref(), &env)?;
+    logging::set_level(level);
+    // After set_level, so the line lands under the configured threshold, not the bootstrap one.
+    log::debug!("log level {level:?}");
     log::info!("netflector {} starting", env!("CARGO_PKG_VERSION"));
     if let Some(path) = path {
         log::debug!(

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -395,6 +395,7 @@ fn pin_egress(fd: RawFd, iface: Option<&str>) -> io::Result<()> {
             return Err(io::Error::last_os_error());
         }
     }
+    log::trace!("connect egress pinned to {name}");
     Ok(())
 }
 

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -473,6 +473,7 @@ impl Reactor {
                 log::trace!("dispatch_deadlines: handler for {key:?} gone mid-sweep, skipped");
                 continue;
             };
+            log::trace!("deadline fired for {key:?}");
             handler.on_deadline(now, self);
             if let Some(entry) = self.handlers.get_mut(key) {
                 entry.handler = Some(handler);
@@ -499,6 +500,7 @@ impl Reactor {
                 .get_mut(key)
                 .and_then(|entry| entry.handler.take())
             else {
+                log::trace!("dispatch_control: handler for {key:?} gone mid-broadcast, skipped");
                 continue;
             };
             handler.on_control(event, self);

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -223,7 +223,7 @@ fn join_group_logged(
     side: &str,
 ) {
     match dispatcher.join_group(capture, group) {
-        Ok(()) => {}
+        Ok(()) => log::debug!("{protocol}: joined {group} on {side}"),
         Err(e) if join_deferrable(&e) => {
             log::debug!(
                 "{protocol}: join {group} on {side} deferred (no address of its family yet): {e}"

--- a/src/reflector/dial/connection.rs
+++ b/src/reflector/dial/connection.rs
@@ -392,6 +392,14 @@ impl Connection {
     /// and tear us down early. Unwatch the vanished fd, whose level-triggered HUP would otherwise re-fire
     /// every wait. The connection closes once the forward flow finishes draining.
     fn peer_gone(&mut self, direction: Direction, reactor: &mut Reactor) -> Outcome {
+        log::debug!(
+            "dial: {} hung up on the connection to {}",
+            match direction {
+                Direction::ClientToDevice => "client",
+                Direction::DeviceToClient => "device",
+            },
+            self.device_endpoint
+        );
         // The abandoned reverse flow's source is the reg to disarm; the hung-up fd is the reg to unwatch.
         // The guard routes here only with a live destination reg, and the source's reg is still set (its
         // fd just hung up, and peer_gone (which takes it) runs once), so both expects hold.
@@ -461,7 +469,10 @@ impl Connection {
     fn on_writable(&mut self, direction: Direction, reactor: &mut Reactor) -> Outcome {
         if direction == Direction::ClientToDevice && self.device.is_connecting() {
             match self.device.finish_connect() {
-                Ok(()) => self.deadline = Instant::now() + IDLE_TIMEOUT,
+                Ok(()) => {
+                    log::debug!("dial: connected to {}", self.device_endpoint);
+                    self.deadline = Instant::now() + IDLE_TIMEOUT;
+                }
                 Err(e) => {
                     log::warn!(
                         "dial: device connect to {} failed: {e}",

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -252,6 +252,12 @@ impl DialDeviceProxy {
         };
         // A description response just revealed (or moved) the device's REST endpoint.
         if let Some(endpoint) = learned {
+            if self.rest_endpoint != Some(endpoint) {
+                log::debug!(
+                    "dial: learned {}'s REST endpoint {endpoint}",
+                    self.desc_endpoint
+                );
+            }
             self.rest_endpoint = Some(endpoint);
         }
         if outcome == Outcome::Close {

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -125,6 +125,7 @@ fn mint_proxy(
     let desc = listen_or_warn(placement.source, Listener::Description)?;
     let rest = listen_or_warn(placement.source, Listener::Rest)?;
     let desc_addr = desc.local_addr();
+    let rest_addr = rest.local_addr();
     let watches = [(desc.as_raw_fd(), 0), (rest.as_raw_fd(), 0)];
     let proxy = DialDeviceProxy::new(
         placement.target,
@@ -141,7 +142,10 @@ fn mint_proxy(
         }
     };
     ctx.insert(key, handler, desc_addr, desc_grace);
-    log::debug!("dial: minted a proxy for {endpoint} via description listener {desc_addr}");
+    log::debug!(
+        "dial: minted a proxy for {endpoint}: description listener {desc_addr}, \
+         REST listener {rest_addr}"
+    );
     Some(desc_addr)
 }
 

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -251,6 +251,12 @@ impl SearchReflector {
                 return Err(Outcome::Dropped(message_type));
             }
         };
+        log::trace!(
+            "{}: reserved {} (ifindex {target_ifindex}) for searcher {}",
+            self.name,
+            SocketAddr::new(our_addr, reservation.port()),
+            packet.source
+        );
         // Register before the reflect so a fast responder's reply is captured, not ICMP-rejected.
         let response_key = dispatcher.register(
             self.target,

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -68,7 +68,9 @@ impl ReplyRewrite for DialRewrite {
                 .egress_addrs(self.target)
                 .and_then(InterfaceAddresses::v4),
         ) else {
-            return None; // a family the proxy can't bridge yet
+            // A family the proxy can't bridge yet; any DIAL LOCATION goes through unrewritten.
+            log::debug!("SSDP: source or target has no IPv4; DIAL rewrite skipped");
+            return None;
         };
         let (ctx, target_iface) = dispatcher.dial_context(self.target);
         let placement = ProxyPlacement {

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -13,7 +13,7 @@ use crate::dispatch::{
     CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, PortSet,
 };
 use crate::logging::log_rate;
-use crate::net::mac::MacSet;
+use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
 
@@ -45,8 +45,15 @@ impl PacketHandler for WolReflector {
         dispatcher: &mut PacketDispatcher,
         _reactor: &mut Reactor,
     ) -> Outcome {
-        if !is_magic_packet(packet.payload, self.target_macs.as_ref()) {
+        let Some(mac) = magic_packet_mac(packet.payload) else {
             log::debug!("WoL: ignoring non-magic packet from {}", packet.source);
+            return Outcome::Filtered;
+        };
+        if !wake_allowed(mac, self.target_macs.as_ref()) {
+            log::debug!(
+                "WoL: ignoring wake for {mac} from {}: not in the configured device set",
+                packet.source
+            );
             return Outcome::Filtered;
         }
         let Some(dst) = wol_destination(self.family, packet) else {
@@ -89,16 +96,14 @@ impl PacketHandler for WolReflector {
     }
 }
 
-/// Whether `payload` opens with a Wake-on-LAN magic packet for an acceptable target: the `6×0xFF`
-/// prefix followed by one MAC repeated 16 times. Only the leading [`MAGIC_LEN`] bytes are inspected;
-/// trailing bytes (a `SecureOn` password) are ignored here and forwarded as-is by the caller. When
-/// `targets` is set, the repeated MAC must be a member, so only those devices' wakes are reflected.
-fn is_magic_packet(payload: &[u8], targets: Option<&MacSet>) -> bool {
-    let Some(magic) = payload.get(..MAGIC_LEN) else {
-        return false;
-    };
+/// The target MAC of the Wake-on-LAN magic packet opening `payload`: the `6×0xFF` prefix followed
+/// by one MAC repeated 16 times. `None` when the structure doesn't match. Only the leading
+/// [`MAGIC_LEN`] bytes are inspected; trailing bytes (a `SecureOn` password) are ignored here and
+/// forwarded as-is by the caller.
+fn magic_packet_mac(payload: &[u8]) -> Option<MacAddr> {
+    let magic = payload.get(..MAGIC_LEN)?;
     if magic[..PREFIX_LEN] != [0xff; PREFIX_LEN] {
-        return false;
+        return None;
     }
     let mac = &magic[PREFIX_LEN..PREFIX_LEN + MAC_LEN];
     // The other 15 repetitions must all equal the first.
@@ -106,9 +111,14 @@ fn is_magic_packet(payload: &[u8], targets: Option<&MacSet>) -> bool {
         .chunks_exact(MAC_LEN)
         .all(|rep| rep == mac)
     {
-        return false;
+        return None;
     }
-    targets.is_none_or(|targets| targets.iter().any(|target| mac == target.octets()))
+    Some(MacAddr::from(<[u8; MAC_LEN]>::try_from(mac).ok()?))
+}
+
+/// Whether the optional `targets` allow-set admits a wake for `mac`.
+fn wake_allowed(mac: MacAddr, targets: Option<&MacSet>) -> bool {
+    targets.is_none_or(|targets| targets.contains(&mac))
 }
 
 /// Link-wide destination a captured magic `packet` re-emits to under `family`: the IPv4 limited
@@ -196,47 +206,48 @@ mod tests {
 
     #[test]
     fn accepts_any_device_when_unfiltered() {
-        assert!(is_magic_packet(&magic_packet(DEVICE, &[]), None));
+        let mac = magic_packet_mac(&magic_packet(DEVICE, &[])).unwrap();
+        assert!(wake_allowed(mac, None));
     }
 
     #[test]
     fn accepts_a_secureon_trailer() {
         // Bytes past the 102 are a SecureOn password: ignored here, forwarded by the caller.
         let packet = magic_packet(DEVICE, &[0xde, 0xad, 0xbe, 0xef]);
-        assert!(is_magic_packet(&packet, None));
+        assert_eq!(magic_packet_mac(&packet), Some(MacAddr::from(DEVICE)));
     }
 
     #[test]
     fn filters_to_the_configured_device() {
-        let packet = magic_packet(DEVICE, &[]);
+        let mac = magic_packet_mac(&magic_packet(DEVICE, &[])).unwrap();
         let allowed = MacSet::from(MacAddr::from(DEVICE));
-        assert!(is_magic_packet(&packet, Some(&allowed)));
+        assert!(wake_allowed(mac, Some(&allowed)));
         let others = MacSet::from(MacAddr::from([0xaa; 6]));
-        assert!(!is_magic_packet(&packet, Some(&others)));
+        assert!(!wake_allowed(mac, Some(&others)));
     }
 
     #[test]
     fn filters_to_any_of_several_configured_devices() {
-        let packet = magic_packet(DEVICE, &[]);
+        let mac = magic_packet_mac(&magic_packet(DEVICE, &[])).unwrap();
         let set = MacSet::try_from(vec![MacAddr::from([0xaa; 6]), MacAddr::from(DEVICE)]).unwrap();
-        assert!(is_magic_packet(&packet, Some(&set)));
+        assert!(wake_allowed(mac, Some(&set)));
         let disjoint =
             MacSet::try_from(vec![MacAddr::from([0xaa; 6]), MacAddr::from([0xbb; 6])]).unwrap();
-        assert!(!is_magic_packet(&packet, Some(&disjoint)));
+        assert!(!wake_allowed(mac, Some(&disjoint)));
     }
 
     #[test]
     fn rejects_a_short_payload() {
         let packet = magic_packet(DEVICE, &[]);
-        assert!(!is_magic_packet(&packet[..MAGIC_LEN - 1], None));
-        assert!(!is_magic_packet(&[], None));
+        assert!(magic_packet_mac(&packet[..MAGIC_LEN - 1]).is_none());
+        assert!(magic_packet_mac(&[]).is_none());
     }
 
     #[test]
     fn rejects_a_broken_prefix() {
         let mut packet = magic_packet(DEVICE, &[]);
         packet[0] = 0xfe;
-        assert!(!is_magic_packet(&packet, None));
+        assert!(magic_packet_mac(&packet).is_none());
     }
 
     #[test]
@@ -244,7 +255,7 @@ mod tests {
         let mut packet = magic_packet(DEVICE, &[]);
         // Corrupt the 7th repetition so it no longer matches the first.
         packet[PREFIX_LEN + 6 * MAC_LEN] ^= 0xff;
-        assert!(!is_magic_packet(&packet, None));
+        assert!(magic_packet_mac(&packet).is_none());
     }
 
     /// A packet whose `dest` (the captured Wake-on-LAN port) drives the re-emit destination.


### PR DESCRIPTION
Adds logging where the daemon decides, falls back, or reads external state silently: 19 additions, all trace/debug except one errno folded into an existing info line. Highlights: name-to-ifindex at interface open, refused v4 candidates on Linux (parity with the v6 branch and the BSD backend), multicast join successes, the one packet drop no counter covers, WoL wakes refused by the `macs` set (previously logged as "non-magic"), egress-pin confirmations, reactor timer dispatch, and DIAL connect/hangup/learned-endpoint lifecycle.

wol.rs splits the structural magic-packet check (`magic_packet_mac`) from the allow-set gate (`wake_allowed`) so the refusal can name the MAC; tests re-anchored to the new seam, no behavior change.

Testing: fmt, clippy `-D warnings`, 494 lib tests, and rustdoc on both host and Linux; two adversarial review passes over the diff (per-addition conformance, wol behavior equivalence) came back clean.