### PR TITLE
config: bidirectional entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ dial      = true                 # optional; enable the DIAL app proxy (requires
 wsd       = true                 # optional; enable WS-Discovery reflection (default false)
 wol_ports = [7, 9]               # optional; WoL UDP ports (default [7, 9]); only valid when wol = true
 address_family = "default"       # optional; default | dual | ipv4 | ipv6 (default "default")
+bidirectional = false            # optional; also relay every enabled protocol target -> source (default false)
 ```
 
 An entry must enable at least one protocol and expands into one reflector per enabled protocol, all
@@ -260,6 +261,13 @@ sharing the entry's interfaces, MAC selection, and `address_family`. The same sh
 specific devices (set `macs`) or a whole network (omit it). No IP addresses ever appear in the config.
 `dial` is not a separate reflector; it augments the entry's SSDP reflector with the DIAL application
 proxy (so it requires `ssdp`; see [DIAL](#dial)).
+
+Each protocol relays in a fixed direction (the table under [Per-protocol behavior](#per-protocol-behavior)):
+queries and searches source → target, responses and advertisements target → source. When both segments
+host clients and devices, `bidirectional = true` builds the entry a second time with its interfaces
+swapped, so every enabled protocol relays both ways, and a `macs` allow-set scopes the device side of
+both legs. Run one active netflector per pair of network segments: two would relay each other's re-emits
+without end. On an HA pair, gate on CARP as the OPNsense plugin does.
 
 ### Environment variables
 
@@ -270,7 +278,7 @@ then optional; with none, the environment is the whole configuration. Variables 
 - `<TAG>` ties one entry's parameters together: any alphanumeric string (`1`, `2`, `TV`, …). It also
   becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
-  `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`), case-insensitive.
+  `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`, `BIDIRECTIONAL`), case-insensitive.
 
 The globals are `NETFLECTOR_LOG_LEVEL`, `NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
 `NETFLECTOR_COUNTERS_INTERVAL_SECS`, so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are
@@ -444,8 +452,10 @@ failure) is forwarded unchanged and logged, leaving on-subnet discovery unaffect
 Entry names must be unique across the file and the environment: a name that appears twice (including the
 same name from both sources) is rejected at startup. Beyond that, two entries that enable the same
 protocol are rejected as a duplicate of that protocol only when they could reflect the same packet
-twice: same `source_if`, same `target_if`, overlapping MAC selection, overlapping address-family
-handling, and, for WoL, at least one shared port. MAC selection overlaps when the entries' allow-sets
+twice: a shared direction, overlapping MAC selection, overlapping address-family handling, and, for
+WoL, at least one shared port. An entry's directions are its `source_if` → `target_if`, plus the reverse
+when it is `bidirectional`, so a bidirectional `lan`/`iot` entry and a plain `iot` → `lan` one duplicate
+each other. MAC selection overlaps when the entries' allow-sets
 share at least one device, or when either omits its MAC filter (any device). Address-family handling overlaps when both can
 handle the same IP version: an `ipv4`-only and an `ipv6`-only entry never overlap, while `default`/`dual`
 overlap with either. Entries that differ in interface, MAC, address family (or WoL ports), or that

--- a/e2e/config-bidirectional.toml
+++ b/e2e/config-bidirectional.toml
@@ -1,0 +1,18 @@
+log_level = "debug"
+
+# config.toml's entries with every protocol relayed both ways, so the reverse-direction cases reflect
+# where the one-way entries drop.
+[reflectors.wol-any]
+source_if = "nf_source"
+target_if = "nf_target"
+wol = true
+wol_ports = [9011]
+bidirectional = true
+
+[reflectors.discovery]
+source_if = "nf_source"
+target_if = "nf_target"
+mdns = true
+ssdp = true
+wsd = true
+bidirectional = true

--- a/e2e/config-dial-mirrored.toml
+++ b/e2e/config-dial-mirrored.toml
@@ -1,18 +1,12 @@
 log_level = "debug"
 counters_interval_secs = 1
 
