### PR TITLE
dispatch: drop our own re-emits handed back by the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,9 +464,11 @@ Per message type: `reflected` (re-emitted on the other interface), `skipped` (ri
 direction for this leg - normal, this is the loop prevention working), `dropped` (should have been
 reflected but was not: a send error, a resource cap, or the advertisement suppression) and `stalled`
 (the egress had no source address of the packet's family yet). Interface-wide: `filtered`
-(unrecognized traffic on the group), `oversized` (received frames too large to forward) and
-`recoveries` (the interface was destroyed and recreated, and its capture re-bound). `netflector(8)`
-carries the full definitions.
+(unrecognized traffic on the group), `echoed` (netflector's own re-emits handed back by the link,
+as a hairpin bridge port or an access point re-broadcasting a station's multicast does; dropped
+before routing), `oversized` (received frames too large to forward) and `recoveries` (the interface
+was destroyed and recreated, and its capture re-bound). `netflector(8)` carries the full
+definitions.
 
 ## Developing
 

--- a/e2e/config-dial-mirrored.toml
+++ b/e2e/config-dial-mirrored.toml
@@ -1,0 +1,18 @@
+log_level = "debug"
+counters_interval_secs = 1
+
+# Both directions of one DIAL pair, the entry pair a `bidirectional = true` entry will expand to.
+# Each interface then carries a same-direction advertisement handler, so netflector's own re-emits,
+# handed back by the Docker harness's hairpin bridges, would relay again without the dispatcher's
+# echo drop.
+[reflectors.dial-tv]
+source_if = "nf_source"
+target_if = "nf_target"
+ssdp = true
+dial = true
+
+[reflectors.dial-tv-reverse]
+source_if = "nf_target"
+target_if = "nf_source"
+ssdp = true
+dial = true

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -928,12 +928,21 @@ class DialCase:
     serve_seconds: float = 6.0
     passive: bool = False      # passive discovery (device advertises NOTIFY; client listens) vs active M-SEARCH
     unreachable: bool = False  # device advertises a dead HTTP port; the proxied fetch must fail, not hang
+    config: str = "config-dial.toml"
+    expect_echoed: bool = False  # echo-drop verdict, per Backend.ECHOES_OWN_FRAMES
 
 
 DIAL_CASES = [
     DialCase(name="dial_launch_roundtrip", family=4, group=SSDP_GROUP_V4),
     DialCase(name="dial_passive_notify_roundtrip", family=4, group=SSDP_GROUP_V4, passive=True),
     DialCase(name="dial_upstream_unreachable", family=4, group=SSDP_GROUP_V4, unreachable=True),
+    # The mirrored pair storms without the dispatcher's echo drop: each side proxies the other's
+    # re-emit. The counter assertion keeps the case from passing vacuously on a bridge that
+    # stopped echoing, and pins the native fabrics as non-echoing.
+    DialCase(name="dial_launch_roundtrip_mirrored", family=4, group=SSDP_GROUP_V4,
+        config="config-dial-mirrored.toml", expect_echoed=True),
+    DialCase(name="dial_passive_notify_roundtrip_mirrored", family=4, group=SSDP_GROUP_V4, passive=True,
+        config="config-dial-mirrored.toml", expect_echoed=True),
 ]
 
 
@@ -952,6 +961,8 @@ class DialAddressChangeCase:
     serve_seconds: float = 60.0  # device keeps advertising + serving across all three passes
     passive: bool = True
     unreachable: bool = False
+    config: str = "config-dial.toml"
+    expect_echoed: bool = False
 
 
 DIAL_ADDRESS_CHANGE_CASES = [
@@ -976,6 +987,8 @@ class DialRecreateCase:
     serve_seconds: float = 120.0  # device serves across passes and the recreation waits
     passive: bool = True
     unreachable: bool = False
+    config: str = "config-dial.toml"
+    expect_echoed: bool = False
 
 
 DIAL_RECREATE_CASES = [
@@ -1171,6 +1184,12 @@ class Backend:
     # recreate case skips its silence probe there (there is no wire left to probe on).
     PROBES_SURVIVE_DELETE = False
 
+    # Whether the fabric hands netflector's own re-emits back as received frames. Docker's
+    # bridges do when their ports run in hairpin mode (Docker Desktop's default; Docker Engine
+    # only with the userland proxy off); a veth/epair pair has no third port to reflect off, so
+    # the mirrored DIAL cases assert the `echoed` count stays absent there.
+    ECHOES_OWN_FRAMES = False
+
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
         self.args = args
         self.prefix = prefix
@@ -1300,6 +1319,7 @@ class Backend:
 
 class DockerBackend(Backend):
     PROBES_SURVIVE_DELETE = True
+    ECHOES_OWN_FRAMES = True
 
     def __init__(self, args: argparse.Namespace, prefix: str) -> None:
         super().__init__(args, prefix)
@@ -1386,6 +1406,40 @@ class DockerBackend(Backend):
             ]
         )
         docker(["start", container])
+        self.enable_hairpin()
+
+    def enable_hairpin(self) -> None:
+        # ECHOES_OWN_FRAMES is the harness's doing, not a daemon default: a bridge port hands a
+        # frame back to its own sender only in hairpin mode, which Docker Desktop sets by default
+        # but Docker Engine sets only with the userland proxy off. Turn it on so the mirrored DIAL
+        # cases meet the echo they exist to exercise on any daemon. Each in-container interface
+        # names its host-side veth by ifindex (iflink); a host-namespace helper resolves that
+        # through sysfs to the bridge port and takes the flag. Where the ports aren't reachable
+        # (nothing resolves), the daemon's own default stands.
+        links = self.admin(
+            "".join(
+                f"cat /sys/class/net/{name}/iflink 2>/dev/null || :; "
+                for name in NETFLECTOR_IFNAMES.values()
+            ),
+            capture=True,
+        ).split()
+        script = (
+            f"for link in {' '.join(links)}; do "
+            "for d in /sys/class/net/*; do "
+            '[ "$(cat "$d/ifindex" 2>/dev/null)" = "$link" ] || continue; '
+            '[ -e "$d/brport/hairpin_mode" ] || continue; '
+            'echo 1 > "$d/brport/hairpin_mode"; basename "$d"; '
+            "done; done"
+        )
+        ports = docker(
+            ["run", "--rm", "--privileged", "--network", "host",
+             self.args.helper_image, "sh", "-ec", script],
+            echo=False,
+        ).stdout.split()
+        if ports:
+            print(f"hairpin enabled on {' '.join(ports)}", flush=True)
+        else:
+            print("no bridge port reachable for hairpin; the daemon's default stands", flush=True)
 
     def start_probe(
         self, role: str, segment: str, ifname: str, probe_args: list[str], *, detach: bool = True
@@ -1493,6 +1547,7 @@ class DockerBackend(Backend):
         if v6:
             command += ["--ip6", v6]
         docker([*command, self.networks[segment], self.roles["netflector"]])
+        self.enable_hairpin()  # the fresh veth comes up with the daemon's default
 
     def add_decoy_interface(self) -> None:
         # The privileged admin sidecar shares netflector's network namespace, so the veth
@@ -2395,11 +2450,10 @@ class DialRunner(CaseRunner):
             group=case.group, direction="forward")
         super().__init__(args, shim)
         self.dial = case
-        # The DIAL case's netflector loads a config with a single DIAL entry. The shared config's any-MAC
-        # [reflectors.discovery] entry also reflects SSDP, which would double-reflect the device's
-        # 200 OK (only one copy rewritten) -- so the DIAL case gets its own config to keep the
-        # relayed reply unambiguous.
-        self.config_path = E2E_DIR / "config-dial.toml"
+        # The DIAL cases load their own configs. The shared config's any-MAC [reflectors.discovery]
+        # entry also reflects SSDP, which would double-reflect the device's 200 OK (only one copy
+        # rewritten), so the relayed reply stays unambiguous only with a DIAL-only entry set.
+        self.config_path = E2E_DIR / case.config
 
     def start_device(self) -> None:
         # Single-homed on the target segment: the device's HTTP endpoints are reachable only via
@@ -2517,6 +2571,13 @@ class DialRunner(CaseRunner):
                 print(out, end="", flush=True)
         else:
             self.assert_device_verdicts()  # device-side verdict: Host rewrite + egress-pinned upstream
+        if self.dial.expect_echoed:
+            if self.backend.ECHOES_OWN_FRAMES:
+                self.wait_for_log("netflector", "echoed=", "netflector echo counter")
+            else:
+                out, err = self.backend.logs("netflector")
+                if "echoed=" in out + err:
+                    raise RuntimeError(f"{self.dial.name}: echoes on a fabric that hands no frame back")
         print(f"PASS {self.dial.name}", flush=True)
         if self.args.show_netflector_logs:
             time.sleep(0.5)

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -191,6 +191,14 @@ Not a message
 .Nm
 handles: unrecognized traffic on the group, or an address family the entry
 does not cover.
+.It Sy echoed
+Frames
+.Nm
+itself re-emitted, handed back by the link as received frames (a hairpin
+bridge port, an access point re-broadcasting a station's multicast), dropped
+before routing.
+The host's own multicast is never reflected: the capture ignores outgoing
+frames, and this drop catches the echo a link may hand back.
 .It Sy oversized
 Received frames too large to forward, dropped before parsing.
 .It Sy recoveries

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -52,9 +52,10 @@ impl Capture {
             )
         })?;
 
