### PR TITLE
toolchain: rust 1.98.0, drop the freebsd-arm64 nightly bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
   # ci/freebsd-sysroot.sh), boot the official FreeBSD image under QEMU (ci/freebsd-vm.sh), and run every
   # test binary in it as root through cargo's target runner (ci/freebsd-ssh-runner.sh) -- privileged
   # tests run instead of skipping. amd64 rides KVM; arm64 has no KVM on any GitHub runner, so its guest
-  # runs under TCG -- compilation stays native-speed on the runner, only test execution is emulated --
-  # and builds with the pinned nightly from ci/freebsd-nightly.env until stable 1.98 ships the target's std.
+  # runs under TCG -- compilation stays native-speed on the runner, only test execution is emulated.
   # One VM per lane, the same debug/release split as the native test lanes; the release lanes test the
   # shipped +crt-static configuration (kept off host proc-macros by the target-scoped rustflags).
   # Everything fetched is FreeBSD-project-official and hash-pinned.
@@ -104,23 +103,12 @@ jobs:
       # Launch first so the VM boots while the sysroot downloads and the build runs.
       - name: Launch the FreeBSD VM
         run: ci/freebsd-vm.sh launch
-      # aarch64-unknown-freebsd has no stable dist until 1.98: those lanes install the pinned
-      # dated nightly from ci/freebsd-nightly.env instead of the rust-toolchain.toml stable, and every
-      # later rustc/cargo call picks it up through the FREEBSD_TOOLCHAIN selector set here.
       - name: Add the Rust target
-        run: |
-          . ci/freebsd-nightly.env
-          if [ '${{ matrix.arch.name }}' = arm64 ]; then
-            rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal
-            rustup target add --toolchain "nightly-${RUST_NIGHTLY}" aarch64-unknown-freebsd
-            echo "FREEBSD_TOOLCHAIN=+nightly-${RUST_NIGHTLY}" >> "$GITHUB_ENV"
-          else
-            rustup target add x86_64-unknown-freebsd
-          fi
+        run: rustup target add ${{ matrix.arch.triple }}
       - name: FreeBSD link sysroot
         run: ci/freebsd-sysroot.sh
       - name: Show toolchain
-        run: rustc ${FREEBSD_TOOLCHAIN:-} -V && cargo ${FREEBSD_TOOLCHAIN:-} -V
+        run: rustc -V && cargo -V
       - name: Wait for the VM
         run: ci/freebsd-vm.sh wait
       - name: cargo test
@@ -130,7 +118,7 @@ jobs:
           export "${prefix}_LINKER=$HOME/freebsd-sysroot/bin/freebsd-clang"
           export "${prefix}_RUNNER=$PWD/ci/freebsd-ssh-runner.sh"
           export "${prefix}_RUSTFLAGS=${{ matrix.profile.rustflags }}"
-          cargo ${FREEBSD_TOOLCHAIN:-} test --locked --target "$triple" ${{ matrix.profile.flags }}
+          cargo test --locked --target "$triple" ${{ matrix.profile.flags }}
       - name: VM console log
         if: always()
         run: ci/freebsd-vm.sh console
@@ -200,30 +188,19 @@ jobs:
       # Launch first so the VM boots while the sysroot downloads and the build runs.
       - name: Launch the FreeBSD VM
         run: ci/freebsd-vm.sh launch
-      # aarch64-unknown-freebsd has no stable dist until 1.98: that lane installs the pinned
-      # dated nightly from ci/freebsd-nightly.env instead of the rust-toolchain.toml stable, and every
-      # later cargo call picks it up through the FREEBSD_TOOLCHAIN selector set here.
       - name: Add the Rust target
-        run: |
-          . ci/freebsd-nightly.env
-          if [ '${{ matrix.arch.name }}' = arm64 ]; then
-            rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal
-            rustup target add --toolchain "nightly-${RUST_NIGHTLY}" aarch64-unknown-freebsd
-            echo "FREEBSD_TOOLCHAIN=+nightly-${RUST_NIGHTLY}" >> "$GITHUB_ENV"
-          else
-            rustup target add x86_64-unknown-freebsd
-          fi
+        run: rustup target add ${{ matrix.arch.triple }}
       - name: FreeBSD link sysroot
         run: ci/freebsd-sysroot.sh
       - name: Show toolchain