-# Both directions of one DIAL pair, the entry pair a `bidirectional = true` entry will expand to.
-# Each interface then carries a same-direction advertisement handler, so netflector's own re-emits,
-# handed back by the Docker harness's hairpin bridges, would relay again without the dispatcher's
-# echo drop.
+# Both directions of one DIAL pair. Each interface then carries a same-direction advertisement
+# handler, so netflector's own re-emits, handed back by the Docker harness's hairpin bridges, would
+# relay again without the dispatcher's echo drop.
 [reflectors.dial-tv]
 source_if = "nf_source"
 target_if = "nf_target"
 ssdp = true
 dial = true
-
-[reflectors.dial-tv-reverse]
-source_if = "nf_target"
-target_if = "nf_source"
-ssdp = true
-dial = true
+bidirectional = true

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -417,6 +417,17 @@ TEST_CASES = [
         timeout_seconds=5.0,
         send_mac=WRONG_MAC,
     ),
+    # The same wake sent target->source, which the one-way entry would drop.
+    TestCase(
+        name="bidirectional_reflects_magic_packet_from_target",
+        send_port=ANY_MAC_PORT,
+        receive_port=ANY_MAC_PORT,
+        expect_mac=WRONG_MAC,
+        timeout_seconds=5.0,
+        send_mac=WRONG_MAC,
+        direction="reverse",
+        config="config-bidirectional.toml",
+    ),
     TestCase(
         name="ignores_malformed_packet_without_configured_mac",
         send_port=ANY_MAC_PORT,
@@ -500,6 +511,32 @@ MDNS_CASES = [
         send_payload_hex=MDNS_RESPONSE_LINK_LOCAL_HEX,
         group=MDNS_GROUP_V4,
         direction="reverse",
+    ),
+    # Against the one-way directions: a query from the target and a response from the source
+    # reflect once the entry relays both ways.
+    TestCase(
+        name="bidirectional_reflects_mdns_query_from_target",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=MDNS_QUERY_HEX,
+        expect_payload_hex=MDNS_QUERY_HEX,
+        group=MDNS_GROUP_V4,
+        direction="reverse",
+        config="config-bidirectional.toml",
+    ),
+    TestCase(
+        name="bidirectional_reflects_mdns_response_from_source",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=MDNS_RESPONSE_HEX,
+        expect_payload_hex=MDNS_RESPONSE_HEX,
+        group=MDNS_GROUP_V4,
+        direction="forward",
+        config="config-bidirectional.toml",
     ),
     # A query sent target->source hits the target's response-only handler and is dropped.
     TestCase(
@@ -613,6 +650,19 @@ SSDP_CASES = [
         expect_payload_hex=SSDP_NOTIFY_HEX,
         group=SSDP_GROUP_V4,
         direction="reverse",
+    ),
+    # A NOTIFY from the source segment, which the one-way entry drops.
+    TestCase(
+        name="bidirectional_reflects_ssdp_notify_from_source",
+        send_port=SSDP_PORT,
+        receive_port=SSDP_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SSDP_NOTIFY_HEX,
+        expect_payload_hex=SSDP_NOTIFY_HEX,
+        group=SSDP_GROUP_V4,
+        direction="forward",
+        config="config-bidirectional.toml",
     ),
     # A routable LOCATION literal reflects; a link-local one is suppressed rather than relayed.
     TestCase(
@@ -781,6 +831,31 @@ WSD_CASES = [
         group=WSD_GROUP_V4,
         direction="reverse",
     ),
+    # Announcements from the source segment, which the one-way entry drops.
+    TestCase(
+        name="bidirectional_reflects_wsd_hello_from_source",
+        config="config-bidirectional.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=WSD_HELLO_HEX,
+        expect_payload_hex=WSD_HELLO_HEX,
+        group=WSD_GROUP_V4,
+        direction="forward",
+    ),
+    TestCase(
+        name="bidirectional_reflects_wsd_bye_from_source",
+        config="config-bidirectional.toml",
+        send_port=WSD_PORT,
+        receive_port=WSD_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=WSD_BYE_HEX,
+        expect_payload_hex=WSD_BYE_HEX,
+        group=WSD_GROUP_V4,
+        direction="forward",
+    ),
     # A routable XAddrs URI beside the link-local one rescues the Hello from suppression.
     TestCase(
         name="reflects_wsd_hello_with_mixed_xaddrs",
@@ -864,6 +939,9 @@ class RoundTripCase:
     reply_hex: str = SSDP_OK_HEX
     config: str = "config.toml"
     evict_log: str = "evicted SSDP session"
+    # "forward" searches from the source segment with the responder on the target; "reverse" swaps
+    # them, the leg a bidirectional entry adds.
+    direction: str = "forward"
 
 
 ROUNDTRIP_CASES = [
@@ -880,6 +958,13 @@ ROUNDTRIP_CASES = [
     RoundTripCase(name="wsd_probe_roundtrip", family=4, group=WSD_GROUP_V4, port=WSD_PORT,
         probe_hex=WSD_PROBE_HEX, reply_hex=WSD_PROBEMATCHES_HEX, config="config-wsd.toml",
         evict_log="evicted WSD session"),
+    # Searches from the target segment with the device on the source: the sessions a bidirectional
+    # entry's second leg opens, reserving its port on the source side.
+    RoundTripCase(name="bidirectional_ssdp_msearch_roundtrip_from_target", family=4, group=SSDP_GROUP_V4,
+        config="config-bidirectional.toml", direction="reverse"),
+    RoundTripCase(name="bidirectional_wsd_probe_roundtrip_from_target", family=4, group=WSD_GROUP_V4,
+        port=WSD_PORT, probe_hex=WSD_PROBE_HEX, reply_hex=WSD_PROBEMATCHES_HEX,
+        config="config-bidirectional.toml", evict_log="evicted WSD session", direction="reverse"),
     # Resolve -> ResolveMatches: the same search-session path as Probe (both classify as a search).
     RoundTripCase(name="wsd_resolve_roundtrip", family=4, group=WSD_GROUP_V4, port=WSD_PORT,
         probe_hex=WSD_RESOLVE_HEX, reply_hex=WSD_RESOLVEMATCHES_HEX, config="config-wsd.toml",
@@ -907,6 +992,7 @@ class SearchRecreateCase:
     probe_hex: str = SSDP_MSEARCH_MX5_HEX  # wide MX window: the first session must outlive the recreation
     reply_hex: str = SSDP_OK_HEX
     config: str = "config.toml"
+    direction: str = "forward"
     timeout_seconds: float = 8.0
     decoy: bool = False  # plant a decoy on the freed index so the recreation lands on a different one
 
@@ -930,6 +1016,9 @@ class DialCase:
     unreachable: bool = False  # device advertises a dead HTTP port; the proxied fetch must fail, not hang
     config: str = "config-dial.toml"
     expect_echoed: bool = False  # echo-drop verdict, per Backend.ECHOES_OWN_FRAMES
+    # "forward" puts the client on the source segment and the device on the target; "reverse"
+    # swaps them, the leg a bidirectional entry adds.
+    direction: str = "forward"
 
 
 DIAL_CASES = [
@@ -943,6 +1032,12 @@ DIAL_CASES = [
         config="config-dial-mirrored.toml", expect_echoed=True),
     DialCase(name="dial_passive_notify_roundtrip_mirrored", family=4, group=SSDP_GROUP_V4, passive=True,
         config="config-dial-mirrored.toml", expect_echoed=True),
+    # The second leg end to end: client on the target, device on the source, proxies minted on the
+    # target side.
+    DialCase(name="bidirectional_dial_launch_roundtrip_from_target", family=4, group=SSDP_GROUP_V4,
+        config="config-dial-mirrored.toml", expect_echoed=True, direction="reverse"),
+    DialCase(name="bidirectional_dial_passive_notify_roundtrip_from_target", family=4, group=SSDP_GROUP_V4,
+        passive=True, config="config-dial-mirrored.toml", expect_echoed=True, direction="reverse"),
 ]
 
 
@@ -963,6 +1058,7 @@ class DialAddressChangeCase:
     unreachable: bool = False
     config: str = "config-dial.toml"
     expect_echoed: bool = False
+    direction: str = "forward"
 
 
 DIAL_ADDRESS_CHANGE_CASES = [
@@ -989,6 +1085,7 @@ class DialRecreateCase:
     unreachable: bool = False
     config: str = "config-dial.toml"
     expect_echoed: bool = False
+    direction: str = "forward"
 
 
 DIAL_RECREATE_CASES = [
@@ -2293,10 +2390,13 @@ class RoundTripRunner(CaseRunner):
             group=case.group, direction="forward", config=case.config)
         super().__init__(args, shim)
         self.rt = case
+        self.searcher_seg, self.responder_seg = (
+            ("source", "target") if case.direction == "forward" else ("target", "source")
+        )
 
     def start_responder(self) -> None:
         ifname = self.backend.helper_ifname(RECEIVER_IFNAME)
-        self.backend.start_probe("responder", "target", ifname, [
+        self.backend.start_probe("responder", self.responder_seg, ifname, [
             "respond",
             "--port", str(self.rt.port), "--timeout", str(self.rt.timeout_seconds),
             "--family", str(self.rt.family), "--join-group", self.rt.group,
@@ -2306,8 +2406,8 @@ class RoundTripRunner(CaseRunner):
 
     def run_searcher(self) -> None:
         expectation = ["--expect-payload-hex", self.rt.reply_hex] if self.rt.expect_reply else ["--expect-none"]
-        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
-        self.backend.start_probe("searcher", "source", ifname, [
+        ifname = self.backend.helper_ifname(NETFLECTOR_IFNAMES[self.searcher_seg])
+        self.backend.start_probe("searcher", self.searcher_seg, ifname, [
             "search",
             "--source-port", str(SEARCHER_SOURCE_PORT), "--port", str(self.rt.port),
             "--address", self.rt.group, "--interface", ifname,
@@ -2450,16 +2550,19 @@ class DialRunner(CaseRunner):
             group=case.group, direction="forward")
         super().__init__(args, shim)
         self.dial = case
+        self.client_seg, self.device_seg = (
+            ("source", "target") if case.direction == "forward" else ("target", "source")
+        )
         # The DIAL cases load their own configs. The shared config's any-MAC [reflectors.discovery]
         # entry also reflects SSDP, which would double-reflect the device's 200 OK (only one copy
         # rewritten), so the relayed reply stays unambiguous only with a DIAL-only entry set.
         self.config_path = E2E_DIR / case.config
 
     def start_device(self) -> None:
-        # Single-homed on the target segment: the device's HTTP endpoints are reachable only via
-        # netflector's egress-pinned upstream connect, so the peer it records is
-        # netflector's target_if address -- never the source-side client (which cannot route to the
-        # target subnet directly).
+        # Single-homed on its segment: the device's HTTP endpoints are reachable only via
+        # netflector's egress-pinned upstream connect, so the peer it records is netflector's
+        # address on that segment -- never the client (which cannot route to the device's subnet
+        # directly).
         ifname = self.backend.helper_ifname(RECEIVER_IFNAME)
         probe_args = [
             "dial-device",
@@ -2471,14 +2574,14 @@ class DialRunner(CaseRunner):
             probe_args.append("--notify")
         if self.dial.unreachable:
             probe_args.append("--unreachable")
-        self.backend.start_probe("device", "target", ifname, probe_args)
+        self.backend.start_probe("device", self.device_seg, ifname, probe_args)
         self.wait_for_log("device", "dial-device ready", "dial-device")
 
     def _client_args(self, netflector_authority: str, device_authority: str) -> list[str]:
-        # The client is single-homed on the source segment. It is told netflector's source_if
-        # address (what the rewritten authorities must point at) and the device's true target_if
-        # address (which must never leak through a rewrite).
-        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
+        # The client is single-homed on its segment. It is told netflector's address there (what
+        # the rewritten authorities must point at) and the device's true address (which must never
+        # leak through a rewrite).
+        ifname = self.backend.helper_ifname(NETFLECTOR_IFNAMES[self.client_seg])
         probe_args = [
             "dial-client",
             "--port", str(SSDP_PORT), "--address", self.dial.group, "--interface", ifname,
@@ -2494,11 +2597,11 @@ class DialRunner(CaseRunner):
         return probe_args
 
     def run_client(self) -> None:
-        device_target_ip = self.backend.probe_ip("device", "target")
-        refl_source_ip = self.backend.netflector_ip("source")
-        ifname = self.backend.helper_ifname(NETFLECTOR_SOURCE_IFNAME)
+        device_ip = self.backend.probe_ip("device", self.device_seg)
+        refl_client_side_ip = self.backend.netflector_ip(self.client_seg)
+        ifname = self.backend.helper_ifname(NETFLECTOR_IFNAMES[self.client_seg])
         self.backend.start_probe(
-            "client", "source", ifname, self._client_args(refl_source_ip, device_target_ip)
+            "client", self.client_seg, ifname, self._client_args(refl_client_side_ip, device_ip)
         )
 
     def wait_for_client(self) -> None:
@@ -2514,9 +2617,9 @@ class DialRunner(CaseRunner):
     def assert_device_verdicts(self) -> None:
         # Two device-side checks: (1) the device exits non-zero if any request reached it with a
         # Host that was not rewritten to its own authority (netflector must rewrite Host
-        # source->device); (2) netflector's upstream connect is egress-pinned to target_if, so
-        # the only peer the device recorded must be exactly netflector's target_if address.
-        refl_target_ip = self.backend.netflector_ip("target")
+        # client->device); (2) netflector's upstream connect is egress-pinned to the device's
+        # interface, so the only peer the device recorded must be exactly netflector's address there.
+        refl_target_ip = self.backend.netflector_ip(self.device_seg)
         exit_code = self.backend.wait("device")
         out, err = self.backend.logs("device")
         if out:
@@ -2532,23 +2635,24 @@ class DialRunner(CaseRunner):
             raise RuntimeError("dial-device did not report the upstream peers it saw")
         seen = ast.literal_eval(line.split(marker, 1)[1].strip())
         if seen != [refl_target_ip]:
-            raise RuntimeError(f"device saw upstream peers {seen}, expected only netflector's target_if "
-                               f"address [{refl_target_ip!r}] (egress not pinned to target_if)")
+            raise RuntimeError(f"device saw upstream peers {seen}, expected only netflector's "
+                               f"{self.device_seg}-side address [{refl_target_ip!r}] (egress not pinned)")
         print(f"dial: every request's Host was rewritten to the device, and every upstream connection came "
-              f"from netflector's target_if address {refl_target_ip}", flush=True)
+              f"from netflector's {self.device_seg}-side address {refl_target_ip}", flush=True)
 
     def _force_upstream_egress_ambiguity(self) -> None:
         # Make the upstream egress pin load-bearing. The device is single-homed on the target
         # segment, so netflector's connect reaches it via target_if by routing alone, and
         # SO_BINDTODEVICE (TcpSocket PinEgress) would be untestable -- assert_device_verdicts'
         # "peer == netflector target_if address" passes even if the pin were dropped. Plant a
-        # more-specific host route to the device via the WRONG interface (source_if): an unpinned
-        # connect now follows it, ARPs the device on the source segment (where it does not live)
-        # and fails, so the whole DIAL flow breaks. Only the egress pin -- which constrains the
-        # route lookup to target_if -- still reaches the device, so PASS now requires it.
-        # (FreeBSD declines: no pin primitive there, see Backend.add_decoy_route.)
-        device_ip = self.backend.probe_ip("device", "target")
-        if not self.backend.add_decoy_route(device_ip, NETFLECTOR_SOURCE_IFNAME):
+        # more-specific host route to the device via the WRONG interface (the client's side): an
+        # unpinned connect now follows it, ARPs the device on the client's segment (where it does
+        # not live) and fails, so the whole DIAL flow breaks. Only the egress pin -- which
+        # constrains the route lookup to the device's interface -- still reaches the device, so
+        # PASS now requires it. (FreeBSD declines: no pin primitive there, see
+        # Backend.add_decoy_route.)
+        device_ip = self.backend.probe_ip("device", self.device_seg)
+        if not self.backend.add_decoy_route(device_ip, NETFLECTOR_IFNAMES[self.client_seg]):
             print(f"{self.dial.name}: no egress-pin primitive on this backend; decoy route skipped",
                   flush=True)
 

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -133,6 +133,17 @@ is rejected at startup.
 Enable WS-Discovery reflection.
 Boolean, default
 .Cm false .
+.It Ic bidirectional
+Also relay every enabled protocol from
+.Ic target_if
+to
+.Ic source_if ,
+for segments that each host clients and devices.
+Run one active
+.Nm netflector
+per pair of network segments: two would relay each other's re-emits without end.
+Boolean, default
+.Cm false .
 .El
 .Pp
 An entry must enable at least one protocol.
@@ -150,7 +161,7 @@ parameter overrides it.
 .Ic NAME ,
 or any entry field:
 .Ic SOURCE_IF , TARGET_IF , MACS , WOL , MDNS , SSDP , WSD , DIAL ,
-.Ic WOL_PORTS , ADDRESS_FAMILY .
+.Ic WOL_PORTS , ADDRESS_FAMILY , BIDIRECTIONAL .
 Case-insensitive.
 .El
 .Pp
@@ -187,12 +198,15 @@ appears twice, including the same name from both sources, is rejected at
 startup.
 .Pp
 Beyond names, two entries that enable the same protocol are rejected only when
-they could reflect the same packet twice: same
-.Ic source_if ,
-same
+they could reflect the same packet twice: a shared direction, overlapping MAC
+selection, overlapping address-family handling, and, for Wake-on-LAN, at least
+one shared port.
+An entry's directions are its
+.Ic source_if
+to
 .Ic target_if ,
-overlapping MAC selection, overlapping address-family handling, and, for
-Wake-on-LAN, at least one shared port.
+plus the reverse when it is
+.Ic bidirectional .
 MAC selection overlaps when the allow-sets share a device or either entry omits
 its filter.
 Address families overlap when both handle the same IP version:

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,14 +68,39 @@ pub(crate) struct Reflector {
     pub(crate) ssdp: Option<Ssdp>,
     /// Whether WS-Discovery (WSD) is enabled.
     pub(crate) wsd: bool,
+    /// Also relay every enabled protocol target → source: the entry is built a second time with
+    /// its interfaces swapped.
+    pub(crate) bidirectional: bool,
 }
 
 impl Reflector {
+    /// This entry with its interfaces swapped: the second leg of a bidirectional entry, built
+    /// exactly like the first.
+    pub(crate) fn reversed(&self) -> Reflector {
+        Reflector {
+            source_if: self.target_if.clone(),
+            target_if: self.source_if.clone(),
+            ..self.clone()
+        }
+    }
+
+    /// The `(source, target)` pairs this entry relays over: its own, plus the reverse when
+    /// bidirectional.
+    fn directions(&self) -> impl Iterator<Item = (&InterfaceName, &InterfaceName)> {
+        std::iter::once((&self.source_if, &self.target_if)).chain(
+            self.bidirectional
+                .then_some((&self.target_if, &self.source_if)),
+        )
+    }
+
     /// The protocol on which `self` and `other` would reflect the same packet
-    /// twice, if any: same direction, overlapping MAC selection and address
+    /// twice, if any: a shared direction, overlapping MAC selection and address
     /// family, and a shared enabled protocol (for `WoL`, also a shared port).
     fn conflicts_with(&self, other: &Reflector) -> Option<Protocol> {
-        if self.source_if != other.source_if || self.target_if != other.target_if {
+        if !self
+            .directions()
+            .any(|mine| other.directions().any(|theirs| theirs == mine))
+        {
             return None;
         }
         if !macs_overlap(self.macs.as_ref(), other.macs.as_ref())
@@ -157,6 +182,7 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             mdns: raw.mdns,
             ssdp,
             wsd: raw.wsd,
+            bidirectional: raw.bidirectional,
         })
     }
 }
@@ -205,9 +231,10 @@ impl TryFrom<RawConfig> for Config {
         for (key, raw_reflector) in raw.reflectors {
             let reflector = Reflector::try_from((key, raw_reflector))?;
             log::debug!(
-                "reflector {}: {} -> {} [{}] family={:?}",
+                "reflector {}: {} {} {} [{}] family={:?}",
                 reflector.name,
                 reflector.source_if,
+                if reflector.bidirectional { "<->" } else { "->" },
                 reflector.target_if,
                 protocol_list(&reflector),
                 reflector.address_family,
@@ -416,6 +443,28 @@ mod tests {
         assert!(!r.mdns);
         assert!(r.wol.is_none());
         assert!(r.ssdp.is_none());
+        assert!(!r.bidirectional);
+    }
+
+    #[test]
+    fn bidirectional_reflector_parses_and_reverses() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.lan]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            bidirectional = true
+            "#,
+        )
+        .unwrap();
+        let r = &cfg.reflectors[0];
+        assert!(r.bidirectional);
+        let reversed = r.reversed();
+        assert_eq!(reversed.source_if, r.target_if);
+        assert_eq!(reversed.target_if, r.source_if);
+        assert_eq!(reversed.name, r.name);
+        assert!(reversed.mdns);
     }
 
     #[test]
@@ -951,6 +1000,51 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn bidirectional_conflicts_with_the_reverse_entry() {
+        // a relays both ways, so b's iot->lan leg duplicates a's second leg.
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            bidirectional = true
+
+            [reflectors.b]
+            source_if = "iot"
+            target_if = "lan"
+            mdns = true
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Mdns,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bidirectional_entries_on_different_pairs_do_not_conflict() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            bidirectional = true
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "guest"
+            mdns = true
+            bidirectional = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.reflectors.len(), 2);
     }
 
     #[test]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -25,6 +25,7 @@ struct PartialReflector {
     ssdp: Option<bool>,
     dial: Option<bool>,
     wsd: Option<bool>,
+    bidirectional: Option<bool>,
     wol_ports: Option<WolPorts>,
     address_family: Option<AddressFamily>,
 }
@@ -61,6 +62,7 @@ impl PartialReflector {
             "ssdp" => put(&mut self.ssdp, env_bool(value, var)?, param, var),
             "dial" => put(&mut self.dial, env_bool(value, var)?, param, var),
             "wsd" => put(&mut self.wsd, env_bool(value, var)?, param, var),
+            "bidirectional" => put(&mut self.bidirectional, env_bool(value, var)?, param, var),
             _ => Err(ConfigError::EnvUnknownParam {
                 var: var.to_owned(),
                 param: param.to_owned(),
@@ -86,6 +88,7 @@ impl PartialReflector {
             ssdp: self.ssdp.unwrap_or(false),
             dial: self.dial.unwrap_or(false),
             wsd: self.wsd.unwrap_or(false),
+            bidirectional: self.bidirectional.unwrap_or(false),
             wol_ports: self.wol_ports,
             address_family: self.address_family.unwrap_or_default(),
         })
@@ -273,6 +276,18 @@ mod tests {
         let r = &cfg.reflectors[0];
         assert!(r.wol.is_some());
         assert!(!r.mdns);
+    }
+
+    #[test]
+    fn env_bidirectional_flag() {
+        let cfg = from_env(&[
+            ("NETFLECTOR_LAN_SOURCE_IF", "lan"),
+            ("NETFLECTOR_LAN_TARGET_IF", "iot"),
+            ("NETFLECTOR_LAN_MDNS", "1"),
+            ("NETFLECTOR_LAN_BIDIRECTIONAL", "true"),
+        ])
+        .unwrap();
+        assert!(cfg.reflectors[0].bidirectional);
     }
 
     #[test]

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -51,6 +51,8 @@ pub(super) struct RawReflector {
     pub(super) dial: bool,
     #[serde(default)]
     pub(super) wsd: bool,
+    #[serde(default)]
+    pub(super) bidirectional: bool,
 }
 
 impl RawConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,14 +115,10 @@ fn reflect(path: Option<&Path>) -> Result<()> {
     let interfaces = open_captures(&config, &mut dispatcher)?;
     for reflector in &config.reflectors {
         log_mtu_info(reflector, &interfaces, &dispatcher);
-        crate::reflector::wol::build(reflector, &interfaces, &mut dispatcher)
-            .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
-        crate::reflector::mdns::build(reflector, &interfaces, &mut dispatcher)
-            .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
-        crate::reflector::ssdp::build(reflector, &interfaces, &mut dispatcher)
-            .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
-        crate::reflector::wsd::build(reflector, &interfaces, &mut dispatcher)
-            .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
+        build_reflector(reflector, &interfaces, &mut dispatcher)?;
+        if reflector.bidirectional {
+            build_reflector(&reflector.reversed(), &interfaces, &mut dispatcher)?;
+        }
     }
 
     if let Some(interval) = config.counter_interval {
@@ -155,6 +151,20 @@ fn reflect(path: Option<&Path>) -> Result<()> {
         memory_report::log_report(); // a final report at shutdown
     }
     log::info!("stopped");
+    Ok(())
+}
+
+/// Register every protocol `reflector` enables, source → target.
+fn build_reflector(
+    reflector: &config::Reflector,
+    interfaces: &InterfaceMap,
+    dispatcher: &mut PacketDispatcher,
+) -> Result<()> {
+    use crate::reflector::{mdns, ssdp, wol, wsd};
+    for build in [wol::build, mdns::build, ssdp::build, wsd::build] {
+        build(reflector, interfaces, dispatcher)
+            .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Increment 2 of the generic-relay work: `bidirectional = true` on a reflector entry (TOML and `NETFLECTOR_<TAG>_BIDIRECTIONAL`, default false) builds the entry a second time with its interfaces swapped, so every enabled protocol relays both ways from one entry. The conflict check treats either leg as a direction the entry owns, so a bidirectional `lan`/`iot` entry and a plain `iot -> lan` one on the same protocol are rejected as duplicates. Safe on one host because of the echo drop (#173); the docs say why two hosts on the same pair must not both be active.

Not included: the OPNsense GUI does not expose the option yet (plugin-tree change with its own version bump).

Testing: `cargo test --lib` green on macOS and Linux (`docker_test.sh`), clippy and doc clean on both; config parse, env and conflict tests added. e2e: the round-trip and DIAL runners take a direction, and every protocol leg gets a case against its one-way direction (WoL, mDNS query and response, SSDP NOTIFY and M-SEARCH round-trip, WSD Hello, Bye and Probe round-trip, DIAL launch and passive), 10 passing, plus 9 forward controls including both interface-recreate variants. The mirrored DIAL config is now one bidirectional entry.
