### PR TITLE
reflector: drop advertised addresses that can never name a device

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,14 +379,17 @@ mDNS is relayed as pure multicast. A querier that asks for a unicast answer (the
 from an ephemeral source port) is answered off the group, and that answer is not relayed; SSDP and WSD
 instead proxy each searcher's unicast reply.
 
-Messages that advertise only link-local addresses (`169.254.0.0/16`, `fe80::/10`) are dropped rather
-than relayed: an mDNS response whose A/AAAA records are all link-local, an SSDP advertisement or
-search reply whose `LOCATION` names one, a WSD message whose `XAddrs` all name one. Such an address
-is valid only on the link it came from, so the relayed message would advertise endpoints the other
-segment can never reach. One routable address among them lets the message through. A `LOCATION` the
-DIAL proxy rewrote is exempt: it names netflector's own listener on the egress interface, reachable
-from that link even when the interface's address is itself link-local. Suppressed messages count as
-`dropped` and log at debug level.
+Messages whose advertised addresses are all unreachable are dropped rather than relayed: an mDNS
+response whose A/AAAA records, an SSDP advertisement or search reply whose `LOCATION`, or a WSD
+message whose `XAddrs` name only such addresses. Unreachable means link-local (`169.254.0.0/16`,
+`fe80::/10`), valid only on the link it came from, or an address that never names a device at all:
+loopback, unspecified (`0.0.0.0`, `::`), multicast, broadcast (`255.255.255.255`). One usable
+address among them lets
+the message through. A `LOCATION` the DIAL proxy rewrote is exempt: it names netflector's own
+listener on the egress interface, reachable from that link even when the interface's address is
+itself link-local. The DIAL proxy itself refuses to proxy a device whose `LOCATION` or
+`Application-URL` names a never-a-device address. Suppressed messages count as `dropped` and log at
+debug level.
 
 netflector reads untagged Ethernet frames carrying IPv4 or IPv6 UDP. VLAN-tagged frames and IPv6
 extension headers are not parsed, so configure the VLAN as its own interface (`vlan10`, `em0.10`) and
@@ -456,7 +459,7 @@ counters eth0: recoveries=1; mDNS query reflected=42 skipped=10; SSDP search ref
 
 Per message type: `reflected` (re-emitted on the other interface), `skipped` (right protocol, wrong
 direction for this leg - normal, this is the loop prevention working), `dropped` (should have been
-reflected but was not: a send error, a resource cap, or the link-local suppression) and `stalled`
+reflected but was not: a send error, a resource cap, or the advertisement suppression) and `stalled`
 (the egress had no source address of the packet's family yet). Interface-wide: `filtered`
 (unrecognized traffic on the group), `oversized` (received frames too large to forward) and
 `recoveries` (the interface was destroyed and recreated, and its capture re-bound). `netflector(8)`

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -59,9 +59,10 @@ MDNS_QUERY_HEX = "00000000000100000000000074657374"
 MDNS_RESPONSE_HEX = "00008400000100010000000074657374"
 # 8 bytes: below the 12-byte DNS-header minimum, so classify() returns None and drops it.
 MDNS_SHORT_QUERY_HEX = "0000000000010000"
-# Well-formed responses for the link-local suppression: QR+AA header, ANCOUNT=2, both answers under
-# the name "x." (each record: 3-byte name, TYPE, IN, TTL 120, RDLENGTH, rdata). A response is
-# suppressed only when every A/AAAA it carries is link-local; one routable address rescues it.
+# Well-formed responses for the advertisement suppression: QR+AA header, ANCOUNT=2, both answers
+# under the name "x." (each record: 3-byte name, TYPE, IN, TTL 120, RDLENGTH, rdata). A response is
+# suppressed only when every A/AAAA it carries is unreachable (here link-local); one routable
+# address rescues it.
 MDNS_RESPONSE_MIXED_HEX = (
     "000084000000000200000000"  # header
     "01780000010001000000780004a9fe0102"  # A x. -> 169.254.1.2 (link-local)
@@ -173,9 +174,9 @@ WSD_HELLO_HEX = (
 ).encode().hex()
 
 
-# A Hello carrying the given XAddrs, for the link-local suppression: suppressed only when every
-# XAddrs URI names a link-local literal. (WSD_HELLO_HEX above has no XAddrs at all and must keep
-# reflecting; resolution then happens via Resolve.)
+# A Hello carrying the given XAddrs, for the advertisement suppression: suppressed only when every
+# XAddrs URI names an unreachable literal (here link-local). (WSD_HELLO_HEX above has no XAddrs at
+# all and must keep reflecting; resolution then happens via Resolve.)
 def wsd_hello_with_xaddrs(xaddrs: str) -> str:
     return (
         '<?xml version="1.0" encoding="utf-8"?>'

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -172,8 +172,8 @@ Recognized, but arrived in a direction the entry does not relay.
 This is normal; it is also what keeps reflected packets from looping.
 .It Sy dropped
 Should have been reflected, but was not: a send error, a resource cap, or a
-message advertising only link-local addresses, which the other segment could
-never reach.
+message advertising only unreachable addresses (link-local, loopback,
+unspecified, multicast, broadcast), which the other segment could never use.
 .It Sy stalled
 Should have been reflected, but the egress interface had no source address
 of the packet's family yet.

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -98,8 +98,8 @@ pub(crate) enum Outcome {
     Reflected(MessageType),
     /// Recognized, but the wrong direction for this leg: the loop-breaker, not ours to forward.
     Skipped(MessageType),
-    /// The right direction, but not re-emitted: a send error, a resource cap, or the link-local
-    /// suppression.
+    /// The right direction, but not re-emitted: a send error, a resource cap, or the
+    /// unreachable-advertisement suppression.
     Dropped(MessageType),
     /// The right direction, but the egress has no source address of the family yet (transient).
     Stalled(MessageType),

--- a/src/net.rs
+++ b/src/net.rs
@@ -62,11 +62,33 @@ pub(crate) const MAX_UDP_PAYLOAD_LEN: usize =
 /// `DLT_NULL` link's 4-byte header leaves a little more room, accepted as slack.
 pub(crate) const MAX_MTU: usize = MAX_FRAME_LEN - ETHERNET_HEADER_SIZE;
 
-/// Whether `ip` is link-local (IPv4 `169.254.0.0/16`, IPv6 `fe80::/10`).
+/// Whether `ip` is link-local (IPv4 `169.254.0.0/16`, IPv6 `fe80::/10`). A v4-mapped IPv6 address
+/// is judged by its IPv4 rules, like [`is_never_a_peer`].
 pub(crate) fn is_link_local(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => v4.is_link_local(),
-        IpAddr::V6(v6) => v6.is_unicast_link_local(),
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => v4.is_link_local(),
+            None => v6.is_unicast_link_local(),
+        },
+    }
+}
+
+/// Whether `ip` can never name another single host: loopback is the connecting host itself,
+/// unspecified is no host, and multicast / IPv4 limited broadcast are groups. Unlike link-local,
+/// which is a valid peer on its own link, such an address names no device from any segment. A
+/// v4-mapped IPv6 address is judged by its IPv4 rules (`::ffff:127.0.0.1` reaches `127.0.0.1`,
+/// and std's `Ipv6Addr::is_loopback` would miss it). A directed IPv4 broadcast is
+/// indistinguishable from a host address without the subnet mask and reads as `false`.
+pub(crate) fn is_never_a_peer(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_unspecified() || v4.is_multicast() || v4.is_broadcast()
+        }
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => is_never_a_peer(IpAddr::V4(v4)),
+            None => v6.is_loopback() || v6.is_unspecified() || v6.is_multicast(),
+        },
     }
 }
 
