### PR TITLE
port: cite the kqueue udata assert in ONLY_FOR_ARCHS_REASON

### DIFF
--- a/dist/freebsd/net/netflector/Makefile
+++ b/dist/freebsd/net/netflector/Makefile
@@ -12,7 +12,7 @@ LICENSE=	BSD2CLAUSE
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 ONLY_FOR_ARCHS=	aarch64 amd64
-ONLY_FOR_ARCHS_REASON=	hand-rolled BPF and PF_ROUTE FFI, only ever built and tested on aarch64 and amd64
+ONLY_FOR_ARCHS_REASON=	packs a 64-bit reactor key into kevent's pointer-sized udata (compile-time assert); untested beyond aarch64 and amd64
 
 USES=		cargo
 USE_GITHUB=	yes


### PR DESCRIPTION
The old reason only said other arches are untested. The hard half is architectural: the reactor key rides in kevent's pointer-sized udata, and a compile-time assert in src/reactor/poll/kqueue.rs refuses sub-64-bit pointers.