-        run: rustc ${FREEBSD_TOOLCHAIN:-} -V && cargo ${FREEBSD_TOOLCHAIN:-} -V
+        run: rustc -V && cargo -V
       - name: Build the release binary
         run: |
           triple='${{ matrix.arch.triple }}'
           prefix="CARGO_TARGET_$(echo "$triple" | tr 'a-z-' 'A-Z_')"
           export "${prefix}_LINKER=$HOME/freebsd-sysroot/bin/freebsd-clang"
           export "${prefix}_RUSTFLAGS=${{ matrix.linkage.rustflags }}"
-          cargo ${FREEBSD_TOOLCHAIN:-} build --release --locked --target "$triple"
+          cargo build --release --locked --target "$triple"
       - name: Wait for the VM
         run: ci/freebsd-vm.sh wait
       - name: Install python3 in the VM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,7 @@ jobs:
   # arm64 are static musl on their native runners (the self-contained default, gcc-driven link),
   # macOS native dynamic (no static libSystem). armv7/armv5 have no native runner, so they
   # cross-compile on the amd64 runner with lld; both FreeBSD arches likewise (clang+lld against a
-  # base.txz sysroot -- the exact configurations CI's freebsd lanes build AND run on every PR;
-  # freebsd-arm64 on the pinned nightly from ci/freebsd-nightly.env until stable 1.98 ships its std).
+  # base.txz sysroot -- the exact configurations CI's freebsd lanes build AND run on every PR).
   binaries:
     name: Binary (${{ matrix.variant }})
     needs: verify-ci
@@ -95,18 +94,8 @@ jobs:
           sudo apt-get update || true
           sudo apt-get install -y --no-install-recommends clang lld
 
-      # aarch64-unknown-freebsd has no stable dist until 1.98: that row installs the pinned dated
-      # nightly from ci/freebsd-nightly.env, and the build picks it up via the FREEBSD_TOOLCHAIN selector.
       - name: Add the Rust target
-        run: |
-          if [ '${{ matrix.target }}' = aarch64-unknown-freebsd ]; then
-            . ci/freebsd-nightly.env
-            rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal
-            rustup target add --toolchain "nightly-${RUST_NIGHTLY}" aarch64-unknown-freebsd
-            echo "FREEBSD_TOOLCHAIN=+nightly-${RUST_NIGHTLY}" >> "$GITHUB_ENV"
-          else
-            rustup target add ${{ matrix.target }}
-          fi
+        run: rustup target add ${{ matrix.target }}
 
       # Link the arm32 musl targets with lld (cross-capable, unlike the host gcc) -- the same config
       # the Dockerfile writes for its cross layers. cfg(target_env = "musl") leaves host
@@ -141,10 +130,10 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Show toolchain
-        run: rustc ${FREEBSD_TOOLCHAIN:-} -V && cargo ${FREEBSD_TOOLCHAIN:-} -V
+        run: rustc -V && cargo -V
 
       - name: Build release binary
-        run: cargo ${FREEBSD_TOOLCHAIN:-} build --release --locked --target ${{ matrix.target }}
+        run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Stage binary
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # compiler drift off rust-toolchain.toml while the diff shows only a new hash. Keep this version equal
 # to rust-toolchain.toml's channel. Referenced by both the builder and the valgrind runtime below so
 # they stay in lockstep.
-ARG RUST_IMAGE=docker.io/library/rust:1.97.1-slim@sha256:8e8cf8f7fd54a2d23d5a743b3a03f56e26b6c774276c33fa0595111704ebb15c
+ARG RUST_IMAGE=docker.io/library/rust:1.98.0-slim@sha256:cc0448b41c3b7b7fea44f5dc50eacba729a56db365b65b7bd5e8a82d5b3db078
 FROM --platform=$BUILDPLATFORM ${RUST_IMAGE} AS builder
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/ci/freebsd-nightly.env
+++ b/ci/freebsd-nightly.env
@@ -1,6 +1,0 @@
-# aarch64-unknown-freebsd has no stable rust dist until 1.98, so the freebsd-arm64
-# lanes (every FreeBSD version) build with this pinned dated nightly (rustup verifies
-# it against the immutable channel manifest). Hand-maintained; delete the file and its
-# consumers once rust-toolchain.toml reaches 1.98 -- the lanes then build with the
-# pinned stable like amd64.
-RUST_NIGHTLY=2026-07-10

