### PR TITLE
linear_map: one container for the hand-rolled keyed scans

### DIFF
--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -250,12 +250,13 @@ pull() {
     scp -qr "${SSH_OPTS[@]}" -P "$SSH_PORT" "root@127.0.0.1:$1" "$2"
 }
 
-# A panicked guest reboots itself, and savecore(8) writes the panic summary
-# (backtrace, faulting process, dmesg tail) to /var/crash during that boot --
-# about a minute after the panic even under TCG. The wait is bounded: a guest
-# that froze without panicking never answers, and burning the first-boot ssh
-# budget (20 minutes on arm64) on a post-mortem would stall the job's real
-# diagnostics.
+# A panicked guest reboots itself; savecore(8) preserves the dump during that
+# boot, about a minute after the panic even under TCG. The wait is bounded: a
+# guest that froze without panicking never answers, and burning the first-boot
+# ssh budget (20 minutes on arm64) on a post-mortem would stall the job's real
+# diagnostics. crashinfo(8)'s boot-time core.txt carries no backtrace without a
+# kernel debugger, and it re-runs fine after the fact, so gdb is fetched and
+# the summary regenerated only on a run that actually panicked.
 crash_summary() {
     if [ ! -f "$VM_DIR/qemu.pid" ]; then
         echo "no crash summary: the VM was never launched"
@@ -269,8 +270,15 @@ crash_summary() {
         fi
         sleep 5
     done
-    run 'cat /var/crash/core.txt.* 2>/dev/null || echo "no crash dump in /var/crash"' ||
-        echo "no crash summary: ssh dropped while reading /var/crash"
+    run 'if ls /var/crash/vmcore.* >/dev/null 2>&1; then
+             if ! command -v gdb >/dev/null; then
+                 pkg install -y gdb >/dev/null
+                 crashinfo >/dev/null
+             fi
+             cat /var/crash/core.txt.*
+         else
+             echo "no crash dump in /var/crash"
+         fi' || echo "no crash summary: fetching it from the guest failed"
 }
 
 case "${1:-}" in

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -38,6 +38,7 @@ use std::time::{Duration, Instant};
 
 use crate::capture::Capture;
 use crate::interface::{InterfaceAddresses, InterfaceEvent, InterfaceMonitor};
+use crate::linear_map::LinearMap;
 use crate::net::LinkType;
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
@@ -660,16 +661,18 @@ impl PacketDispatcher {
         let Some(monitor) = self.monitor.as_mut() else {
             return;
         };
-        // Coalesce to one (ifindex, saw-a-Link-event) row per interface.
-        let mut changed: Vec<(u32, bool)> = Vec::new();
+        // Coalesce to one ifindex -> saw-a-Link-event entry per interface.
+        let mut changed: LinearMap<u32, bool> = LinearMap::new();
         let mut overflow = false;
         if let Err(e) = monitor.drain(|event| match event {
             InterfaceEvent::Overflow => overflow = true,
             InterfaceEvent::Address(ifindex) | InterfaceEvent::Link(ifindex) => {
                 let is_link = matches!(event, InterfaceEvent::Link(_));
-                match changed.iter_mut().find(|(seen, _)| *seen == ifindex) {
-                    Some((_, link)) => *link |= is_link,
-                    None => changed.push((ifindex, is_link)),
+                match changed.get_mut(&ifindex) {
+                    Some(link) => *link |= is_link,
+                    None => {
+                        changed.insert(ifindex, is_link);
+                    }
                 }
             }
         }) {
@@ -686,7 +689,7 @@ impl PacketDispatcher {
         // The creation gate compares against the ceiling from BEFORE this batch: the creation's
         // own Link event would otherwise raise the ceiling past itself and slip through.
         let prior_ceiling = self.max_seen_ifindex;
-        for (ifindex, _) in &changed {
+        for (ifindex, _) in changed.iter() {
             self.max_seen_ifindex = self.max_seen_ifindex.max(*ifindex);
         }
         let mut want_reconcile = overflow;
@@ -727,7 +730,7 @@ impl PacketDispatcher {
                 }
             }
         } else {
-            for (ifindex, is_link) in &changed {
+            for (ifindex, is_link) in changed.iter() {
                 match self.table.refresh_by_ifindex(*ifindex) {
                     Ok(Some(change)) => {
                         log::debug!("re-resolved interface (ifindex {ifindex}) after a change");

--- a/src/dispatch/dial_context.rs
+++ b/src/dispatch/dial_context.rs
@@ -4,6 +4,7 @@
 use std::net::SocketAddrV4;
 use std::time::Instant;
 
+use crate::linear_map::LinearMap;
 use crate::reactor::{HandlerKey, Reactor};
 
 use super::CaptureKey;
@@ -30,7 +31,6 @@ pub(crate) struct DialProxyKey {
 /// - `desc_grace`: eviction deadline, refreshed to each advertisement's `max-age` so a cached
 ///   `LOCATION` keeps resolving while the device is advertised.
 struct DialEntry {
-    key: DialProxyKey,
     handler: HandlerKey,
     desc_addr: SocketAddrV4,
     desc_grace: Instant,
@@ -41,13 +41,13 @@ struct DialEntry {
 /// DIAL hook (`reflector::dial::rewrite_location`) reuses a live proxy found here (refreshing its grace)
 /// or records a freshly-minted one. An evicted proxy's entry is pruned on the next lookup or capacity check.
 pub(crate) struct DialContext {
-    proxies: Vec<DialEntry>,
+    proxies: LinearMap<DialProxyKey, DialEntry>,
 }
 
 impl DialContext {
     pub(crate) fn new() -> Self {
         Self {
-            proxies: Vec::new(),
+            proxies: LinearMap::new(),
         }
     }
 
@@ -60,20 +60,21 @@ impl DialContext {
         reactor: &Reactor,
         desc_grace: Instant,
     ) -> Option<SocketAddrV4> {
-        let pos = self.proxies.iter().position(|p| p.key == key)?;
-        if reactor.is_registered(self.proxies[pos].handler) {
-            self.proxies[pos].desc_grace = desc_grace;
-            Some(self.proxies[pos].desc_addr)
-        } else {
-            log::trace!("dial: pruning the stale proxy entry for {}", key.endpoint);
-            self.proxies.swap_remove(pos);
-            None
+        if let Some(entry) = self.proxies.get_mut(&key)
+            && reactor.is_registered(entry.handler)
+        {
+            entry.desc_grace = desc_grace;
+            return Some(entry.desc_addr);
         }
+        if self.proxies.remove(&key).is_some() {
+            log::trace!("dial: pruning the stale proxy entry for {}", key.endpoint);
+        }
+        None
     }
 
     /// Whether another proxy may be minted: prune every evicted entry, then check the cap.
     pub(crate) fn has_capacity(&mut self, reactor: &Reactor) -> bool {
-        self.proxies.retain(|p| reactor.is_registered(p.handler));
+        self.proxies.retain(|_, p| reactor.is_registered(p.handler));
         self.proxies.len() < MAX_DIAL_PROXIES
     }
 
@@ -86,24 +87,20 @@ impl DialContext {
         desc_addr: SocketAddrV4,
         desc_grace: Instant,
     ) {
-        if let Some(entry) = self.proxies.iter_mut().find(|p| p.key == key) {
-            entry.handler = handler;
-            entry.desc_addr = desc_addr;
-            entry.desc_grace = desc_grace;
-        } else {
-            self.proxies.push(DialEntry {
-                key,
+        self.proxies.insert(
+            key,
+            DialEntry {
                 handler,
                 desc_addr,
                 desc_grace,
-            });
-        }
+            },
+        );
     }
 
     /// The soonest grace deadline across recorded proxies: when [`sweep`](Self::sweep) next has work,
     /// folded into the dispatcher's [`next_deadline`](super::PacketHandler::next_deadline). `None` when empty.
     pub(crate) fn next_grace(&self) -> Option<Instant> {
-        self.proxies.iter().map(|p| p.desc_grace).min()
+        self.proxies.iter().map(|(_, p)| p.desc_grace).min()
     }
 
     /// Evict every proxy `evict` selects: unregister it from the reactor (tearing down its listeners and
@@ -113,16 +110,16 @@ impl DialContext {
         &mut self,
         reactor: &mut Reactor,
         reason: &str,
-        evict: impl Fn(&DialEntry) -> bool,
+        evict: impl Fn(&DialProxyKey, &DialEntry) -> bool,
     ) {
-        self.proxies.retain(|p| {
-            if evict(p) {
+        self.proxies.retain(|key, p| {
+            if evict(key, p) {
                 match reactor.unregister(p.handler) {
-                    Ok(_) => log::debug!("dial: evicted the proxy for {} {reason}", p.key.endpoint),
+                    Ok(_) => log::debug!("dial: evicted the proxy for {} {reason}", key.endpoint),
                     Err(e) => {
                         log::warn!(
                             "dial: evicting the proxy for {} {reason} failed: {e}",
-                            p.key.endpoint
+                            key.endpoint
                         );
                     }
                 }
@@ -135,7 +132,7 @@ impl DialContext {
 
     /// Evict every proxy whose grace has lapsed (`now` past its `desc_grace`).
     pub(crate) fn sweep(&mut self, now: Instant, reactor: &mut Reactor) {
-        self.evict_where(reactor, "past its grace", |p| now >= p.desc_grace);
+        self.evict_where(reactor, "past its grace", |_, p| now >= p.desc_grace);
     }
 
     /// Evict every proxy whose source or target capture is in `changed`: an address move or recreation
@@ -148,8 +145,8 @@ impl DialContext {
         changed: &[CaptureKey],
         reason: &str,
     ) {
-        self.evict_where(reactor, reason, |p| {
-            changed.contains(&p.key.source) || changed.contains(&p.key.target)
+        self.evict_where(reactor, reason, |key, _| {
+            changed.contains(&key.source) || changed.contains(&key.target)
         });
     }
 }
@@ -166,15 +163,12 @@ mod tests {
 
         /// The recorded proxies' handler keys: a seam to simulate an eviction.
         pub(crate) fn handler_keys(&self) -> Vec<HandlerKey> {
-            self.proxies.iter().map(|p| p.handler).collect()
+            self.proxies.iter().map(|(_, p)| p.handler).collect()
         }
 
         /// The recorded grace for `key`: a seam to assert a re-advertisement refreshed it.
         pub(crate) fn grace_of(&self, key: DialProxyKey) -> Option<Instant> {
-            self.proxies
-                .iter()
-                .find(|p| p.key == key)
-                .map(|p| p.desc_grace)
+            self.proxies.get(&key).map(|p| p.desc_grace)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod dispatch;
 mod error;
 mod interface;
 mod libcex;
+mod linear_map;
 mod logging;
 mod memory_report;
 mod net;

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -27,7 +27,7 @@ impl<K: PartialEq, V> LinearMap<K, V> {
             .map(|(_, v)| v)
     }
 
-    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    pub(crate) fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
         Q: PartialEq + ?Sized,
@@ -45,6 +45,14 @@ impl<K: PartialEq, V> LinearMap<K, V> {
         }
         self.0.push((key, value));
         None
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.0.iter().map(|(k, v)| (k, v))
     }
 }
 
@@ -74,5 +82,26 @@ mod tests {
         map.insert(7u32, "old");
         assert_eq!(map.insert(7, "new"), Some("old"));
         assert_eq!(map.get(&7), Some(&"new"));
+    }
+
+    #[test]
+    fn get_mut_edits_in_place() {
+        let mut map = LinearMap::new();
+        map.insert(1u32, false);
+        *map.get_mut(&1).unwrap() |= true;
+        assert_eq!(map.get(&1), Some(&true));
+        assert_eq!(map.get_mut(&2), None);
+    }
+
+    #[test]
+    fn iter_yields_every_pair() {
+        let mut map = LinearMap::new();
+        assert!(map.is_empty());
+        map.insert(1u32, "one");
+        map.insert(2, "two");
+        assert!(!map.is_empty());
+        let mut pairs: Vec<_> = map.iter().map(|(k, v)| (*k, *v)).collect();
+        pairs.sort_unstable();
+        assert_eq!(pairs, [(1, "one"), (2, "two")]);
     }
 }

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -51,8 +51,31 @@ impl<K: PartialEq, V> LinearMap<K, V> {
         self.0.is_empty()
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
         self.0.iter().map(|(k, v)| (k, v))
+    }
+
+    /// Remove `key`'s entry, returning its value. `swap_remove` underneath, so iteration order is
+    /// not insertion order once anything was removed.
+    pub(crate) fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + ?Sized,
+    {
+        let pos = self.0.iter().position(|(k, _)| k.borrow() == key)?;
+        Some(self.0.swap_remove(pos).1)
+    }
+
+    pub(crate) fn retain(&mut self, mut keep: impl FnMut(&K, &mut V) -> bool) {
+        self.0.retain_mut(|(k, v)| keep(k, v));
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.0.clear();
     }
 }
 
@@ -103,5 +126,40 @@ mod tests {
         let mut pairs: Vec<_> = map.iter().map(|(k, v)| (*k, *v)).collect();
         pairs.sort_unstable();
         assert_eq!(pairs, [(1, "one"), (2, "two")]);
+    }
+
+    #[test]
+    fn remove_takes_the_entry_out() {
+        let mut map = LinearMap::new();
+        map.insert(1u32, "one");
+        map.insert(2, "two");
+        assert_eq!(map.remove(&1), Some("one"));
+        assert_eq!(map.remove(&1), None);
+        assert_eq!(map.get(&1), None);
+        assert_eq!(map.get(&2), Some(&"two"));
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn retain_filters_by_key_and_value() {
+        let mut map = LinearMap::new();
+        for i in 0..4u32 {
+            map.insert(i, i * 10);
+        }
+        map.retain(|k, v| *k % 2 == 0 && *v < 30);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&0), Some(&0));
+        assert_eq!(map.get(&1), None);
+        assert_eq!(map.get(&2), Some(&20));
+        assert_eq!(map.get(&3), None);
+    }
+
+    #[test]
+    fn clear_empties_the_map() {
+        let mut map = LinearMap::new();
+        map.insert(1u32, ());
+        map.clear();
+        assert!(map.is_empty());
+        assert_eq!(map.get(&1), None);
     }
 }

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -1,0 +1,78 @@
+//! A map over a `Vec` of `(key, value)` pairs, looked up by linear scan.
+//!
+//! The runtime collections here hold a handful of entries (interfaces, sessions, proxies), where
+//! a scan over contiguous pairs beats a `HashMap`'s hashing and heap layout.
+
+use std::borrow::Borrow;
+
+/// A `Vec<(K, V)>` with a map API. `insert` replaces the value of an existing key, so keys stay
+/// unique. Lookups borrow the key form ([`Borrow`]), so a `LinearMap<String, _>` is queried with
+/// a `&str`.
+#[derive(Debug)]
+pub(crate) struct LinearMap<K, V>(Vec<(K, V)>);
+
+impl<K: PartialEq, V> LinearMap<K, V> {
+    pub(crate) fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + ?Sized,
+    {
+        self.0
+            .iter()
+            .find(|(k, _)| k.borrow() == key)
+            .map(|(_, v)| v)
+    }
+
+    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + ?Sized,
+    {
+        self.0
+            .iter_mut()
+            .find(|(k, _)| k.borrow() == key)
+            .map(|(_, v)| v)
+    }
+
+    /// Returns the replaced value when `key` was already present.
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if let Some(slot) = self.get_mut(&key) {
+            return Some(std::mem::replace(slot, value));
+        }
+        self.0.push((key, value));
+        None
+    }
+}
+
+impl<K: PartialEq, V> Default for LinearMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_finds_what_insert_put() {
+        let mut map = LinearMap::new();
+        assert_eq!(map.insert("a".to_owned(), 1), None);
+        assert_eq!(map.insert("b".to_owned(), 2), None);
+        assert_eq!(map.get("a"), Some(&1));
+        assert_eq!(map.get("b"), Some(&2));
+        assert_eq!(map.get("c"), None);
+    }
+
+    #[test]
+    fn insert_replaces_an_existing_key_and_returns_the_old_value() {
+        let mut map = LinearMap::new();
+        map.insert(7u32, "old");
+        assert_eq!(map.insert(7, "new"), Some("old"));
+        assert_eq!(map.get(&7), Some(&"new"));
+    }
+}

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -22,6 +22,7 @@ use thiserror::Error;
 use crate::config::AddressFamily;
 use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_deferrable};
 use crate::interface::InterfaceAddresses;
+use crate::linear_map::LinearMap;
 use crate::logging::WARN_WINDOW;
 use crate::net::LinkType;
 use crate::net::mac::MacSet;
@@ -94,19 +95,19 @@ impl fmt::Display for IpFamily {
 /// Maps each configured interface name to the capture `run()` opened for it, so a reflector's
 /// `source_if` / `target_if` resolve to the ingress / egress [`CaptureKey`]s. `run()` opens one
 /// capture per distinct interface and records it here; the per-protocol `build` functions look
-/// names up. A plain `Vec`: only ever a handful of interfaces.
+/// names up.
 #[derive(Default)]
-pub(crate) struct InterfaceMap(Vec<(String, CaptureKey)>);
+pub(crate) struct InterfaceMap(LinearMap<String, CaptureKey>);
 
 impl InterfaceMap {
     /// Record the capture `run()` opened for `name`.
     pub(crate) fn insert(&mut self, name: String, key: CaptureKey) {
-        self.0.push((name, key));
+        self.0.insert(name, key);
     }
 
     /// The capture key recorded for `name`, or `None` if none was.
     pub(crate) fn key_for(&self, name: &str) -> Option<CaptureKey> {
-        self.0.iter().find(|(n, _)| n == name).map(|&(_, key)| key)
+        self.0.get(name).copied()
     }
 
     /// The capture key for `name`, or [`BuildError::UnknownInterface`]. Build functions call this

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -17,6 +17,7 @@ use crate::dispatch::{
     CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, RegistrationKey,
 };
 use crate::interface::{InterfaceAddresses, Ipv6Scope};
+use crate::linear_map::LinearMap;
 use crate::logging::log_rate;
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
@@ -29,17 +30,22 @@ use super::{ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
 /// the cap a new search is dropped (no live session is evicted early).
 const MAX_SESSIONS: usize = 64;
 
-/// One in-flight search, keyed by `(searcher, dest)`. The searcher (`ip:port`) plus the group it
-/// searched: each group's replies arrive at a different scope-matched target address (link-local for
-/// `ff02::c`, routable for `ff05::c`), so one searcher's searches to two scopes need separate sessions.
-/// `expiry` is when the session lapses; `reservation` holds the ephemeral target reply port for the
-/// session's life (dropping it frees the port); `response_key` is the per-session response registration. A
-/// `RegistrationKey` is not a RAII guard, so eviction and rollback `unregister` it by hand.
-struct Session {
+/// What identifies an in-flight search session: the searcher (`ip:port`) plus the group it
+/// searched. The group is part of the key because its scope picks the reserved reply address
+/// (link-local for `ff02::c`, routable for `ff05::c`), so one searcher's searches to two scopes
+/// are separate sessions, not retransmits.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct SessionKey {
     searcher: SocketAddr,
-    /// The multicast group searched; part of the dedup key, since its scope picks the reserved reply
-    /// address — a different group is a new session, not a retransmit.
+    /// The multicast group searched.
     dest: SocketAddr,
+}
+
+/// One in-flight search. `expiry` is when the session lapses; `reservation` holds the ephemeral
+/// target reply port for the session's life (dropping it frees the port); `response_key` is the
+/// per-session response registration. A `RegistrationKey` is not a RAII guard, so eviction and
+/// rollback `unregister` it by hand.
+struct Session {
     expiry: Instant,
     reservation: PortReservation,
     response_key: RegistrationKey,
@@ -161,7 +167,7 @@ pub(crate) struct SearchReflector {
     /// The protocol's `advertises_only_link_local` check, handed to each session's
     /// [`ResponseReflector`]: an untouched reply it flags is dropped rather than reflected.
     suppress: fn(&[u8]) -> bool,
-    sessions: Vec<Session>,
+    sessions: LinearMap<SessionKey, Session>,
 }
 
 impl SearchReflector {
@@ -189,7 +195,7 @@ impl SearchReflector {
             window,
             make_reply,
             suppress,
-            sessions: Vec::new(),
+            sessions: LinearMap::new(),
         }
     }
 
@@ -278,8 +284,6 @@ impl SearchReflector {
             }),
         );
         Ok(Session {
-            searcher: packet.source,
-            dest: packet.dest,
             expiry,
             reservation,
             response_key,
@@ -301,16 +305,6 @@ fn reply_source(dispatcher: &PacketDispatcher, target: CaptureKey, dest: IpAddr)
             .and_then(|a| a.v6(Ipv6Scope::of(dst6)))
             .map(IpAddr::V6),
     }
-}
-
-/// The index of the live session a search belongs to: same searcher *and* same group. The group is
-/// part of the key because its scope picks the reserved reply address, so a search to a different
-/// group is a new session, not a retransmit. An index, not a `&mut Session`: the caller decides
-/// between reusing the session and evicting it, and a borrow would lock `self.sessions` for both.
-fn session_for(sessions: &[Session], source: SocketAddr, dest: SocketAddr) -> Option<usize> {
-    sessions
-        .iter()
-        .position(|s| s.searcher == source && s.dest == dest)
 }
 
 impl PacketHandler for SearchReflector {
@@ -342,8 +336,11 @@ impl PacketHandler for SearchReflector {
         // an interface recreation or address change orphans a session's reservation, but the dispatcher
         // drops such sessions eagerly via [`on_iface_change`](SearchReflector::on_iface_change), so a
         // reused session is always bound to the interface's current identity.
-        if let Some(index) = session_for(&self.sessions, packet.source, packet.dest) {
-            let session = &mut self.sessions[index];
+        let key = SessionKey {
+            searcher: packet.source,
+            dest: packet.dest,
+        };
+        if let Some(session) = self.sessions.get_mut(&key) {
             let port = session.reservation.port();
             return match dispatcher.send_udp_group(
                 self.target,
@@ -385,7 +382,7 @@ impl PacketHandler for SearchReflector {
         let port = session.reservation.port();
         match dispatcher.send_udp_group(self.target, packet.dest, port, self.ttl, packet.payload) {
             Ok(()) => {
-                self.sessions.push(session);
+                self.sessions.insert(key, session);
                 log::debug!(
                     "reflected {} search from {} to {} on reserved port {port}; opened a session, {} active",
                     self.name,
@@ -412,7 +409,7 @@ impl PacketHandler for SearchReflector {
     }
 
     fn next_deadline(&self) -> Option<Instant> {
-        self.sessions.iter().map(|s| s.expiry).min()
+        self.sessions.iter().map(|(_, s)| s.expiry).min()
     }
 
     fn on_deadline(
@@ -421,13 +418,13 @@ impl PacketHandler for SearchReflector {
         dispatcher: &mut PacketDispatcher,
         _reactor: &mut Reactor,
     ) {
-        self.sessions.retain(|session| {
+        self.sessions.retain(|key, session| {
             if session.expiry <= now {
                 dispatcher.unregister(session.response_key);
                 log::debug!(
                     "evicted {} session for searcher {} on reserved port {}",
                     self.name,
-                    session.searcher,
+                    key.searcher,
                     session.reservation.port()
                 );
                 false
@@ -451,9 +448,10 @@ impl PacketHandler for SearchReflector {
         if self.sessions.is_empty() || !captures.contains(&self.target) {
             return;
         }
-        for session in self.sessions.drain(..) {
+        for (_, session) in self.sessions.iter() {
             dispatcher.unregister(session.response_key);
         }
+        self.sessions.clear();
         log::debug!(
             "{}: cleared all sessions after the target interface changed",
             self.name
@@ -527,13 +525,14 @@ mod tests {
                 suppress: |_| false,
             }),
         );
-        reflector.sessions.push(Session {
-            searcher,
-            dest,
-            expiry,
-            reservation,
-            response_key,
-        });
+        reflector.sessions.insert(
+            SessionKey { searcher, dest },
+            Session {
+                expiry,
+                reservation,
+                response_key,
+            },
+        );
     }
 
     #[test]
@@ -598,7 +597,7 @@ mod tests {
             "the expired session is dropped"
         );
         assert_eq!(
-            reflector.sessions[0].searcher,
+            reflector.sessions.iter().next().unwrap().0.searcher,
             "10.0.0.2:5".parse::<SocketAddr>().unwrap()
         );
         assert_eq!(
@@ -651,7 +650,7 @@ mod tests {
             "no second response registration is made"
         );
         assert!(
-            reflector.sessions[0].expiry > base,
+            reflector.sessions.iter().next().unwrap().1.expiry > base,
             "the session's window is refreshed"
         );
     }
@@ -683,7 +682,8 @@ mod tests {
         reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
 
         assert_eq!(
-            reflector.sessions[0].expiry, far,
+            reflector.sessions.iter().next().unwrap().1.expiry,
+            far,
             "replies promised by the earlier window are still collected"
         );
     }
@@ -707,8 +707,9 @@ mod tests {
         let searcher: SocketAddr = "[fe80::1]:50000".parse().unwrap();
         let link_local: SocketAddr = "[ff02::c]:1900".parse().unwrap();
         let site_local: SocketAddr = "[ff05::c]:1900".parse().unwrap();
-        assert!(session_for(&reflector.sessions, searcher, link_local).is_some());
-        assert!(session_for(&reflector.sessions, searcher, site_local).is_none());
+        let key = |dest| SessionKey { searcher, dest };
+        assert!(reflector.sessions.get(&key(link_local)).is_some());
+        assert!(reflector.sessions.get(&key(site_local)).is_none());
     }
 
     // on_iface_change drops every session on a capture the reflector uses: a recreation or address
@@ -821,11 +822,11 @@ mod tests {
         // At MAX_SESSIONS in flight a new searcher is dropped; no live session is evicted early.
         let mut dispatcher = PacketDispatcher::new();
         let mut reflector = test_reflector();
-        for _ in 0..MAX_SESSIONS {
+        for i in 0..MAX_SESSIONS {
             push_session(
                 &mut reflector,
                 &mut dispatcher,
-                "10.0.0.1:5",
+                &format!("10.0.0.1:{}", 5000 + i),
                 "239.255.255.250:1900",
                 Instant::now(),
             );


### PR DESCRIPTION
Four runtime collections hand-rolled a keyed linear scan over a `Vec`: this extracts `LinearMap<K, V>` (`Vec<(K, V)>` behind the std map API; a `HashMap` was rejected earlier - tiny collections, and a contiguous scan fits the footprint target) and converts them. `InterfaceMap` and the dispatcher's monitor-event coalescer are mechanical swaps; `Session` splits into `SessionKey{searcher, dest}` plus state, retiring the index-returning `session_for` and its borrow-conflict workaround; `DialEntry` sheds its embedded key. Container methods arrive with their first consumer, one commit per consumer group.

Testing: fmt, clippy `-D warnings`, lib tests, and rustdoc on host and Linux; full 63-case Docker e2e green (covers the search-session and DIAL paths the split touches).