@@ -80,8 +102,30 @@ mod tests {
         assert!(is_link_local("fe80::1".parse().unwrap()));
         assert!(!is_link_local("192.168.1.1".parse().unwrap()));
         assert!(!is_link_local("2001:db8::1".parse().unwrap()));
+        // A v4-mapped address is judged by its IPv4 rules.
+        assert!(is_link_local("::ffff:169.254.7.9".parse().unwrap()));
+        assert!(!is_link_local("::ffff:192.168.1.1".parse().unwrap()));
         // Adjacent special ranges don't leak in: loopback and unique-local are not link-local.
         assert!(!is_link_local("127.0.0.1".parse().unwrap()));
         assert!(!is_link_local("fd00::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn never_a_peer_covers_the_non_host_classes_and_nothing_else() {
+        assert!(is_never_a_peer("127.0.0.1".parse().unwrap()));
+        assert!(is_never_a_peer("0.0.0.0".parse().unwrap()));
+        assert!(is_never_a_peer("239.255.255.250".parse().unwrap()));
+        assert!(is_never_a_peer("255.255.255.255".parse().unwrap()));
+        assert!(is_never_a_peer("::1".parse().unwrap()));
+        assert!(is_never_a_peer("::".parse().unwrap()));
+        assert!(is_never_a_peer("ff02::c".parse().unwrap()));
+        // A v4-mapped address is judged by its IPv4 rules.
+        assert!(is_never_a_peer("::ffff:127.0.0.1".parse().unwrap()));
+        assert!(!is_never_a_peer("::ffff:192.168.1.1".parse().unwrap()));
+        // Host addresses stay peers, link-local and a maskless directed broadcast included.
+        assert!(!is_never_a_peer("192.168.1.1".parse().unwrap()));
+        assert!(!is_never_a_peer("169.254.7.9".parse().unwrap()));
+        assert!(!is_never_a_peer("fe80::1".parse().unwrap()));
+        assert!(!is_never_a_peer("192.168.1.255".parse().unwrap()));
     }
 }

--- a/src/net/mdns.rs
+++ b/src/net/mdns.rs
@@ -2,7 +2,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use super::is_link_local;
+use super::{is_link_local, is_never_a_peer};
 
 /// RFC 6762.
 pub(crate) const MDNS_PORT: u16 = 5353;
@@ -52,16 +52,17 @@ pub(crate) fn classify(payload: &[u8]) -> Option<MdnsKind> {
 const TYPE_A: u16 = 1;
 const TYPE_AAAA: u16 = 28;
 
-/// Whether the message carries at least one A/AAAA record and every one is link-local. Callers
-/// apply it to responses only: a query's records are known-answer cache state, not an
-/// advertisement. No address records, a routable address, or malformation all read as `false`.
-pub(crate) fn advertises_only_link_local(payload: &[u8]) -> bool {
-    only_link_local_records(payload).unwrap_or(false)
+/// Whether the message carries at least one A/AAAA record and every one is link-local or otherwise
+/// never a peer ([`is_never_a_peer`]). Callers apply it to responses only: a query's records are
+/// known-answer cache state, not an advertisement. No address records, a usable address, or
+/// malformation all read as `false`.
+pub(crate) fn advertises_only_unreachable(payload: &[u8]) -> bool {
+    only_unreachable_records(payload).unwrap_or(false)
 }
 
-/// The record walk behind [`advertises_only_link_local`]: `None` on truncation or an undefined
+/// The record walk behind [`advertises_only_unreachable`]: `None` on truncation or an undefined
 /// label type.
-fn only_link_local_records(payload: &[u8]) -> Option<bool> {
+fn only_unreachable_records(payload: &[u8]) -> Option<bool> {
     if payload.len() < DNS_HEADER_LEN {
         return None;
     }
@@ -95,7 +96,7 @@ fn only_link_local_records(payload: &[u8]) -> Option<bool> {
             // Any other type, or an A/AAAA whose rdata is not address-sized, holds no address.
             _ => continue,
         };
-        if !is_link_local(ip) {
+        if !(is_link_local(ip) || is_never_a_peer(ip)) {
             return Some(false);
         }
         saw_address = true;
@@ -251,38 +252,51 @@ mod tests {
         TYPE_AAAA,
         &[0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
     );
+    const A_LOOPBACK: (u16, &[u8]) = (TYPE_A, &[127, 0, 0, 1]);
+    const A_UNSPECIFIED: (u16, &[u8]) = (TYPE_A, &[0, 0, 0, 0]);
     const TXT: (u16, &[u8]) = (16, b"vers=1");
 
     #[test]
-    fn suppresses_only_when_every_address_is_link_local() {
-        assert!(advertises_only_link_local(&response_with_records(&[
+    fn suppresses_only_when_every_address_is_unreachable() {
+        assert!(advertises_only_unreachable(&response_with_records(&[
             A_LINK_LOCAL
         ])));
-        assert!(advertises_only_link_local(&response_with_records(&[
+        assert!(advertises_only_unreachable(&response_with_records(&[
             AAAA_LINK_LOCAL
         ])));
-        assert!(advertises_only_link_local(&response_with_records(&[
+        assert!(advertises_only_unreachable(&response_with_records(&[
             A_LINK_LOCAL,
             AAAA_LINK_LOCAL
         ])));
         // One routable address of either family rescues the message: the client can use it.
-        assert!(!advertises_only_link_local(&response_with_records(&[
+        assert!(!advertises_only_unreachable(&response_with_records(&[
             A_LINK_LOCAL,
             A_ROUTABLE
         ])));
-        assert!(!advertises_only_link_local(&response_with_records(&[
+        assert!(!advertises_only_unreachable(&response_with_records(&[
             AAAA_LINK_LOCAL,
             AAAA_ROUTABLE
         ])));
+        // The never-a-peer classes suppress like link-local, and a routable address rescues them too.
+        assert!(advertises_only_unreachable(&response_with_records(&[
+            A_LOOPBACK
+        ])));
+        assert!(advertises_only_unreachable(&response_with_records(&[
+            A_UNSPECIFIED,
+            AAAA_LINK_LOCAL
+        ])));
+        assert!(!advertises_only_unreachable(&response_with_records(&[
+            A_LOOPBACK, A_ROUTABLE
+        ])));
         // Other record types don't veto: a bundled advertisement (PTR/SRV/TXT beside the
         // addresses) whose only addresses are link-local is exactly the dead-service case.
-        assert!(advertises_only_link_local(&response_with_records(&[
+        assert!(advertises_only_unreachable(&response_with_records(&[
             TXT,
             A_LINK_LOCAL
         ])));
         // No address records at all is not an advertisement of dead endpoints.
-        assert!(!advertises_only_link_local(&response_with_records(&[TXT])));
-        assert!(!advertises_only_link_local(&response_with_records(&[])));
+        assert!(!advertises_only_unreachable(&response_with_records(&[TXT])));
+        assert!(!advertises_only_unreachable(&response_with_records(&[])));
     }
 
     #[test]
@@ -294,7 +308,7 @@ mod tests {
         m.extend_from_slice(&[0xc0, 0x0c]);
         m.extend_from_slice(&TYPE_A.to_be_bytes());
         m.extend_from_slice(&[0x00, 0x01, 0, 0, 0, 120, 0x00, 0x04, 169, 254, 3, 4]);
-        assert!(advertises_only_link_local(&m));
+        assert!(advertises_only_unreachable(&m));
     }
 
     #[test]
@@ -302,20 +316,20 @@ mod tests {
         // Truncated rdata: the record claims 4 bytes and the payload ends.
         let mut m = response_with_records(&[A_LINK_LOCAL]);
         m.truncate(m.len() - 2);
-        assert!(!advertises_only_link_local(&m));
+        assert!(!advertises_only_unreachable(&m));
         // An undefined label type (0x40) aborts the walk.
         let mut m = response_with_records(&[A_LINK_LOCAL]);
         m[DNS_HEADER_LEN] = 0x40;
-        assert!(!advertises_only_link_local(&m));
-        assert!(!advertises_only_link_local(b""));
+        assert!(!advertises_only_unreachable(&m));
+        assert!(!advertises_only_unreachable(b""));
     }
 
     #[test]
     fn real_responses_with_a_routable_address_are_not_suppressed() {
         // Bonjour: fe80:: AAAA + routable A + global AAAA (mixed); RAOP: one routable A.
-        assert!(!advertises_only_link_local(&MDNS_RESPONSE_BONJOUR));
-        assert!(!advertises_only_link_local(&MDNS_RESPONSE_RAOP));
+        assert!(!advertises_only_unreachable(&MDNS_RESPONSE_BONJOUR));
+        assert!(!advertises_only_unreachable(&MDNS_RESPONSE_RAOP));
         // The reverse-PTR query carries no address records.
-        assert!(!advertises_only_link_local(&MDNS_QUERY_PTR_LINKLOCAL));
+        assert!(!advertises_only_unreachable(&MDNS_QUERY_PTR_LINKLOCAL));
     }
 }

--- a/src/net/ssdp.rs
+++ b/src/net/ssdp.rs
@@ -6,7 +6,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::net::http::{strip_prefix_ignore_ascii_case, url_host_ip};
 
-use super::is_link_local;
+use super::{is_link_local, is_never_a_peer};
 
 /// The SSDP UDP port (`UPnP` Device Architecture).
 pub(crate) const SSDP_PORT: u16 = 1900;
@@ -51,12 +51,13 @@ pub(crate) fn classify(payload: &[u8]) -> Option<SsdpKind> {
     }
 }
 
-/// Whether the message's `LOCATION` names a link-local IP literal. An absent `LOCATION` (a
-/// `byebye`), a hostname, or a routable literal reads as `false`.
-pub(crate) fn advertises_only_link_local(payload: &[u8]) -> bool {
+/// Whether the message's `LOCATION` names an IP literal no client on the other segment could use:
+/// link-local, or one that can never name a device at all ([`is_never_a_peer`]). An absent
+/// `LOCATION` (a `byebye`), a hostname, or a routable literal reads as `false`.
+pub(crate) fn advertises_only_unreachable(payload: &[u8]) -> bool {
     dial::dial_location_value(payload)
         .and_then(url_host_ip)
-        .is_some_and(is_link_local)
+        .is_some_and(|ip| is_link_local(ip) || is_never_a_peer(ip))
 }
 
 /// MX is clamped to `[1, 5]` seconds (`UPnP` Device Architecture 2.0).
@@ -199,19 +200,29 @@ mod tests {
     const NOTIFY_BYEBYE_CANON: &str = "NOTIFY * HTTP/1.1\r\nHost: 239.255.255.250:1900\r\nNT: urn:schemas-canon-com:service:ICPO-SmartPhoneEOSSystemService:1\r\nNTS: ssdp:byebye\r\nUSN: uuid:00000000-0000-0000-0001-2C9EFCD137BE::urn:schemas-canon-com:service:ICPO-SmartPhoneEOSSystemService:1\r\n\r\n";
 
     #[test]
-    fn suppresses_only_a_link_local_location() {
-        assert!(advertises_only_link_local(
+    fn suppresses_an_unreachable_location() {
+        assert!(advertises_only_unreachable(
             b"NOTIFY * HTTP/1.1\r\nNTS: ssdp:alive\r\nLOCATION: http://169.254.9.9:1900/d.xml\r\n\r\n"
         ));
-        assert!(advertises_only_link_local(
+        assert!(advertises_only_unreachable(
             b"HTTP/1.1 200 OK\r\nLOCATION: http://[fe80::1]:8080/d.xml\r\n\r\n"
         ));
+        // The never-a-peer classes: loopback, unspecified, multicast.
+        assert!(advertises_only_unreachable(
+            b"NOTIFY * HTTP/1.1\r\nNTS: ssdp:alive\r\nLOCATION: http://127.0.0.1:8008/d.xml\r\n\r\n"
+        ));
+        assert!(advertises_only_unreachable(
+            b"NOTIFY * HTTP/1.1\r\nNTS: ssdp:alive\r\nLOCATION: http://0.0.0.0:8008/d.xml\r\n\r\n"
+        ));
+        assert!(advertises_only_unreachable(
+            b"HTTP/1.1 200 OK\r\nLOCATION: http://239.255.255.250:1900/d.xml\r\n\r\n"
+        ));
         // Routable, hostname, or no LOCATION at all (a byebye): reflect as usual.
-        assert!(!advertises_only_link_local(NOTIFY_ALIVE_SONY.as_bytes()));
-        assert!(!advertises_only_link_local(
+        assert!(!advertises_only_unreachable(NOTIFY_ALIVE_SONY.as_bytes()));
+        assert!(!advertises_only_unreachable(
             b"NOTIFY * HTTP/1.1\r\nLOCATION: http://printer.local/d.xml\r\n\r\n"
         ));
-        assert!(!advertises_only_link_local(NOTIFY_BYEBYE_CANON.as_bytes()));
+        assert!(!advertises_only_unreachable(NOTIFY_BYEBYE_CANON.as_bytes()));
     }
 
     #[test]

--- a/src/net/wsd.rs
+++ b/src/net/wsd.rs
@@ -8,7 +8,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::net::http::url_host_ip;
 
-use super::is_link_local;
+use super::{is_link_local, is_never_a_peer};
 
 /// WSD runs SOAP-over-UDP on port 3702, re-emitted at TTL 1. The re-emit is a single hop onto the
 /// egress link, matching the link scope of the groups it serves.
@@ -49,9 +49,9 @@ fn action_segment(payload: &[u8]) -> Option<&[u8]> {
 }
 
 /// Whether the message's `XAddrs` (the device's transport addresses) hold at least one IP-literal
-/// URI and every one is link-local. A hostname or unparseable URI, a routable literal, or no
-/// `XAddrs` at all reads as `false`.
-pub(crate) fn advertises_only_link_local(payload: &[u8]) -> bool {
+/// URI and every one is link-local or otherwise never a peer ([`is_never_a_peer`]). A hostname or
+/// unparseable URI, a usable literal, or no `XAddrs` at all reads as `false`.
+pub(crate) fn advertises_only_unreachable(payload: &[u8]) -> bool {
     // Every XAddrs element counts: a ProbeMatches carries one per ProbeMatch.
     let mut saw_ip = false;
     let mut rest = payload;
@@ -61,7 +61,7 @@ pub(crate) fn advertises_only_link_local(payload: &[u8]) -> bool {
                 continue;
             }
             match url_host_ip(uri) {
-                Some(ip) if is_link_local(ip) => saw_ip = true,
+                Some(ip) if is_link_local(ip) || is_never_a_peer(ip) => saw_ip = true,
                 // A routable literal, a hostname, or an unparseable URI: not provably dead.
                 _ => return false,
             }
@@ -420,25 +420,32 @@ urn:schemas-xmlsoap-org:ws:2005:04:discovery
     }
 
     #[test]
-    fn suppresses_only_all_link_local_xaddrs() {
-        assert!(advertises_only_link_local(&hello_with_xaddrs(
+    fn suppresses_only_unreachable_xaddrs() {
+        assert!(advertises_only_unreachable(&hello_with_xaddrs(
             "http://169.254.1.5:5357/dev"
         )));
-        assert!(advertises_only_link_local(&hello_with_xaddrs(
+        assert!(advertises_only_unreachable(&hello_with_xaddrs(
             "http://[fe80::1]:5357/a http://169.254.2.2:5357/a"
         )));
         // WSDAPI advertises zoned link-local XAddrs.
-        assert!(advertises_only_link_local(&hello_with_xaddrs(
+        assert!(advertises_only_unreachable(&hello_with_xaddrs(
             "http://[fe80::1%25eth0]:5357/a"
         )));
+        // The never-a-peer classes suppress like link-local.
+        assert!(advertises_only_unreachable(&hello_with_xaddrs(
+            "http://127.0.0.1:5357/dev"
+        )));
+        assert!(advertises_only_unreachable(&hello_with_xaddrs(
+            "http://0.0.0.0:5357/a http://[fe80::1]:5357/a"
+        )));
         // One routable address, a hostname, or an unparseable URI rescues the message.
-        assert!(!advertises_only_link_local(&hello_with_xaddrs(
+        assert!(!advertises_only_unreachable(&hello_with_xaddrs(
             "http://[fe80::1]:5357/a http://192.168.1.5:5357/a"
         )));
-        assert!(!advertises_only_link_local(&hello_with_xaddrs(
+        assert!(!advertises_only_unreachable(&hello_with_xaddrs(
             "http://169.254.1.5:5357/a http://printer.local:5357/a"
         )));
-        assert!(!advertises_only_link_local(&hello_with_xaddrs("")));
+        assert!(!advertises_only_unreachable(&hello_with_xaddrs("")));
     }
 
     #[test]
@@ -451,11 +458,11 @@ urn:schemas-xmlsoap-org:ws:2005:04:discovery
             )
             .into_bytes()
         };
-        assert!(advertises_only_link_local(&two(
+        assert!(advertises_only_unreachable(&two(
             "http://169.254.1.5:5357/a",
             "http://[fe80::2]:5357/b"
         )));
-        assert!(!advertises_only_link_local(&two(
+        assert!(!advertises_only_unreachable(&two(
             "http://169.254.1.5:5357/a",
             "http://10.0.0.2:5357/b"
         )));
@@ -464,13 +471,13 @@ urn:schemas-xmlsoap-org:ws:2005:04:discovery
     #[test]
     fn messages_without_xaddrs_are_not_suppressed() {
         // Resolution then happens via Resolve; there is no advertised endpoint to judge.
-        assert!(!advertises_only_link_local(HELLO_OASIS_2009.as_bytes()));
-        assert!(!advertises_only_link_local(b""));
+        assert!(!advertises_only_unreachable(HELLO_OASIS_2009.as_bytes()));
+        assert!(!advertises_only_unreachable(b""));
         // Real replies carrying routable XAddrs (http and https).
-        assert!(!advertises_only_link_local(
+        assert!(!advertises_only_unreachable(
             PROBEMATCHES_ONVIF_UNIVIEW.as_bytes()
         ));
-        assert!(!advertises_only_link_local(
+        assert!(!advertises_only_unreachable(
             RESOLVEMATCHES_MS_WSDAPI.as_bytes()
         ));
     }

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -46,7 +46,8 @@ pub(crate) enum Verdict {
 /// Transforms a datagram's payload before it is re-emitted: the SSDP DIAL `LOCATION` rewrite, applied
 /// on both the advertisement direction and each search session's reply. Returns the rewrite, held in
 /// the implementor's own reused scratch, or `None` to forward `payload` verbatim; the caller also
-/// reads `None` as "still advertising the device's own addresses" for the link-local suppression.
+/// reads `None` as "still advertising the device's own addresses" for the unreachable-advertisement
+/// suppression.
 /// The `Fn` traits can't express that lending signature, which is why this is a trait rather than a
 /// closure.
 pub(crate) trait ReplyRewrite {

--- a/src/reflector/dial/proxy.rs
+++ b/src/reflector/dial/proxy.rs
@@ -8,11 +8,12 @@
 //! sweeps its own connections past their connect/idle deadlines.
 
 use std::fmt;
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
 use crate::logging::log_rate;
+use crate::net::is_never_a_peer;
 use crate::net::tcp::TcpSocket;
 use crate::reactor::{Arena, Handler, HandlerKey, Key, Reactor, ReadyEvent};
 
@@ -252,17 +253,31 @@ impl DialDeviceProxy {
         };
         // A description response just revealed (or moved) the device's REST endpoint.
         if let Some(endpoint) = learned {
-            if self.rest_endpoint != Some(endpoint) {
-                log::debug!(
-                    "dial: learned {}'s REST endpoint {endpoint}",
-                    self.desc_endpoint
-                );
-            }
-            self.rest_endpoint = Some(endpoint);
+            self.adopt_rest_endpoint(endpoint);
         }
         if outcome == Outcome::Close {
             self.close_conn(conn_key, reactor);
         }
+    }
+
+    /// Adopt a REST endpoint a description response revealed, unless it can never name a device
+    /// ([`is_never_a_peer`]): dialing such an address would reach a local service, not the device.
+    /// A link-local endpoint is fine, deliberately: the dial goes out the target interface, on-link.
+    fn adopt_rest_endpoint(&mut self, endpoint: SocketAddrV4) {
+        if is_never_a_peer(IpAddr::V4(*endpoint.ip())) {
+            log::debug!(
+                "dial: ignoring {}'s REST endpoint {endpoint}: it can never name a device",
+                self.desc_endpoint
+            );
+            return;
+        }
+        if self.rest_endpoint != Some(endpoint) {
+            log::debug!(
+                "dial: learned {}'s REST endpoint {endpoint}",
+                self.desc_endpoint
+            );
+        }
+        self.rest_endpoint = Some(endpoint);
     }
 
     /// A connection socket is writable: complete the connect / drain its send backlog; close on error.
@@ -383,6 +398,24 @@ mod tests {
         );
         proxy.adopt_key(key);
         (proxy, rest_addr)
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
+    fn a_never_a_peer_rest_endpoint_is_not_adopted() {
+        let mut reactor = Reactor::new().expect("reactor");
+        let (mut proxy, _rest_addr) = watched_proxy(&mut reactor);
+        let device: SocketAddrV4 = "10.0.0.5:8009".parse().unwrap();
+        proxy.adopt_rest_endpoint(device);
+        assert_eq!(proxy.rest_endpoint, Some(device));
+        // A later description naming loopback or unspecified does not displace it.
+        proxy.adopt_rest_endpoint("127.0.0.1:9".parse().unwrap());
+        proxy.adopt_rest_endpoint("0.0.0.0:8009".parse().unwrap());
+        assert_eq!(proxy.rest_endpoint, Some(device));
+        // A link-local endpoint is adoptable: the proxy dials it on-link from the target side.
+        let link_local: SocketAddrV4 = "169.254.9.9:8009".parse().unwrap();
+        proxy.adopt_rest_endpoint(link_local);
+        assert_eq!(proxy.rest_endpoint, Some(link_local));
     }
 
     #[test]

--- a/src/reflector/dial/rewrite.rs
+++ b/src/reflector/dial/rewrite.rs
@@ -5,11 +5,12 @@
 //! registry) if none is live for the device, and refreshing its grace either way.
 
 use std::io;
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::os::fd::AsRawFd;
 use std::time::{Duration, Instant};
 
 use crate::dispatch::{CaptureKey, DialContext, DialProxyKey};
+use crate::net::is_never_a_peer;
 use crate::net::ssdp::dial::{
     dial_location_value, is_dial_service_message, parse_cache_control_max_age,
     parse_dial_location_authority,
@@ -45,8 +46,10 @@ pub(crate) struct ProxyPlacement<'a> {
 /// Rewrite a DIAL discovery message's `LOCATION` to a source-side description proxy, minting and
 /// registering the proxy if one isn't already live for this device and refreshing its grace either way.
 /// On a rewrite the datagram is written to `out` and `true` is returned. `false` means forward `payload`
-/// unchanged: it isn't a DIAL message, its `LOCATION` isn't a rewritable IPv4 `http` URL, the proxy cap
-/// was reached / a mint failed (device stays visible but unproxied), or the rewrite didn't fit `out`.
+/// unchanged: it isn't a DIAL message, its `LOCATION` isn't a rewritable IPv4 `http` URL or names an
+/// address that can never be a device's ([`is_never_a_peer`]; the reflector's suppression then drops
+/// the message), the proxy cap was reached / a mint failed (device stays visible but unproxied), or
+/// the rewrite didn't fit `out`.
 /// `out` is the caller's reused sink; a fixed-capacity one makes an over-long rewrite fail rather
 /// than truncate.
 pub(crate) fn rewrite_location(
@@ -68,6 +71,15 @@ pub(crate) fn rewrite_location(
         );
         return false;
     };
+    // Never-a-peer only, deliberately not link-local: a link-local device stays proxyable, since
+    // the proxy connects on-link from the target side.
+    if is_never_a_peer(IpAddr::V4(*location.endpoint.ip())) {
+        log::debug!(
+            "dial: LOCATION {} can never name a device; not minting a proxy",
+            location.endpoint
+        );
+        return false;
+    }
     // The grace is refreshed on every advertisement / search response, so a re-advertised device's
     // cached LOCATION keeps resolving for another max-age. Clamp it (MAX_DESC_GRACE): the value is
     // attacker-controlled and sets a proxy-slot eviction deadline.
@@ -353,6 +365,39 @@ mod tests {
             LOCATION: https://tv.local/dd.xml\r\n\r\n";
         assert!(rewrite_advert(&mut ctx, &mut reactor, bad).is_none());
         assert_eq!(ctx.proxy_count(), 0, "nothing is minted for either");
+    }
+
+    #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore = "needs a real kqueue")]
+    fn rewrite_location_refuses_a_never_a_peer_device() {
+        let mut reactor = Reactor::new().expect("reactor");
+        let mut ctx = DialContext::new();
+        for advert in [
+            &b"NOTIFY * HTTP/1.1\r\nNT: urn:dial-multiscreen-org:service:dial:1\r\n\
+                LOCATION: http://127.0.0.1:8008/dd.xml\r\n\r\n"[..],
+            &b"NOTIFY * HTTP/1.1\r\nNT: urn:dial-multiscreen-org:service:dial:1\r\n\
+                LOCATION: http://0.0.0.0:8008/dd.xml\r\n\r\n"[..],
+            &b"NOTIFY * HTTP/1.1\r\nNT: urn:dial-multiscreen-org:service:dial:1\r\n\
+                LOCATION: http://239.255.255.250:8008/dd.xml\r\n\r\n"[..],
+        ] {
+            assert!(rewrite_advert(&mut ctx, &mut reactor, advert).is_none());
+        }
+        assert_eq!(ctx.proxy_count(), 0, "no proxy is minted for a non-device");
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real poll backend")]
+    fn rewrite_location_proxies_a_link_local_device() {
+        let mut reactor = Reactor::new().expect("reactor");
+        let mut ctx = DialContext::new();
+        let advert = b"NOTIFY * HTTP/1.1\r\nNT: urn:dial-multiscreen-org:service:dial:1\r\n\
+            LOCATION: http://169.254.9.9:8008/dd.xml\r\n\r\n";
+        assert!(rewrite_advert(&mut ctx, &mut reactor, advert).is_some());
+        assert_eq!(
+            ctx.proxy_count(),
+            1,
+            "a link-local device is proxyable on-link"
+        );
     }
 
     #[test]

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{Filter, IpSet, MessageType, PacketDispatcher};
 use crate::net::mdns::{
-    MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT, MDNS_TTL, MdnsKind, advertises_only_link_local,
+    MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT, MDNS_TTL, MdnsKind, advertises_only_unreachable,
     classify,
 };
 
@@ -136,9 +136,10 @@ pub(crate) fn build(
                 MDNS_TTL,
                 response_verdict,
             )
-            // A response whose A/AAAA records are all link-local advertises endpoints the source
-            // side can never reach; queries carry no advertisement, so only this leg checks.
-            .with_suppress(advertises_only_link_local),
+            // A response whose A/AAAA records are all link-local or otherwise never a peer
+            // advertises endpoints the source side can never use; queries carry no advertisement,
+            // so only this leg checks.
+            .with_suppress(advertises_only_unreachable),
         ),
     );
     log::info!(

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -66,7 +66,8 @@ struct ResponseReflector {
     message_type: MessageType,
     ttl: u8,
     reply: Box<dyn ReplyRewrite>,
-    /// The link-local suppression check for untouched replies (see [`SearchReflector::suppress`]).
+    /// The unreachable-advertisement suppression check for untouched replies (see
+    /// [`SearchReflector::suppress`]).
     suppress: fn(&[u8]) -> bool,
 }
 
@@ -95,7 +96,7 @@ impl PacketHandler for ResponseReflector {
         // A rewritten reply is exempt; the why lives at `SimpleReflector::on_packet`'s gate.
         if rewritten.is_none() && (self.suppress)(packet.payload) {
             log::debug!(
-                "{}: suppressing response from {} to searcher {}: advertises only link-local \
+                "{}: suppressing response from {} to searcher {}: advertises only unreachable \
                  addresses",
                 self.name,
                 packet.source,
@@ -164,7 +165,7 @@ pub(crate) struct SearchReflector {
     window: fn(&[u8]) -> Duration,
     /// Mints a fresh reply transform per session (its own scratch, for a rewriting protocol).
     make_reply: Box<dyn Fn() -> Box<dyn ReplyRewrite>>,
-    /// The protocol's `advertises_only_link_local` check, handed to each session's
+    /// The protocol's `advertises_only_unreachable` check, handed to each session's
     /// [`ResponseReflector`]: an untouched reply it flags is dropped rather than reflected.
     suppress: fn(&[u8]) -> bool,
     sessions: LinearMap<SessionKey, Session>,

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -30,7 +30,8 @@ pub(crate) struct SimpleReflector {
     classify: fn(&[u8]) -> Verdict,
     /// Transforms the payload before re-emit; [`NoRewrite`] (the default) forwards verbatim.
     rewrite: Box<dyn ReplyRewrite>,
-    /// The link-local suppression check for payloads `rewrite` left untouched (default: none).
+    /// The unreachable-advertisement suppression check for payloads `rewrite` left untouched
+    /// (default: none).
     suppress: fn(&[u8]) -> bool,
 }
 
@@ -63,7 +64,7 @@ impl SimpleReflector {
     }
 
     /// Drop (rather than re-emit) any payload `suppress` flags: the protocol's
-    /// `advertises_only_link_local` check.
+    /// `advertises_only_unreachable` check.
     pub(crate) fn with_suppress(mut self, suppress: fn(&[u8]) -> bool) -> Self {
         self.suppress = suppress;
         self
@@ -114,7 +115,7 @@ impl PacketHandler for SimpleReflector {
         // Only an untouched payload still advertises the far link's addresses.
         if rewritten.is_none() && (self.suppress)(packet.payload) {
             log::debug!(
-                "{}: suppressing {} from {}: advertises only link-local addresses",
+                "{}: suppressing {} from {}: advertises only unreachable addresses",
                 self.name,
                 self.kind,
                 packet.source

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -16,7 +16,7 @@ use crate::interface::InterfaceAddresses;
 use crate::net::MAX_UDP_PAYLOAD_LEN;
 use crate::net::ssdp::{
     MSEARCH_MX_DEFAULT, SSDP_GROUP_V4, SSDP_GROUP_V6_LINK_LOCAL, SSDP_GROUP_V6_SITE_LOCAL,
-    SSDP_PORT, SSDP_TTL, SsdpKind, advertises_only_link_local, classify, parse_msearch_mx,
+    SSDP_PORT, SSDP_TTL, SsdpKind, advertises_only_unreachable, classify, parse_msearch_mx,
 };
 use crate::net::uninit_buf::UninitBuf;
 use crate::reactor::Reactor;
@@ -185,8 +185,8 @@ pub(crate) fn build(
     let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();
     // target -> source: advertisements (a stateless re-emit), optionally filtered to the configured
     // device's MAC. With `dial`, the reflected `LOCATION` is rewritten to a source-side proxy.
-    // A NOTIFY whose LOCATION names a link-local address advertises an endpoint the source side
-    // can never reach.
+    // A NOTIFY whose LOCATION names a link-local or never-a-peer address advertises an endpoint
+    // the source side can never use.
     let advertisement = SimpleReflector::new(
         source,
         "SSDP",
@@ -195,7 +195,7 @@ pub(crate) fn build(
         SSDP_TTL,
         advertisement_verdict,
     )
-    .with_suppress(advertises_only_link_local);
+    .with_suppress(advertises_only_unreachable);
     let advertisement = if ssdp.dial {
         advertisement.with_rewrite(Box::new(DialRewrite::new(target)))
     } else {
@@ -240,7 +240,7 @@ pub(crate) fn build(
             search_window,
             make_reply,
             // Each session's 200 OK reply is gated the same way as the NOTIFY leg.
-            advertises_only_link_local,
+            advertises_only_unreachable,
         )),
     );
     log::info!(

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use crate::config::{AddressFamily, Reflector};
 use crate::dispatch::{Filter, IpSet, MessageType, PacketDispatcher};
 use crate::net::wsd::{
-    WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT, WSD_TTL, WsdKind, advertises_only_link_local, classify,
+    WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT, WSD_TTL, WsdKind, advertises_only_unreachable, classify,
 };
 
 use super::{
@@ -121,9 +121,9 @@ pub(crate) fn build(
                 WSD_TTL,
                 announcement_verdict,
             )
-            // A Hello whose XAddrs are all link-local advertises endpoints the source side can
-            // never reach.
-            .with_suppress(advertises_only_link_local),
+            // A Hello whose XAddrs are all link-local or otherwise never a peer advertises
+            // endpoints the source side can never use.
+            .with_suppress(advertises_only_unreachable),
         ),
     );
     // source -> target: Probe/Resolve searches (unfiltered, any source client may search); each
@@ -148,7 +148,7 @@ pub(crate) fn build(
             window,
             Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
             // Each session's ProbeMatches / ResolveMatches reply is gated the same way.
-            advertises_only_link_local,
+            advertises_only_unreachable,
         )),
     );
     log::info!(


### PR DESCRIPTION
Extends the link-local advertisement suppression to addresses that can never name a device: loopback, unspecified, multicast, limited broadcast (a v4-mapped IPv6 address is judged by its IPv4 rules). The DIAL proxy additionally refuses to mint a proxy for such a LOCATION and to adopt such an Application-URL REST endpoint. Link-local stays proxyable on the DIAL side: the proxy connects on-link from the target side.

The motivating gap: on FreeBSD the RTM_GET egress check resolves 0.0.0.0 via the default route, so when the target interface carries it, a LOCATION naming 0.0.0.0 passed the check and the kernel treats the connect as "this host". Loopback was already blocked by egress confinement on every OS, but only after minting a junk proxy slot; now neither is minted nor reflected.

Testing: 505 unit tests (new: the predicate incl. v4-mapped forms, per-protocol suppression of loopback/unspecified/multicast, DIAL mint/adopt rejection, and the deliberate link-local acceptance pinned so it can't regress), clippy/rustdoc/fmt clean on macOS and Linux, mandoc lint on the man page.