--- a/ci/freebsd-pin.sh
+++ b/ci/freebsd-pin.sh
@@ -4,9 +4,7 @@
 # sysroots), fetched from the official CHECKSUM.SHA512 / MANIFEST files. With no
 # argument it refreshes every pin file at its current release -- the way to
 # complete a Renovate bump PR, which can only edit RELEASE and leaves the hashes
-# stale (the checksum gates keep CI red until this runs). The freebsd-arm64
-# nightly bridge lives separately in ci/freebsd-nightly.env; this script does
-# not touch it.
+# stale (the checksum gates keep CI red until this runs).
 #
 #   ci/freebsd-pin.sh                 # refresh the hashes of every pinned release
 #   ci/freebsd-pin.sh 14.5            # move the 14 pin to 14.5 (the file follows the major)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,8 +2,6 @@
 # Pinned (not "stable") so every environment -- host, the Docker builds, and the rustup CI lanes --
 # compiles with one known rustc, and a new stable can't silently change codegen or fail a release
 # build on a fresh warn-by-default lint. Renovate's rust-toolchain manager bumps this via a CI-gated
-# PR; the Dockerfile's RUST_IMAGE tag names the same version and has to move with it. (The
-# freebsd-arm64 lanes build with the pinned nightly from ci/freebsd-nightly.env instead, until stable
-# 1.98 ships aarch64-unknown-freebsd std.)
-channel = "1.97.1"
+# PR; the Dockerfile's RUST_IMAGE tag names the same version and has to move with it.
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]

--- a/src/net/checksum.rs
+++ b/src/net/checksum.rs
@@ -75,12 +75,12 @@ fn udp_checksum(pseudo: &[u8], udp: &[u8]) -> u16 {
 /// `seed`; a trailing odd byte is treated as the high byte of a final word.
 /// `seed` lets callers chain segments (pseudo-header, then datagram).
 fn sum_words(data: &[u8], seed: u32) -> u32 {
-    let mut words = data.chunks_exact(2);
+    let (words, tail) = data.as_chunks::<2>();
     let mut sum = seed;
-    for word in &mut words {
-        sum += u32::from(u16::from_be_bytes([word[0], word[1]]));
+    for word in words {
+        sum += u32::from(u16::from_be_bytes(*word));
     }
-    if let [tail] = words.remainder() {
+    if let [tail] = tail {
         sum += u32::from(*tail) << 8;
     }
     sum

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -105,15 +105,14 @@ fn magic_packet_mac(payload: &[u8]) -> Option<MacAddr> {
     if magic[..PREFIX_LEN] != [0xff; PREFIX_LEN] {
         return None;
     }
-    let mac = &magic[PREFIX_LEN..PREFIX_LEN + MAC_LEN];
-    // The other 15 repetitions must all equal the first.
-    if !magic[PREFIX_LEN + MAC_LEN..]
-        .chunks_exact(MAC_LEN)
-        .all(|rep| rep == mac)
-    {
+    // The other 15 repetitions must all equal the first; the prefix length leaves no remainder.
+    let ([mac, repeats @ ..], []) = magic[PREFIX_LEN..].as_chunks::<MAC_LEN>() else {
+        return None;
+    };
+    if repeats.iter().any(|rep| rep != mac) {
         return None;
     }
-    Some(MacAddr::from(<[u8; MAC_LEN]>::try_from(mac).ok()?))
+    Some(MacAddr::from(*mac))
 }
 
 /// Whether the optional `targets` allow-set admits a wake for `mac`.


### PR DESCRIPTION
Moves the pin (and the Dockerfile image, at the current digest) to 1.98.0. The only breakage was clippy 1.98's new chunks_exact_to_as_chunks lint at two sites; both move to as_chunks, which hands the checksum and the WoL MAC check proper arrays instead of slices. Stable 1.98 ships aarch64-unknown-freebsd std, so the dated-nightly bridge (ci/freebsd-nightly.env and the FREEBSD_TOOLCHAIN selector in ci.yml and release.yml) is gone; every FreeBSD lane and the release asset now build with the pinned stable like amd64.

Testing: host 506 tests + clippy + rustdoc, Linux on the 1.98 image 504 tests + clippy, clippy for both FreeBSD targets on stable 1.98, and an aarch64-unknown-freebsd release cross-build on stable (std fetched by rustup) as the proof for the bridge removal. The real freebsd-arm64 lanes and the Docker e2e image build run on this PR.