### PR TITLE
ci: e2e the built package before publishing

### DIFF
--- a/.github/workflows/build-daemon-pkgs.yml
+++ b/.github/workflows/build-daemon-pkgs.yml
@@ -80,12 +80,13 @@ jobs:
         run: ci/freebsd-vm.sh run 'echo IGNORE_OSVERSION=yes >> /usr/local/etc/pkg.conf'
       - name: Build the package from the port
         run: ci/freebsd-port-package.sh
-      # pkg add of the built file, not make install: the artifact being
-      # published is what gets exercised, plist and metadata included.
-      - name: Install the package
-        run: ci/freebsd-vm.sh run 'pkg add /usr/ports/net/netflector/work/pkg/netflector-*.pkg'
-      - name: e2e against the installed package
+      - name: Install and run
+        run: ci/port-install.sh
+      - name: Native e2e against the installed package
         run: ci/port-e2e.sh
+      - name: Deinstall
+        run: |
+          ci/freebsd-vm.sh run 'pkg delete -y netflector'
       - name: Fetch the package
         run: |
           mkdir out

--- a/.github/workflows/build-daemon-pkgs.yml
+++ b/.github/workflows/build-daemon-pkgs.yml
@@ -36,9 +36,10 @@ jobs:
   package:
     name: Package (freebsd${{ matrix.os }}-${{ matrix.arch.name }})
     runs-on: ubuntu-24.04
-    # Measured across publish runs: KVM lanes 2-5 minutes, arm64 13-14 (no
-    # GitHub runner offers KVM for aarch64 guests, so rustc runs under TCG).
-    timeout-minutes: ${{ matrix.arch.kvm && 15 || 40 }}
+    # Measured across publish runs: KVM lanes 2-5 minutes plus ~9 of e2e,
+    # arm64 13-14 plus ~12 (no GitHub runner offers KVM for aarch64 guests,
+    # so rustc and the suite run under TCG).
+    timeout-minutes: ${{ matrix.arch.kvm && 25 || 40 }}
     env:
       FREEBSD_VM_ARCH: ${{ matrix.arch.name }}
       FREEBSD_VM_VERSION: ${{ matrix.os }}-opnsense
@@ -79,6 +80,12 @@ jobs:
         run: ci/freebsd-vm.sh run 'echo IGNORE_OSVERSION=yes >> /usr/local/etc/pkg.conf'
       - name: Build the package from the port
         run: ci/freebsd-port-package.sh
+      # pkg add of the built file, not make install: the artifact being
+      # published is what gets exercised, plist and metadata included.
+      - name: Install the package
+        run: ci/freebsd-vm.sh run 'pkg add /usr/ports/net/netflector/work/pkg/netflector-*.pkg'
+      - name: e2e against the installed package
+        run: ci/port-e2e.sh
       - name: Fetch the package
         run: |
           mkdir out

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/ci-port.yml'
       # --check runs only here; ci.yml exercises just --local.
       - 'ci/port-sync.py'
+      # Consumed by the port-build e2e step.
+      - 'ci/port-e2e.sh'
   workflow_call:
     inputs:
       # For publish-daemon: build-daemon-pkgs builds the port on every ABI
@@ -117,13 +119,10 @@ jobs:
           ci/freebsd-vm.sh run 'mandoc -T lint -W style /usr/local/share/man/man8/netflector.8.gz /usr/local/share/man/man5/netflector.toml.5.gz'
       # The port's binary is the one configuration no other lane executes end to end: release
       # profile, dynamically linked, built by the ports framework from the release tarball. Run
-      # the full native e2e suite against the INSTALLED binary before deinstalling it. The suite
-      # comes from the extracted tarball (WRKSRC), not the working tree: HEAD cases may assert
-      # behavior the release predates (HEAD code with HEAD suite is ci.yml's from-source build).
+      # the full native e2e suite against the INSTALLED binary before deinstalling it; the
+      # script picks the suite that matches it.
       - name: Native e2e against the installed port binary
-        run: |
-          ci/freebsd-vm.sh run 'pkg install -y python3'
-          ci/freebsd-vm.sh run 'cd $(make -C /usr/ports/net/netflector -V WRKSRC) && python3 e2e/run.py --backend native --binary /usr/local/bin/netflector'
+        run: ci/port-e2e.sh
       - name: Deinstall
         run: |
           ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make deinstall'

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -14,7 +14,8 @@ on:
       - '.github/workflows/ci-port.yml'
       # --check runs only here; ci.yml exercises just --local.
       - 'ci/port-sync.py'
-      # Consumed by the port-build e2e step.
+      # Consumed by the port-build install and e2e steps.
+      - 'ci/port-install.sh'
       - 'ci/port-e2e.sh'
   workflow_call:
     inputs:
@@ -99,15 +100,7 @@ jobs:
           ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make check-plist'
           ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make package'
       - name: Install and run
-        run: |
-          ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make install'
-          ci/freebsd-vm.sh run '/usr/local/bin/netflector --version'
-          # The rc script must refuse a configuration the daemon would reject, rather than launching a
-          # service that dies a second later.
-          ci/freebsd-vm.sh run 'sysrc netflector_enable=YES'
-          ci/freebsd-vm.sh run 'printf "[reflectors.bad]\nsource_if = \"em0\"\ntarget_if = \"em0\"\nmdns = true\n" > /usr/local/etc/netflector.toml'
-          ci/freebsd-vm.sh run 'service netflector start 2>&1 | grep -q "refusing to start" && echo "rc refused an invalid configuration"'
-          ci/freebsd-vm.sh run 'rm /usr/local/etc/netflector.toml'
+        run: ci/port-install.sh
       # Lint the pages as installed, cross-reference check included: at the default floor
       # the Xr search is deliberately base-system-only, but -W style (added in mandoc
       # 1.14.6 for exactly this case) searches the full manpath, which has the port tree.
