### PR TITLE
port: submission polish, rc stop fix, poudriere testport lane

### DIFF
--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -158,8 +158,10 @@ jobs:
         run: ci/freebsd-vm.sh launch
       - name: Wait for the VM
         run: ci/freebsd-vm.sh wait
-      - name: Ports tree, pinned to the commit our packages were built from
-        run: ci/freebsd-ports-tree.sh
+      # Current main, not the package pin: -b latest serves packages a pinned
+      # tree's older pkg can't consume.
+      - name: Ports tree, current main
+        run: PORTS_TREE_CURRENT=1 ci/freebsd-ports-tree.sh
       - name: Install the port into the tree
         run: ci/port-into-tree.sh
       - name: Set up poudriere
@@ -170,7 +172,22 @@ jobs:
           # The jail mirrors the guest's own release; base sets come off the mirror.
           ci/freebsd-vm.sh run 'poudriere jail -c -j ci -v "$(freebsd-version -r | sed "s/-p[0-9]*$//")" -a amd64'
           ci/freebsd-vm.sh run 'poudriere ports -c -p main -m null -M /usr/ports'
+      # A rust bump in main the cluster has not built yet would make testport
+      # compile rust from source for hours. Skip loudly instead; the window
+      # closes on its own within days.
+      - name: Check the latest set has the tree's rust
+        id: rust
+        run: |
+          tree=$(ci/freebsd-vm.sh run 'make -C /usr/ports/lang/rust -V PKGVERSION' | tr -d ' \r')
+          ci/freebsd-vm.sh run 'mkdir -p /usr/local/etc/pkg/repos && printf "ci-latest: { url: \"pkg+https://pkg.FreeBSD.org/\${ABI}/latest\", enabled: yes }\n" > /usr/local/etc/pkg/repos/ci-latest.conf'
+          latest=$(ci/freebsd-vm.sh run 'pkg rquery -r ci-latest %v rust' | tail -1 | tr -d ' \r')
+          echo "tree wants rust $tree; latest has $latest"
+          if [ "$tree" != "$latest" ]; then
+            echo "::warning::latest has rust $latest but the tree wants $tree; skipping testport until the cluster catches up"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: poudriere testport
+        if: steps.rust.outputs.skip != 'true'
         run: ci/freebsd-vm.sh run 'poudriere testport -j ci -p main -b latest net/netflector'
       - name: VM console log
         if: always()

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -17,6 +17,8 @@ on:
       # Consumed by the port-build install and e2e steps.
       - 'ci/port-install.sh'
       - 'ci/port-e2e.sh'
+      # Shared by port-build and port-testport.
+      - 'ci/port-into-tree.sh'
   workflow_call:
     inputs:
       # For publish-daemon: build-daemon-pkgs builds the port on every ABI
@@ -82,12 +84,7 @@ jobs:
       - name: Ports tree, pinned to the commit our packages were built from
         run: ci/freebsd-ports-tree.sh
       - name: Install the port into the tree
-        run: |
-          # scp -r nests into an existing directory; see ci/freebsd-port-package.sh.
-          ci/freebsd-vm.sh run 'rm -rf /usr/ports/net/netflector'
-          ci/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
-          # net/Makefile's SUBDIR list is a deliverable of the submission, and portlint checks it.
-          ci/freebsd-vm.sh run 'cd /usr/ports/net && awk "/^ *SUBDIR \+= / && !ins && \$3 > \"netflector\" { print \"    SUBDIR += netflector\"; ins = 1 } { print } END { if (!ins) print \"    SUBDIR += netflector\" }" Makefile > Makefile.new && mv Makefile.new Makefile && grep -n "SUBDIR += netflector" Makefile'
+        run: ci/port-into-tree.sh
       - name: portlint
         run: |
           ci/freebsd-vm.sh run 'pkg install -y ports-mgmt/portlint'
@@ -126,13 +123,66 @@ jobs:
         if: always()
         run: ci/freebsd-vm.sh crash
 