-        // Loop prevention: stop the kernel from handing us our own injected frames.
-        // PACKET_IGNORE_OUTGOING (Linux 4.20+) drops them at the socket; if the kernel
-        // lacks it (or user-mode QEMU rejects it), prepend an in-filter drop instead.
+        // Loop prevention: stop the kernel from handing us our own injected frames. A link that
+        // returns them as received frames (a hairpin bridge port) gets past this; the dispatcher's
+        // echo drop catches those. PACKET_IGNORE_OUTGOING (Linux 4.20+) drops them at the socket;
+        // if the kernel lacks it (or user-mode QEMU rejects it), prepend an in-filter drop instead.
         match set_ignore_outgoing(&fd) {
             Ok(()) => attach_filter(&fd, &ETHERNET_UDP_FILTER)?,
             Err(e) => {

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -308,12 +308,12 @@ fn attach(fd: &OwnedFd, if_name: &str) -> io::Result<LinkType> {
         }
     };
 
-    // Loop prevention on Ethernet: don't hand us our own egress, so two mirrored
-    // reflector entries don't ping-pong each other's frames. On DLT_NULL links see-sent
-    // stays on: the BSD lo driver taps each frame once (and tags it outbound), so
-    // default BPF already delivers it; receive-only would instead silence the interface
-    // entirely. Set explicitly both ways so a rebind onto different framing restores the
-    // right mode.
+    // Loop prevention on Ethernet: don't hand us our own egress. A link that returns it
+    // as received frames gets past this; the dispatcher's echo drop catches those. On
+    // DLT_NULL links see-sent stays on: the BSD lo driver taps each frame once (and tags
+    // it outbound), so default BPF already delivers it; receive-only would instead silence
+    // the interface entirely. Set explicitly both ways so a rebind onto different framing
+    // restores the right mode.
     let mut see_sent: c_uint = c_uint::from(link_type == LinkType::DltNull);
     ioctl(fd, libc::BIOCSSEESENT, (&raw mut see_sent).cast())?;
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -577,6 +577,24 @@ impl PacketDispatcher {
                 .all(|(_, reg)| reg.handler.is_some()),
             "route re-entered from inside a handler call"
         );
+        // Our own re-emit handed back by the link (a hairpin bridge port, an access point that
+        // re-broadcasts a station's multicast) arrives as an ordinary received frame, past the
+        // capture's outgoing drop, and a same-direction handler on this ingress (the mirrored leg
+        // of a bidirectional pair) would relay it again. Only its source MAC gives it away.
+        if is_own_echo(
+            packet.src_mac,
+            self.table
+                .egress_addrs(ingress)
+                .and_then(InterfaceAddresses::mac),
+        ) {
+            self.table.record_echo(ingress);
+            log::trace!(
+                "dropping our own echoed frame {} -> {} on {ingress:?}",
+                packet.source,
+                packet.dest
+            );
+            return;
+        }
         // Snapshot the live registration keys into the reused buffer. Taking them once means a
         // reflector registering mid-route isn't fed the in-flight frame (its key isn't in the
         // snapshot whether it appended or reused a freed slot), and a generational key keeps the
@@ -1026,6 +1044,16 @@ impl Handler for PacketDispatcher {
         match event {
             ControlEvent::Dump => log_counters(self.table.counter_rows()),
         }
+    }
+}
+
+/// Whether a captured frame is one of our own re-emits handed back by the link: its source MAC is
+/// the ingress interface's own. The all-zero address is exempt: Linux reports it as a loopback's
+/// hardware address and every loopback frame carries it, so it identifies nothing.
+fn is_own_echo(src_mac: Option<MacAddr>, own_mac: Option<MacAddr>) -> bool {
+    match (src_mac, own_mac) {
+        (Some(src), Some(own)) => src == own && !own.is_unspecified(),
+        _ => false,
     }
 }
 
