### PR TITLE
reflector: emit policy and classifier trait on the stateless engine

### DIFF
--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -12,7 +12,7 @@ mod search;
 mod simple;
 
 pub(crate) use search::SearchReflector;
-pub(crate) use simple::SimpleReflector;
+pub(crate) use simple::{Classify, Emit, SimpleReflector};
 
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
@@ -40,6 +40,9 @@ pub(crate) enum Verdict {
     /// reflected query re-emitted on the egress is still a query, which the egress side's
     /// response-only reflector skips.
     Skip(MessageType),
+    /// A message this leg recognizes but is configured not to relay (a wake for a device outside
+    /// the allow-set). The classifier logged why; drop it silently.
+    Excluded,
     /// Not a recognizable protocol message on this dedicated group. Drop it with a debug log.
     Junk,
 }

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -20,7 +20,7 @@ use crate::net::mdns::{
 };
 
 use super::{
-    BuildError, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
+    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
     require_bidirectional_families, require_macs_matchable,
 };
 
@@ -113,9 +113,8 @@ pub(crate) fn build(
             target,
             "mDNS",
             "query",
-            MDNS_PORT,
-            MDNS_TTL,
             query_verdict,
+            Emit::fixed(MDNS_PORT, MDNS_TTL),
         )),
     );
     // target → source: reflect responses, optionally only from the configured device's MAC.