@@ -119,13 +112,13 @@ jobs:
           ci/freebsd-vm.sh run 'mandoc -T lint -W style /usr/local/share/man/man8/netflector.8.gz /usr/local/share/man/man5/netflector.toml.5.gz'
       # The port's binary is the one configuration no other lane executes end to end: release
       # profile, dynamically linked, built by the ports framework from the release tarball. Run
-      # the full native e2e suite against the INSTALLED binary before deinstalling it; the
+      # the full native e2e suite against the INSTALLED package before deinstalling it; the
       # script picks the suite that matches it.
-      - name: Native e2e against the installed port binary
+      - name: Native e2e against the installed package
         run: ci/port-e2e.sh
       - name: Deinstall
         run: |
-          ci/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make deinstall'
+          ci/freebsd-vm.sh run 'pkg delete -y netflector'
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       # only ignored paths fires nothing and stays blocked; workflow_dispatch
       # ci.yml unsticks it.
       - '.github/workflows/ci-port.yml'
+      - 'ci/port-e2e.sh'
       - '.github/workflows/ci-opnsense.yml'
       - '.github/workflows/ci-docs.yml'
       - '.github/workflows/ci-supply-chain.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       # only ignored paths fires nothing and stays blocked; workflow_dispatch
       # ci.yml unsticks it.
       - '.github/workflows/ci-port.yml'
+      - 'ci/port-install.sh'
       - 'ci/port-e2e.sh'
       - '.github/workflows/ci-opnsense.yml'
       - '.github/workflows/ci-docs.yml'

--- a/ci/freebsd-port-package.sh
+++ b/ci/freebsd-port-package.sh
@@ -16,3 +16,6 @@ HERE="$(dirname "$0")"
 "$HERE"/freebsd-vm.sh run 'rm -rf /usr/ports/net/netflector'
 "$HERE"/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
 "$HERE"/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make ALLOW_UNSUPPORTED_SYSTEM=yes package'
+# Base-sensitive QA the PR lanes cannot cover: they lint on the release images,
+# while this stages on the EOL OPNsense bases the packages are built for.
+"$HERE"/freebsd-vm.sh run 'cd /usr/ports/net/netflector && make ALLOW_UNSUPPORTED_SYSTEM=yes stage-qa check-plist'

--- a/ci/port-e2e.sh
+++ b/ci/port-e2e.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run the e2e suite in the running FreeBSD VM (ci/freebsd-vm.sh env applies)
+# against the installed daemon. The suite comes from the port's extracted
+# source (WRKSRC), never the working tree: the tree's cases may assert
+# behavior the pinned release predates, while WRKSRC's suite matches the
+# installed binary by construction. ALLOW_UNSUPPORTED_SYSTEM: the publish VMs
+# run EOL OPNsense bases the pinned ports tree otherwise refuses.
+set -euo pipefail
+
+HERE="$(dirname "$0")"
+
+"$HERE"/freebsd-vm.sh run 'pkg install -y python3'
+"$HERE"/freebsd-vm.sh run 'cd $(make -C /usr/ports/net/netflector ALLOW_UNSUPPORTED_SYSTEM=yes -V WRKSRC) && python3 e2e/run.py --backend native --binary /usr/local/bin/netflector'

--- a/ci/port-install.sh
+++ b/ci/port-install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Install the port-built daemon package into the running FreeBSD VM
+# (ci/freebsd-vm.sh env applies) and smoke it. pkg add of the .pkg file, not
+# make install: the framework installs from the stage directory and never
+# opens the tarball again, so only pkg add exercises the artifact that ships,
+# manifest and packaged scripts included.
+set -euo pipefail
+
+HERE="$(dirname "$0")"
+
+"$HERE"/freebsd-vm.sh run 'pkg add /usr/ports/net/netflector/work/pkg/netflector-*.pkg'
+"$HERE"/freebsd-vm.sh run '/usr/local/bin/netflector --version'
+# The rc script must refuse a configuration the daemon would reject, rather
+# than launching a service that dies a second later.
+"$HERE"/freebsd-vm.sh run 'sysrc netflector_enable=YES'
+"$HERE"/freebsd-vm.sh run 'printf "[reflectors.bad]\nsource_if = \"em0\"\ntarget_if = \"em0\"\nmdns = true\n" > /usr/local/etc/netflector.toml'
+"$HERE"/freebsd-vm.sh run 'service netflector start 2>&1 | grep -q "refusing to start" && echo "rc refused an invalid configuration"'
+"$HERE"/freebsd-vm.sh run 'rm /usr/local/etc/netflector.toml'


### PR DESCRIPTION
Closes the artifact gap in the publish flow: at publish time nothing reflected a packet through the bits being signed (the recipe e2e runs at PR stage, the OPNsense gates exercise install/start only, and the in-VM toolchain floats). build-daemon-pkgs now `pkg add`s the package it just built and runs the release's own e2e suite against it, per ABI, before the sign/deploy tail; a failed suite kills the publish via fail-fast.

The suite invocation moves to `ci/port-e2e.sh`, shared with ci-port's lane (kept a script rather than a callable workflow: a reusable workflow runs on a fresh runner and would need a second VM boot per lane). The suite always comes from the port's WRKSRC, so it matches the installed binary by construction; `ALLOW_UNSUPPORTED_SYSTEM` covers the publish VMs' EOL OPNsense bases. KVM lane timeout raised 15 to 25 minutes for the ~9-minute suite.

Testing: ci-port runs the shared script on all four rows on this PR; the publish path is exercised on the next publish.