@@ -1524,6 +1552,63 @@ mod tests {
             dispatcher.counts(ingress, MessageType::SsdpSearch),
             (0, 0, 0, 0)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn is_own_echo_matches_the_ingress_mac_except_all_zeros() {
+        let own = MacAddr::from([0x02, 0, 0, 0, 0, 1]);
+        let other = MacAddr::from([0x02, 0, 0, 0, 0, 2]);
+        assert!(is_own_echo(Some(own), Some(own)));
+        assert!(!is_own_echo(Some(other), Some(own)));
+        // A DLT_NULL frame carries no MAC; an interface without one owns nothing.
+        assert!(!is_own_echo(None, Some(own)));
+        assert!(!is_own_echo(Some(own), None));
+        // Linux loopback: zeros on both sides identify nothing.
+        let zero = MacAddr::from([0; 6]);
+        assert!(!is_own_echo(Some(zero), Some(zero)));
+    }
+
+    // A frame whose source MAC is the ingress's own is our own re-emit handed back by the link: it
+    // reaches no handler and counts as echoed, while a peer's frame routes as usual.
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real socket and interface")]
+    fn route_drops_our_own_echoed_frames_before_any_handler() -> io::Result<()> {
+        let mut dispatcher = PacketDispatcher::new();
+        let mut reactor = Reactor::new()?;
+        // The capture-less entry links to interface 0: give that interface a known MAC.
+        let interface = dispatcher.table.find_or_add_interface(LOOPBACK_IFACE)?;
+        let own = MacAddr::from([0x02, 0, 0, 0, 0, 1]);
+        dispatcher.table.set_test_addrs(
+            interface,
+            InterfaceAddresses::new(Some(own), Some(Ipv4Addr::LOCALHOST), None, None),
+        );
+        let ingress = dispatcher.add_test_capture();
+        assert_eq!(dispatcher.table.interface_of(ingress), Some(interface));
+        dispatcher.register(
+            ingress,
+            Filter::default(),
+            Box::new(Outcomer(Outcome::Reflected(MessageType::MdnsQuery))),
+        );
+
+        let mut echo = probe_packet(b"ours");
+        echo.src_mac = Some(own);
+        dispatcher.route(ingress, &echo, &mut reactor);
+        assert_eq!(dispatcher.table.echoed_of(ingress), 1);
+        assert_eq!(
+            dispatcher.counts(ingress, MessageType::MdnsQuery),
+            (0, 0, 0, 0),
+            "the handler never ran"
+        );
+
+        let mut peer = probe_packet(b"theirs");
+        peer.src_mac = Some(MacAddr::from([0x02, 0, 0, 0, 0, 2]));
+        dispatcher.route(ingress, &peer, &mut reactor);
+        assert_eq!(
+            dispatcher.counts(ingress, MessageType::MdnsQuery),
+            (1, 0, 0, 0)
+        );
+        assert_eq!(dispatcher.table.echoed_of(ingress), 1);
         Ok(())
     }
 

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -174,13 +174,15 @@ impl TypeCounters {
 }
 
 /// Every count for one interface (capture): one [`TypeCounters`] per [`MessageType`], a type-less
-/// `filtered` count for junk, a `recoveries` count of completed interface rebuilds (a recreated
-/// or returned interface whose captures re-bound), and a type-less `oversized` count of received
-/// frames too large to forward (dropped before parsing).
+/// `filtered` count for junk, an `echoed` count of our own re-emits the link handed back (dropped
+/// before routing), a `recoveries` count of completed interface rebuilds (a recreated or returned
+/// interface whose captures re-bound), and a type-less `oversized` count of received frames too
+/// large to forward (dropped before parsing).
 #[derive(Clone, Default)]
 pub(crate) struct CaptureCounters {
     types: [TypeCounters; MESSAGE_TYPE_COUNT],
     filtered: u64,
+    echoed: u64,
     recoveries: u64,
     oversized: u64,
 }
@@ -210,6 +212,11 @@ impl CaptureCounters {
         self.oversized += n;
     }
 
+    /// Count one of our own re-emits that the link handed back, dropped before routing.
+    pub(crate) fn record_echo(&mut self) {
+        self.echoed += 1;
+    }
+
     /// This row's non-zero counts as one line, e.g. `recoveries=1; mDNS query reflected=42
     /// skipped=10; SSDP search reflected=5 dropped=1; filtered=2`. `None` when nothing has been
     /// counted, so an idle interface produces no report line.
@@ -230,6 +237,9 @@ impl CaptureCounters {
         );
         if self.filtered > 0 {
             parts.push(format!("filtered={}", self.filtered));
+        }
+        if self.echoed > 0 {
+            parts.push(format!("echoed={}", self.echoed));
         }
         if self.oversized > 0 {
             parts.push(format!("oversized={}", self.oversized));
@@ -260,9 +270,16 @@ mod tests {
             let c = self.types[ty as usize];
             (c.reflected, c.skipped, c.dropped, c.stalled)
         }
+
         fn filtered(&self) -> u64 {
             self.filtered
         }
+
+        /// The echo count, for the dispatcher's echo-drop test.
+        pub(crate) fn echoed(&self) -> u64 {
+            self.echoed
+        }
+
         /// This row's recovery count. Read from the dispatcher's reconcile test through the
         /// interface table, hence `pub(crate)`.
         pub(crate) fn recoveries(&self) -> u64 {
@@ -327,6 +344,21 @@ mod tests {
         assert_eq!(
             c.format_nonzero().as_deref(),
             Some("filtered=1; oversized=5")
+        );
+    }
+
+    #[test]
+    fn record_echo_counts_and_reports() {
+        let mut c = CaptureCounters::default();
+        c.record_echo();
+        c.record_echo();
+        assert_eq!(c.echoed(), 2);
+        // Interface-wide counts trail the typed ones: filtered, echoed, oversized.
+        c.record(Outcome::Filtered);
+        c.record_oversized(1);
+        assert_eq!(
+            c.format_nonzero().as_deref(),
+            Some("filtered=1; echoed=2; oversized=1")
         );
     }
 

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -220,6 +220,13 @@ impl InterfaceTable {
             .record_oversized(n);
     }
 
+    /// Count one of our own re-emits handed back on a capture's row (see
+    /// [`CaptureCounters::record_echo`]). Indexed directly, like [`record`](Self::record): reached
+    /// only from `route` with a real ingress key.
+    pub(super) fn record_echo(&mut self, capture: CaptureKey) {
+        self.captures[capture.0 as usize].counters.record_echo();
+    }
+
     /// Each capture's `(interface name, counter row)` for the periodic report. The table owns the
     /// capture→interface-name mapping and stays log-free (the dispatcher does the logging).
     pub(super) fn counter_rows(&self) -> impl Iterator<Item = (&str, &CaptureCounters)> {
@@ -503,6 +510,21 @@ mod tests {
         /// The recovery count recorded on `capture`'s row, for the dispatcher's reconcile test.
         pub(in crate::dispatch) fn recoveries_of(&self, capture: CaptureKey) -> u64 {
             self.captures[capture.0 as usize].counters.recoveries()
+        }
+
+        /// The echo count recorded on `capture`'s row, for the dispatcher's echo-drop test.
+        pub(in crate::dispatch) fn echoed_of(&self, capture: CaptureKey) -> u64 {
+            self.captures[capture.0 as usize].counters.echoed()
+        }
+
+        /// Overwrite an interface's cached addresses, giving a routing test's ingress a known MAC
+        /// without a real link. For the dispatcher's echo-drop test.
+        pub(in crate::dispatch) fn set_test_addrs(
+            &mut self,
+            interface: InterfaceKey,
+            addrs: InterfaceAddresses,
+        ) {
+            self.entries[interface.0 as usize].interface.addrs = addrs;
         }
     }
 

--- a/src/net/mac.rs
+++ b/src/net/mac.rs
@@ -26,6 +26,13 @@ impl MacAddr {
         MacAddr([0xff; 6])
     }
 
+    /// Whether this is the all-zero address, which names no station: Linux reports it as a
+    /// loopback's hardware address, and loopback frames carry it.
+    #[must_use]
+    pub(crate) fn is_unspecified(self) -> bool {
+        self.0 == [0; 6]
+    }
+
     /// The L2 destination MAC for a multicast IP `addr`: IPv4 maps to `01:00:5e`
     /// plus the low 23 address bits (RFC 1112), IPv6 to `33:33` plus the low 32
     /// bits (RFC 2464).
@@ -207,6 +214,12 @@ mod tests {
     #[test]
     fn broadcast_is_all_ones() {
         assert_eq!(MacAddr::broadcast().octets(), [0xff; 6]);
+    }
+
+    #[test]
+    fn unspecified_is_all_zeros() {
+        assert!(MacAddr::from([0; 6]).is_unspecified());
+        assert!(!MacAddr::from([0, 0, 0, 0, 0, 1]).is_unspecified());
     }
 
     #[test]

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -36,8 +36,9 @@ pub(crate) enum Verdict {
     /// A message for this direction. Re-emit it.
     Reflect(MessageType),
     /// A message for the *other* direction; drop it silently. Dropping the opposite direction is
-    /// the loop-breaker (atop the capture's own-egress drop): a reflected query re-emitted on the
-    /// egress is still a query, which the egress side's response-only reflector skips.
+    /// the loop-breaker (atop the capture's own-egress drop and the dispatcher's echo drop): a
+    /// reflected query re-emitted on the egress is still a query, which the egress side's
+    /// response-only reflector skips.
     Skip(MessageType),
     /// Not a recognizable protocol message on this dedicated group. Drop it with a debug log.
     Junk,


### PR DESCRIPTION
A hairpin bridge port or a multicast-reflecting access point hands an injected frame back as an ordinary received frame, past the capture's outgoing drop. Single-direction entries were safe only because the echo lands on an opposite-direction handler, which skips it; two mirrored entries (what a `bidirectional` option would generate) relay it back and forth, and with DIAL each side proxies the other's listener until the cap. The e2e harness's Docker bridges run with hairpin on, which is how it surfaced: the mirrored passive case stormed to ~120k reflections in two seconds.

The dispatcher now drops a frame whose source MAC is the ingress's own before any handler sees it, counted as `echoed` (README, man page). The all-zero MAC is exempt (Linux loopback reports and carries it); DLT_NULL frames have none. Kept in userspace rather than the capture's BPF program: the MAC has to be supplied either way, and echo volume equals our own send rate.

Testing: unit tests for the match rule, the routing drop, and the counter; `cargo test --lib` green on macOS and Linux (`docker_test.sh`), clippy and doc clean on both. e2e: the three DIAL cases plus two new mirrored-pair cases, which stormed before and now pass while asserting a non-zero `echoed` count (one echo per re-emit, as the counter lines show).