@@ -132,9 +131,8 @@ pub(crate) fn build(
                 source,
                 "mDNS",
                 "response",
-                MDNS_PORT,
-                MDNS_TTL,
                 response_verdict,
+                Emit::fixed(MDNS_PORT, MDNS_TTL),
             )
             // A response whose A/AAAA records are all link-local or otherwise never a peer
             // advertises endpoints the source side can never use; queries carry no advertisement,

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -319,6 +319,7 @@ impl PacketHandler for SearchReflector {
             Verdict::Reflect(message_type) => message_type,
             // A message for the other direction (an announcement) flows through that reflector.
             Verdict::Skip(message_type) => return Outcome::Skipped(message_type),
+            Verdict::Excluded => return Outcome::Filtered,
             Verdict::Junk => {
                 log::debug!(
                     "{}: dropping unrecognized payload ({} B) on the search path from {}",

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -1,10 +1,15 @@
-//! A shared stateless reflector for the multicast-discovery protocols.
+//! The shared stateless reflector.
 //!
-//! mDNS (both directions), the WSD Hello/Bye announcements, and SSDP's `NOTIFY` advertisements are the
-//! same operation: classify the payload and, if it's a message for this direction, re-emit it to its
-//! own group on the egress interface, verbatim or through an optional [`ReplyRewrite`] (SSDP's
-//! advertisement direction rewrites the DIAL `LOCATION`). The search directions are stateful
-//! (per-searcher sessions), so they use the shared `SearchReflector` instead.
+//! mDNS (both directions), the WSD Hello/Bye announcements, SSDP's `NOTIFY` advertisements and
+//! Wake-on-LAN are the same operation: classify the payload and, if it's a message for this leg,
+//! re-emit it on the egress interface, verbatim or through an optional [`ReplyRewrite`] (SSDP's
+//! advertisement direction rewrites the DIAL `LOCATION`). What differs per protocol enters as
+//! parameters: the [`Classify`] gate and the [`Emit`] policy (which source port and TTL the re-emit
+//! carries). Where it goes follows from the captured destination alone ([`link_destination`]). The
+//! search directions are stateful (per-searcher sessions), so they use the shared `SearchReflector`
+//! instead.
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::dispatch::{CaptureKey, Outcome, PacketDispatcher, PacketHandler};
 use crate::logging::log_rate;
@@ -13,21 +18,90 @@ use crate::reactor::Reactor;
 
 use super::{NoRewrite, ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
 
-/// One direction of one multicast-discovery protocol: re-emits each accepted message captured on its
-/// ingress onto `egress`, to the message's own destination (the dispatcher's filter pins that to the
-/// group). The `classify` fn is the directional gate; an optional [`ReplyRewrite`] transforms the
-/// payload before re-emit (default: forward verbatim).
-pub(crate) struct SimpleReflector {
+/// A leg's ingress gate: is this packet a message for it? See [`Verdict`].
+pub(crate) trait Classify {
+    fn classify(&self, packet: &Packet) -> Verdict;
+}
+
+/// A plain function over the payload: the multicast-discovery protocols gate on the message alone.
+impl<F: Fn(&[u8]) -> Verdict> Classify for F {
+    fn classify(&self, packet: &Packet) -> Verdict {
+        self(packet.payload)
+    }
+}
+
+/// The UDP source port a re-emit carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourcePort {
+    /// A protocol's well-known port.
+    Fixed(u16),
+    /// The captured packet's own.
+    Captured,
+}
+
+impl SourcePort {
+    fn resolve(self, packet: &Packet) -> u16 {
+        match self {
+            Self::Fixed(port) => port,
+            Self::Captured => packet.source.port(),
+        }
+    }
+}
+
+/// The TTL / hop limit a re-emit carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Ttl {
+    Fixed(u8),
+    /// The captured packet's own.
+    Captured,
+}
+
+impl Ttl {
+    fn resolve(self, packet: &Packet) -> u8 {
+        match self {
+            Self::Fixed(ttl) => ttl,
+            Self::Captured => packet.ttl,
+        }
+    }
+}
+
+/// How a re-emit is stamped: the source port and TTL it carries. The address is always the
+/// egress's own; the destination follows from the captured one ([`link_destination`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Emit {
+    pub(crate) source_port: SourcePort,
+    pub(crate) ttl: Ttl,
+}
+
+impl Emit {
+    /// From `port` at `ttl`: the multicast-discovery protocols.
+    pub(crate) const fn fixed(port: u16, ttl: u8) -> Self {
+        Self {
+            source_port: SourcePort::Fixed(port),
+            ttl: Ttl::Fixed(ttl),
+        }
+    }
+
+    /// From the captured source port at the captured TTL: Wake-on-LAN.
+    pub(crate) const fn captured() -> Self {
+        Self {
+            source_port: SourcePort::Captured,
+            ttl: Ttl::Captured,
+        }
+    }
+}
+
+/// One stateless leg of one protocol: re-emits each accepted packet captured on its ingress onto
+/// `egress`, stamped per its [`Emit`] policy. `classify` is the directional gate; an optional
+/// [`ReplyRewrite`] transforms the payload before re-emit (default: forward verbatim).
+pub(crate) struct SimpleReflector<C> {
     egress: CaptureKey,
     /// Protocol tag for logs, e.g. `"mDNS"`.
     name: &'static str,
     /// The message kind/direction this reflector handles, for logs, e.g. `"query"`.
     kind: &'static str,
-    /// The UDP source port to emit from: a protocol's well-known port. The destination comes from
-    /// `packet.dest`.
-    src_port: u16,
-    ttl: u8,
-    classify: fn(&[u8]) -> Verdict,
+    classify: C,
+    emit: Emit,
     /// Transforms the payload before re-emit; [`NoRewrite`] (the default) forwards verbatim.
     rewrite: Box<dyn ReplyRewrite>,
     /// The unreachable-advertisement suppression check for payloads `rewrite` left untouched
@@ -35,22 +109,20 @@ pub(crate) struct SimpleReflector {
     suppress: fn(&[u8]) -> bool,
 }
 
-impl SimpleReflector {
+impl<C: Classify> SimpleReflector<C> {
     pub(crate) fn new(
         egress: CaptureKey,
         name: &'static str,
         kind: &'static str,
-        src_port: u16,
-        ttl: u8,
-        classify: fn(&[u8]) -> Verdict,
+        classify: C,
+        emit: Emit,
     ) -> Self {
         Self {
             egress,
             name,
             kind,
-            src_port,
-            ttl,
             classify,
+            emit,
             rewrite: Box::new(NoRewrite),
             suppress: |_| false,
         }
@@ -71,16 +143,17 @@ impl SimpleReflector {
     }
 }
 
-impl PacketHandler for SimpleReflector {
+impl<C: Classify> PacketHandler for SimpleReflector<C> {
     fn on_packet(
         &mut self,
         packet: &Packet,
         dispatcher: &mut PacketDispatcher,
         reactor: &mut Reactor,
     ) -> Outcome {
-        let message_type = match (self.classify)(packet.payload) {
+        let message_type = match self.classify.classify(packet) {
             Verdict::Reflect(message_type) => message_type,
             Verdict::Skip(message_type) => return Outcome::Skipped(message_type),
+            Verdict::Excluded => return Outcome::Filtered,
             Verdict::Junk => {
                 log::debug!(
                     "{}: dropping unrecognized payload ({} B) to {} from {}",
@@ -93,13 +166,14 @@ impl PacketHandler for SimpleReflector {
             }
         };
 
+        let dest = link_destination(packet.dest);
+
         // A family the egress can't currently source is a quiet, transient drop (address
         // loss): a Stalled, not a genuine send failure.
-        if !egress_sources(dispatcher, self.egress, packet.dest) {
+        if !egress_sources(dispatcher, self.egress, dest) {
             log::debug!(
-                "{}: egress has no source for {} yet; dropping {} from {}",
+                "{}: egress has no source for {dest} yet; dropping {} from {}",
                 self.name,
-                packet.dest,
                 self.kind,
                 packet.source
             );
@@ -124,15 +198,19 @@ impl PacketHandler for SimpleReflector {
         }
         let payload = rewritten.unwrap_or(packet.payload);
 
-        match dispatcher.send_udp_group(self.egress, packet.dest, self.src_port, self.ttl, payload)
-        {
+        match dispatcher.send_udp_group(
+            self.egress,
+            dest,
+            self.emit.source_port.resolve(packet),
+            self.emit.ttl.resolve(packet),
+            payload,
+        ) {
             Ok(()) => {
                 log::debug!(
-                    "reflected {} {} from {} to {}",
+                    "reflected {} {} from {} to {dest}",
                     self.name,
                     self.kind,
-                    packet.source,
-                    packet.dest
+                    packet.source
                 );
                 Outcome::Reflected(message_type)
             }
@@ -140,15 +218,33 @@ impl PacketHandler for SimpleReflector {
                 log_rate!(
                     log::Level::Warn,
                     WARN_WINDOW,
-                    "{}: cannot reflect {} from {} to {}: {e}",
+                    "{}: cannot reflect {} from {} to {dest}: {e}",
                     self.name,
                     self.kind,
-                    packet.source,
-                    packet.dest
+                    packet.source
                 );
                 Outcome::Dropped(message_type)
             }
         }
+    }
+}
+
+/// IPv6 link-local all-nodes group (`ff02::1`), the v6 equivalent of the IPv4 limited broadcast.
+const V6_ALL_NODES: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
+
+/// Where a re-emit of a packet captured to `dest` goes: a multicast group re-emits to itself (the
+/// dispatcher's filter pinned it); anything else, a limited or directed broadcast or a unicast wake
+/// aimed at this host, goes link-wide on the egress at the captured port, the IPv4 limited
+/// broadcast or the IPv6 all-nodes group.
+fn link_destination(dest: SocketAddr) -> SocketAddr {
+    match dest {
+        SocketAddr::V4(v4) if !v4.ip().is_multicast() => {
+            SocketAddr::from((Ipv4Addr::BROADCAST, v4.port()))
+        }
+        SocketAddr::V6(v6) if !v6.ip().is_multicast() => {
+            SocketAddr::from((V6_ALL_NODES, v6.port()))
+        }
+        group => group,
     }
 }
 
@@ -177,21 +273,33 @@ mod tests {
         Verdict::Reflect(MessageType::MdnsResponse)
     }
 
+    type LoopbackRig = (
+        SimpleReflector<fn(&[u8]) -> Verdict>,
+        PacketDispatcher,
+        Reactor,
+    );
+
     /// A reflector with the given transform and suppression check, plus the dispatcher/reactor it
     /// runs against, over a real loopback egress (`None` = skip, no `CAP_NET_RAW`).
     fn reflector_over_loopback(
         rewrite: Box<dyn ReplyRewrite>,
         suppress: fn(&[u8]) -> bool,
-    ) -> Option<(SimpleReflector, PacketDispatcher, Reactor)> {
+    ) -> Option<LoopbackRig> {
         let cap = open_loopback_or_skip()?;
         let mut dispatcher = PacketDispatcher::new();
         let egress = dispatcher
             .add_capture(cap)
             .expect("add the loopback capture");
         let reactor = Reactor::new().expect("reactor");
-        let reflector = SimpleReflector::new(egress, "TEST", "response", 5353, 255, reflect_all)
-            .with_rewrite(rewrite)
-            .with_suppress(suppress);
+        let reflector = SimpleReflector::new(
+            egress,
+            "TEST",
+            "response",
+            reflect_all as fn(&[u8]) -> Verdict,
+            Emit::fixed(5353, 255),
+        )
+        .with_rewrite(rewrite)
+        .with_suppress(suppress);
         Some((reflector, dispatcher, reactor))
     }
 
@@ -204,6 +312,63 @@ mod tests {
             src_mac: None,
             payload: b"response",
         }
+    }
+
+    /// A packet from an ephemeral port at a non-default TTL, so a captured policy reads apart from a
+    /// fixed one.
+    fn packet_to(dest: &str) -> Packet<'static> {
+        Packet {
+            source: "10.0.0.1:40000".parse().unwrap(),
+            dest: dest.parse().unwrap(),
+            ttl: 7,
+            dst_mac: None,
+            src_mac: None,
+            payload: b"",
+        }
+    }
+
+    #[test]
+    fn link_destination_keeps_groups_and_broadcasts_the_rest() {
+        let dest = |s: &str| s.parse::<SocketAddr>().unwrap();
+        assert_eq!(
+            dest("224.0.0.251:5353"),
+            link_destination(dest("224.0.0.251:5353"))
+        );
+        assert_eq!(
+            dest("[ff02::fb]:5353"),
+            link_destination(dest("[ff02::fb]:5353"))
+        );
+        // Limited and directed broadcasts, and a unicast wake aimed at this host, go link-wide at
+        // the captured port.
+        for captured in ["255.255.255.255:9", "10.0.0.255:9", "10.0.0.2:9"] {
+            assert_eq!(dest("255.255.255.255:9"), link_destination(dest(captured)));
+        }
+        assert_eq!(dest("[ff02::1]:9"), link_destination(dest("[fe80::2]:9")));
+    }
+
+    #[test]
+    fn source_port_and_ttl_policies_resolve_fixed_or_captured() {
+        let packet = packet_to("10.0.0.2:9");
+        assert_eq!(SourcePort::Fixed(1900).resolve(&packet), 1900);
+        assert_eq!(SourcePort::Captured.resolve(&packet), 40000);
+        assert_eq!(Ttl::Fixed(2).resolve(&packet), 2);
+        assert_eq!(Ttl::Captured.resolve(&packet), 7);
+    }
+
+    #[test]
+    fn a_function_classifies_by_payload_alone() {
+        fn by_length(payload: &[u8]) -> Verdict {
+            if payload.is_empty() {
+                Verdict::Junk
+            } else {
+                Verdict::Reflect(MessageType::MdnsQuery)
+            }
+        }
+        assert_eq!(by_length.classify(&packet_to("10.0.0.2:9")), Verdict::Junk);
+        assert_eq!(
+            by_length.classify(&group_packet()),
+            Verdict::Reflect(MessageType::MdnsQuery)
+        );
     }
 
     #[test]

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -23,8 +23,8 @@ use crate::reactor::Reactor;
 
 use super::dial::{ProxyPlacement, rewrite_location};
 use super::{
-    BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
-    join_group_logged, require_bidirectional_families, require_macs_matchable,
+    BuildError, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector,
+    Verdict, join_group_logged, require_bidirectional_families, require_macs_matchable,
 };
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
@@ -191,9 +191,8 @@ pub(crate) fn build(
         source,
         "SSDP",
         "advertisement",
-        SSDP_PORT,
-        SSDP_TTL,
         advertisement_verdict,
+        Emit::fixed(SSDP_PORT, SSDP_TTL),
     )
     .with_suppress(advertises_only_unreachable);
     let advertisement = if ssdp.dial {

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -2,22 +2,22 @@
 //! target interface, so a wake sent on one link reaches a sleeping device on another.
 //!
 //! A magic packet is 6 bytes of `0xFF` followed by the target device's MAC repeated 16 times
-//! (102 bytes). A trailing `SecureOn` password, if present, is forwarded verbatim. The reflector
-//! validates the payload, then re-emits it on the target interface as a v4 limited broadcast or
-//! v6 link-local all-nodes multicast, sourced from that interface's own address.
+//! (102 bytes). A trailing `SecureOn` password, if present, is forwarded verbatim. The
+//! [`WakeClassifier`] validates the payload and applies the optional device allow-set and the
+//! family policy; the shared [`SimpleReflector`] re-emits on the target interface link-wide (a v4
+//! limited broadcast or v6 all-nodes multicast), sourced from that interface's own address at the
+//! captured source port and TTL ([`Emit::captured`]).
 
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::SocketAddr;
 
 use crate::config::{AddressFamily, Reflector};
-use crate::dispatch::{
-    CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, PortSet,
-};
-use crate::logging::log_rate;
+use crate::dispatch::{Filter, MessageType, PacketDispatcher, PortSet};
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
-use crate::reactor::Reactor;
 
-use super::{BuildError, InterfaceMap, WARN_WINDOW, egress_sources, missing_required_family};
+use super::{
+    BuildError, Classify, Emit, InterfaceMap, SimpleReflector, Verdict, missing_required_family,
+};
 
 const PREFIX_LEN: usize = 6;
 const MAC_LEN: usize = 6;
@@ -25,74 +25,39 @@ const MAC_REPS: usize = 16;
 /// Smallest valid magic packet: prefix plus the 16 MAC repetitions.
 const MAGIC_LEN: usize = PREFIX_LEN + MAC_REPS * MAC_LEN;
 
-/// IPv6 link-local all-nodes group (`ff02::1`), the v6 equivalent of the IPv4 limited broadcast.
-const V6_ALL_NODES: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
-
-/// Built Wake-on-LAN reflector: re-emits each validated magic packet on its `egress` interface.
-/// One handler covers all configured ports.
-struct WolReflector {
-    egress: CaptureKey,
-    /// Optional device allow-set; `None` reflects a wake for any device.
+/// The Wake-on-LAN gate: a magic packet whose target MAC the optional allow-set admits, in a
+/// family the policy handles. The family is gated here because the filter pins only the port, so
+/// both families arrive.
+struct WakeClassifier {
+    /// Optional device allow-set; `None` admits a wake for any device.
     target_macs: Option<MacSet>,
-    /// IP-version policy: which families this reflector re-emits.
     family: AddressFamily,
 }
 
-impl PacketHandler for WolReflector {
-    fn on_packet(
-        &mut self,
-        packet: &Packet,
-        dispatcher: &mut PacketDispatcher,
-        _reactor: &mut Reactor,
-    ) -> Outcome {
+impl Classify for WakeClassifier {
+    fn classify(&self, packet: &Packet) -> Verdict {
         let Some(mac) = magic_packet_mac(packet.payload) else {
-            log::debug!("WoL: ignoring non-magic packet from {}", packet.source);
-            return Outcome::Filtered;
+            return Verdict::Junk;
         };
         if !wake_allowed(mac, self.target_macs.as_ref()) {
             log::debug!(
                 "WoL: ignoring wake for {mac} from {}: not in the configured device set",
                 packet.source
             );
-            return Outcome::Filtered;
+            return Verdict::Excluded;
         }
-        let Some(dst) = wol_destination(self.family, packet) else {
+        let handled = match packet.dest {
+            SocketAddr::V4(_) => self.family.uses_ipv4(),
+            SocketAddr::V6(_) => self.family.uses_ipv6(),
+        };
+        if !handled {
             log::debug!(
                 "WoL: {} is not a handled address family; ignoring",
                 packet.source
             );
-            return Outcome::Filtered;
-        };
-        // A family the egress can't currently source is a transient drop (address loss): Stalled,
-        // not a genuine send failure.
-        if !egress_sources(dispatcher, self.egress, dst) {
-            log::debug!(
-                "WoL: egress has no source for {dst} yet; dropping wake from {}",
-                packet.source
-            );
-            return Outcome::Stalled(MessageType::WakeOnLan);
+            return Verdict::Excluded;
         }
-        match dispatcher.send_udp_group(
-            self.egress,
-            dst,
-            packet.source.port(),
-            packet.ttl,
-            packet.payload,
-        ) {
-            Ok(()) => {
-                log::debug!("reflected WoL packet from {} to {dst}", packet.source);
-                Outcome::Reflected(MessageType::WakeOnLan)
-            }
-            Err(e) => {
-                log_rate!(
-                    log::Level::Warn,
-                    WARN_WINDOW,
-                    "WoL: cannot reflect packet from {} to {dst}: {e}",
-                    packet.source
-                );
-                Outcome::Dropped(MessageType::WakeOnLan)
-            }
-        }
+        Verdict::Reflect(MessageType::WakeOnLan)
     }
 }
 
@@ -118,21 +83,6 @@ fn magic_packet_mac(payload: &[u8]) -> Option<MacAddr> {
 /// Whether the optional `targets` allow-set admits a wake for `mac`.
 fn wake_allowed(mac: MacAddr, targets: Option<&MacSet>) -> bool {
     targets.is_none_or(|targets| targets.contains(&mac))
-}
-
-/// Link-wide destination a captured magic `packet` re-emits to under `family`: the IPv4 limited
-/// broadcast or the IPv6 link-local all-nodes group, at the captured destination port. `None` when
-/// `family` doesn't handle the packet's IP version.
-fn wol_destination(family: AddressFamily, packet: &Packet) -> Option<SocketAddr> {
-    match packet.dest {
-        SocketAddr::V4(dest) if family.uses_ipv4() => {
-            Some(SocketAddr::from((Ipv4Addr::BROADCAST, dest.port())))
-        }
-        SocketAddr::V6(dest) if family.uses_ipv6() => {
-            Some(SocketAddr::from((V6_ALL_NODES, dest.port())))
-        }
-        _ => None,
-    }
 }
 
 /// Build the Wake-on-LAN reflector for `reflector` and register it on `dispatcher`. No-op when
@@ -170,11 +120,16 @@ pub(crate) fn build(
             dst_port: Some(ports),
             ..Filter::default()
         },
-        Box::new(WolReflector {
+        Box::new(SimpleReflector::new(
             egress,
-            target_macs: reflector.macs.clone(),
-            family: reflector.address_family,
-        }),
+            "WoL",
+            "wake",
+            WakeClassifier {
+                target_macs: reflector.macs.clone(),
+                family: reflector.address_family,
+            },
+            Emit::captured(),
+        )),
     );
     log::info!(
         "WoL reflector \"{}\": {} -> {} on {} port(s)",
@@ -201,6 +156,17 @@ mod tests {
         }
         p.extend_from_slice(trailer);
         p
+    }
+
+    fn packet_with(payload: &[u8]) -> Packet<'_> {
+        Packet {
+            source: "10.0.0.1:5".parse().unwrap(),
+            dest: "10.0.0.2:9".parse().unwrap(),
+            ttl: 64,
+            dst_mac: None,
+            src_mac: None,
+            payload,
+        }
     }
 
     #[test]
@@ -257,33 +223,31 @@ mod tests {
         assert!(magic_packet_mac(&packet).is_none());
     }
 
-    /// A packet whose `dest` (the captured Wake-on-LAN port) drives the re-emit destination.
-    fn packet_to(dest: &str) -> Packet<'static> {
-        Packet {
-            source: "10.0.0.1:5".parse().unwrap(),
-            dest: dest.parse().unwrap(),
-            ttl: 64,
-            dst_mac: None,
-            src_mac: None,
-            payload: b"",
-        }
-    }
-
     #[test]
-    fn wol_destination_targets_the_link_for_used_families() {
-        let v4 = packet_to("10.0.0.2:9");
-        let v6 = packet_to("[fe80::2]:9");
-        // Dual handles both: v4 -> limited broadcast, v6 -> ff02::1, at the captured dst port.
+    fn classifier_reflects_admitted_wakes_and_excludes_the_rest() {
+        let magic = magic_packet(DEVICE, &[]);
+        let any = WakeClassifier {
+            target_macs: None,
+            family: AddressFamily::Dual,
+        };
         assert_eq!(
-            wol_destination(AddressFamily::Dual, &v4),
-            Some("255.255.255.255:9".parse().unwrap())
+            any.classify(&packet_with(&magic)),
+            Verdict::Reflect(MessageType::WakeOnLan)
         );
-        assert_eq!(
-            wol_destination(AddressFamily::Dual, &v6),
-            Some("[ff02::1]:9".parse().unwrap())
-        );
-        // A single-family policy ignores the other family.
-        assert_eq!(wol_destination(AddressFamily::Ipv4, &v6), None);
-        assert_eq!(wol_destination(AddressFamily::Ipv6, &v4), None);
+        // A device outside the allow-set is excluded (recognized, configured out), not junk.
+        let others = WakeClassifier {
+            target_macs: Some(MacSet::from(MacAddr::from([0xaa; 6]))),
+            family: AddressFamily::Dual,
+        };
+        assert_eq!(others.classify(&packet_with(&magic)), Verdict::Excluded);
+        // So is a family the policy doesn't handle: the port-only filter lets both families in.
+        let v4_only = WakeClassifier {
+            target_macs: None,
+            family: AddressFamily::Ipv4,
+        };
+        let mut v6 = packet_with(&magic);
+        v6.dest = "[fe80::2]:9".parse().unwrap();
+        assert_eq!(v4_only.classify(&v6), Verdict::Excluded);
+        assert_eq!(any.classify(&packet_with(b"not magic")), Verdict::Junk);
     }
 }

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -15,8 +15,8 @@ use crate::net::wsd::{
 };
 
 use super::{
-    BuildError, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector, Verdict,
-    join_group_logged, require_bidirectional_families, require_macs_matchable,
+    BuildError, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector,
+    Verdict, join_group_logged, require_bidirectional_families, require_macs_matchable,
 };
 
 /// WSD's classifier kind maps to its group message types. The `ProbeMatches`/`ResolveMatches` unicast
@@ -117,9 +117,8 @@ pub(crate) fn build(
                 source,
                 "WSD",
                 "announcement",
-                WSD_PORT,
-                WSD_TTL,
                 announcement_verdict,
+                Emit::fixed(WSD_PORT, WSD_TTL),
             )
             // A Hello whose XAddrs are all link-local or otherwise never a peer advertises
             // endpoints the source side can never use.


### PR DESCRIPTION
Increment 1 of the generic-relay work: the stateless reflector engine gains an `Emit` policy (source port and TTL, fixed or captured) and a `Classify` trait that a plain function still satisfies, and Wake-on-LAN folds onto it, dropping its own handler. The re-emit destination follows from the captured one: a multicast group re-emits to itself, anything else goes link-wide. WoL's family gate moves into its classifier, since its port-only filter admits both families; a new `Verdict::Excluded` keeps its allow-set and family diagnostics instead of collapsing them into "unrecognized payload".

No behaviour change.

Testing: `cargo test --lib` green on macOS and Linux (`docker_test.sh`), clippy and doc clean on both. e2e: all seven WoL cases (including `ignores_wrong_mac`, the `Excluded` path), the mDNS, SSDP NOTIFY and WSD Hello/Bye stateless legs, the family-policy and direction cases, and the mirrored DIAL case, 29 passing on the first cut and 16 re-run after the destination simplification.