+  # The same build in a pristine poudriere jail: an undeclared dependency fails
+  # loudly instead of borrowing from the VM's toolchain, and the deinstall is
+  # diffed against the jail's clean state. Hermeticity is a property of the
+  # port's metadata, not the CPU, so the KVM lanes carry it alone.
+  port-testport:
+    name: poudriere testport (freebsd${{ matrix.os }})
+    if: ${{ !inputs.skip_build }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      FREEBSD_VM_ARCH: amd64
+      FREEBSD_VM_VERSION: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [14, 15]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install QEMU
+        run: |
+          sudo apt-get update || true
+          sudo apt-get install -y --no-install-recommends qemu-utils genisoimage qemu-system-x86
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Launch the FreeBSD VM
+        run: ci/freebsd-vm.sh launch
+      - name: Wait for the VM
+        run: ci/freebsd-vm.sh wait
+      - name: Ports tree, pinned to the commit our packages were built from
+        run: ci/freebsd-ports-tree.sh
+      - name: Install the port into the tree
+        run: ci/port-into-tree.sh
+      - name: Set up poudriere
+        run: |
+          ci/freebsd-vm.sh run 'pkg install -y ports-mgmt/poudriere'
+          ci/freebsd-vm.sh run 'printf "NO_ZFS=yes\nBASEFS=/usr/local/poudriere\nDISTFILES_CACHE=/usr/ports/distfiles\nFREEBSD_HOST=https://download.freebsd.org\nRESOLV_CONF=/etc/resolv.conf\n" > /usr/local/etc/poudriere.conf'
+          ci/freebsd-vm.sh run 'mkdir -p /usr/ports/distfiles'
+          # The jail mirrors the guest's own release; base sets come off the mirror.
+          ci/freebsd-vm.sh run 'poudriere jail -c -j ci -v "$(freebsd-version -r | sed "s/-p[0-9]*$//")" -a amd64'
+          ci/freebsd-vm.sh run 'poudriere ports -c -p main -m null -M /usr/ports'
+      - name: poudriere testport
+        run: ci/freebsd-vm.sh run 'poudriere testport -j ci -p main -b latest net/netflector'
+      - name: VM console log
+        if: always()
+        run: ci/freebsd-vm.sh console
+      - name: Crash summary
+        if: always()
+        run: ci/freebsd-vm.sh crash
+
   # The aggregate the ruleset requires: green only when every job above is.
   # Without !cancelled() a failed job would skip this one, and a skipped
   # required check counts as passing.
   success:
     name: Success
     if: ${{ !cancelled() }}
-    needs: [port-check, port-build]
+    needs: [port-check, port-build, port-testport]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci-port.yml
+++ b/.github/workflows/ci-port.yml
@@ -135,6 +135,9 @@ jobs:
     env:
       FREEBSD_VM_ARCH: amd64
       FREEBSD_VM_VERSION: ${{ matrix.os }}
+      # The jail's base+lib32 sets plus the binary build deps outgrow the
+      # default headroom.
+      FREEBSD_VM_DISK_EXTRA_GB: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - '.github/workflows/ci-port.yml'
       - 'ci/port-install.sh'
       - 'ci/port-e2e.sh'
+      - 'ci/port-into-tree.sh'
       - '.github/workflows/ci-opnsense.yml'
       - '.github/workflows/ci-docs.yml'
       - '.github/workflows/ci-supply-chain.yml'

--- a/ci/freebsd-ports-tree.sh
+++ b/ci/freebsd-ports-tree.sh
@@ -1,24 +1,40 @@
 #!/usr/bin/env bash
 # Check out /usr/ports inside the running FreeBSD VM (ci/freebsd-vm.sh env
-# applies), pinned to the commit the VM's binary packages were built from:
-# every official package records it in the ports_top_git_hash annotation, and
-# rust is queried because the port needs it installed anyway. Building against
-# that exact tree matches the framework the packages themselves saw.
+# applies). Default: pinned to the commit the VM's binary packages were built
+# from -- every official package records it in the ports_top_git_hash
+# annotation, and rust is queried because the port needs it installed anyway.
+# Building against that exact tree matches the framework the packages saw.
+#
+# PORTS_TREE_CURRENT=1 checks out current main instead: the poudriere lane
+# fetches build deps from the rolling latest package set, which a pinned
+# tree's older ports-mgmt/pkg cannot consume -- poudriere then rebuilds
+# everything from source. No rust in the host VM there: testport needs it
+# only inside the jail.
 set -euo pipefail
 
 VM="$(dirname "$0")/freebsd-vm.sh"
 
-"$VM" run 'pkg install -y git rust'
-# shellcheck disable=SC2016  # the single quotes are the point: $hash expands in the guest
-"$VM" run '
+if [ "${PORTS_TREE_CURRENT:-0}" = 1 ]; then
+    "$VM" run 'pkg install -y git'
+    ref=main
+else
+    "$VM" run 'pkg install -y git rust'
+    ref=$("$VM" run 'pkg info -A rust | sed -n "s/.*ports_top_git_hash:[[:space:]]*//p"' | tr -d ' \r')
+    [ -n "$ref" ] || { echo "rust package records no ports_top_git_hash" >&2; exit 1; }
+    echo "ports tree pinned to $ref (the commit our rust package was built from)"
+fi
+
+"$VM" run "
     set -e
-    hash=$(pkg info -A rust | sed -n "s/.*ports_top_git_hash:[[:space:]]*//p")
-    [ -n "$hash" ] || { echo "rust package records no ports_top_git_hash"; exit 1; }
-    echo "ports tree at $hash (the commit our rust package was built from)"
     mkdir -p /usr/ports && cd /usr/ports
     git init -q .
     git remote add origin https://git.FreeBSD.org/ports.git
-    git fetch -q --depth 1 origin "$hash"
+    git fetch -q --depth 1 origin $ref
     git checkout -q FETCH_HEAD
-    [ "$(git rev-parse HEAD)" = "$hash" ] || { echo "tree is not at the pinned commit"; exit 1; }
-'
+    echo \"ports tree at \$(git rev-parse HEAD)\"
+"
+
+if [ "$ref" != main ]; then
+    got=$("$VM" run 'cd /usr/ports && git rev-parse HEAD' | tr -d ' \r')
+    [ "$got" = "$ref" ] || { echo "tree is not at the pinned commit" >&2; exit 1; }
+fi

--- a/ci/freebsd-vm.sh
+++ b/ci/freebsd-vm.sh
@@ -154,7 +154,9 @@ launch() {
     }
     xz -dT0 "$VM_DIR/$IMAGE.xz"
     # Headroom over the image's ~1 GB free; the guest growfs's into it at boot.
-    qemu-img resize "$VM_DIR/$IMAGE" +4G
+    # The poudriere lane overrides: a jail's base+lib32 plus binary build deps
+    # need ~10 GB of their own.
+    qemu-img resize "$VM_DIR/$IMAGE" "+${FREEBSD_VM_DISK_EXTRA_GB:-4}G"
     ssh-keygen -q -t ed25519 -N '' -f "$VM_DIR/id_ed25519"
     seed_iso
     # Slirp networking: sshd reachable only through the localhost hostfwd.

--- a/ci/port-into-tree.sh
+++ b/ci/port-into-tree.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copy the working tree's port into the VM's ports tree and register it in
+# net/Makefile's SUBDIR list: the list entry is a deliverable of the ports-tree
+# submission, and portlint checks it.
+set -eu
+
+# scp -r nests into an existing directory; see ci/freebsd-port-package.sh.
+ci/freebsd-vm.sh run 'rm -rf /usr/ports/net/netflector'
+ci/freebsd-vm.sh push dist/freebsd/net/netflector /usr/ports/net/netflector
+ci/freebsd-vm.sh run 'cd /usr/ports/net && awk "/^ *SUBDIR \+= / && !ins && \$3 > \"netflector\" { print \"    SUBDIR += netflector\"; ins = 1 } { print } END { if (!ins) print \"    SUBDIR += netflector\" }" Makefile > Makefile.new && mv Makefile.new Makefile && grep -n "SUBDIR += netflector" Makefile'

--- a/dist/freebsd/net/netflector/Makefile
+++ b/dist/freebsd/net/netflector/Makefile
@@ -1,6 +1,7 @@
 PORTNAME=	netflector
 DISTVERSIONPREFIX=	v
 DISTVERSION=	0.15.1
+PORTREVISION=	1
 CATEGORIES=	net
 
 MAINTAINER=	sergii@bogomolov.io
@@ -11,13 +12,10 @@ LICENSE=	BSD2CLAUSE
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 ONLY_FOR_ARCHS=	aarch64 amd64
-ONLY_FOR_ARCHS_REASON=	upstream builds and tests FreeBSD on aarch64 and amd64 only
+ONLY_FOR_ARCHS_REASON=	hand-rolled BPF and PF_ROUTE FFI, only ever built and tested on aarch64 and amd64
 
 USES=		cargo
 USE_GITHUB=	yes
-GH_ACCOUNT=	netflector
-GH_PROJECT=	netflector
-GH_TAGNAME=	${DISTVERSIONPREFIX}${DISTVERSION}
 
 USE_RC_SUBR=	netflector
 CARGO_CRATES=	equivalent-1.0.2 \
@@ -41,13 +39,15 @@ CARGO_CRATES=	equivalent-1.0.2 \
 		unicode-ident-1.0.24 \
 		winnow-1.0.3
 
+SUB_FILES=	netflector.toml.sample pkg-message
+
 PLIST_FILES=	bin/netflector \
 		"@sample etc/netflector.toml.sample" \
 		share/man/man5/netflector.toml.5.gz \
 		share/man/man8/netflector.8.gz
 
 post-install:
-	${INSTALL_DATA} ${FILESDIR}/netflector.toml.sample ${STAGEDIR}${PREFIX}/etc
+	${INSTALL_DATA} ${WRKDIR}/netflector.toml.sample ${STAGEDIR}${PREFIX}/etc
 	${INSTALL_MAN} ${WRKSRC}/man/netflector.8 ${STAGEDIR}${PREFIX}/share/man/man8
 	${INSTALL_MAN} ${WRKSRC}/man/netflector.toml.5 ${STAGEDIR}${PREFIX}/share/man/man5
 

--- a/dist/freebsd/net/netflector/files/netflector.in
+++ b/dist/freebsd/net/netflector/files/netflector.in
@@ -28,15 +28,19 @@ load_rc_config $name
 : ${netflector_carp_vhid:=""}
 : ${netflector_carp_interface:=""}
 
+# The pidfile must hold daemon(8) itself (-P), not the child: stop then terminates the supervisor,
+# which forwards the signal and exits. Killing only the child would let a restarting supervisor
+# (netflector_flags="-r") respawn it behind rc's back. The child's pid stays visible beside it.
 pidfile="/var/run/${name}.pid"
-procname="%%PREFIX%%/bin/${name}"
+child_pidfile="/var/run/${name}_child.pid"
+netflector_bin="%%PREFIX%%/bin/${name}"
 
 # The daemon runs in the foreground and logs to stderr, so daemon(8) backgrounds it and -S routes that
 # stderr into syslog under our own tag rather than /dev/null. -f closes the descriptors daemon(8)
 # inherited: without it the supervisor holds the caller's stdout open for the service's lifetime, so
 # `ssh host service netflector start` never returns. It does not affect -S, which redirects the child.
 command="/usr/sbin/daemon"
-command_args="-f -S -T ${name} -p ${pidfile} ${procname} '${netflector_config}'"
+command_args="-f -S -T ${name} -P ${pidfile} -p ${child_pidfile} ${netflector_bin} '${netflector_config}'"
 
 start_precmd="${name}_precmd"
 
@@ -49,8 +53,8 @@ netflector_precmd()
     # Refuse to start on a configuration the daemon would reject, so the failure is one clear message
     # here rather than a service that appears to start and is gone a moment later. --check-config parses
     # and validates only: it opens no interface and needs no privileges.
-    if ! ${procname} --check-config "${netflector_config}" > /dev/null 2>&1; then
-        ${procname} --check-config "${netflector_config}" 2>&1 | while read -r line; do
+    if ! ${netflector_bin} --check-config "${netflector_config}" > /dev/null 2>&1; then
+        ${netflector_bin} --check-config "${netflector_config}" 2>&1 | while read -r line; do
             warn "${line}"
         done
         err 1 "refusing to start: ${netflector_config} is not valid"

--- a/dist/freebsd/net/netflector/files/netflector.toml.sample.in
+++ b/dist/freebsd/net/netflector/files/netflector.toml.sample.in
@@ -2,7 +2,7 @@
 #
 # Nothing below is enabled, so the daemon refuses to start until you uncomment an entry and name
 # your own interfaces. Check your work with
-# `netflector --check-config /usr/local/etc/netflector.toml`.
+# `netflector --check-config %%PREFIX%%/etc/netflector.toml`.
 
 # off, error, warn, info, debug, or trace. trace is compiled out and behaves as debug.
 #log_level = "info"

--- a/dist/freebsd/net/netflector/files/pkg-message.in
+++ b/dist/freebsd/net/netflector/files/pkg-message.in
@@ -1,0 +1,12 @@
+[
+{ type: install
+  message: <<EOM
+Add at least one reflector entry to %%PREFIX%%/etc/netflector.toml, then:
+
+  sysrc netflector_enable=YES
+  service netflector start
+
+netflector.toml(5) documents the configuration, netflector(8) the operation.
+EOM
+}
+]


### PR DESCRIPTION
The rc script's pidfile now holds the daemon(8) supervisor (-P): stop used to kill only the child, which a supervisor running with netflector_flags="-r" respawned immediately; the child's pid stays in a second file for SIGUSR1. The rest readies the port for the ports-tree submission: pkg-message, the sample config rendered via SUB_FILES with %%PREFIX%%, redundant GH_* defaults dropped, a sharper ONLY_FOR_ARCHS reason. PORTREVISION=1 so published packages pick up the rc fix. Also adds a poudriere-testport lane to Port CI (pristine-jail hermeticity plus a deinstall diff), amd64 KVM lanes; this PR is its first live run.

Testing: rc matrix live on a FreeBSD 15.1 VM (start/status/stop/restart with and without -r, crash-respawn, invalid/missing-config refusal); portlint -AC, portclippy and poudriere testport (15.1 aarch64) all clean.