### PR TITLE
dispatch: re-emit to the egress's directed broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ the periodic reconcile (up to ~30 s).
 
 | Protocol | Port(s) | Group / destination | Relay direction |
 |---|---|---|---|
-| WoL | `wol_ports` (default 7, 9) | `255.255.255.255` (v4) / `ff02::1` (v6) | magic packets source → target |
+| WoL | `wol_ports` (default 7, 9) | the target's directed broadcast or `255.255.255.255` (v4) / `ff02::1` (v6) | magic packets source → target |
 | mDNS | 5353 | `224.0.0.251` / `ff02::fb` | queries source→target, responses target→source |
 | SSDP | 1900 | `239.255.255.250` / `ff02::c` + `ff05::c` | M-SEARCH source→target, NOTIFY target→source |
 | DIAL | 1900 + ephemeral TCP | (uses SSDP discovery) | terminating HTTP reverse proxy (IPv4 only) |
@@ -379,7 +379,10 @@ the periodic reconcile (up to ~30 s).
 
 WoL matching requires the magic-packet sequence (six `0xFF` bytes followed by the target MAC repeated 16
 times) at the start of the UDP payload; trailing bytes such as a SecureOn password are ignored when
-matching and forwarded as-is. mDNS responses include unsolicited announcements (so they flow
+matching and forwarded as-is. A wake sent to the source segment's directed broadcast, or to
+netflector's own address, is re-emitted to the target segment's directed broadcast (to
+`255.255.255.255` while the target's prefix is unknown); one sent to `255.255.255.255` stays a
+limited broadcast. mDNS responses include unsolicited announcements (so they flow
 target→source too); mDNS/SSDP/WSD datagrams are re-emitted verbatim to the same group (mDNS at hop
 limit 255, SSDP at 2, WSD at 1).
 A site-local SSDP group (`ff05::c`) is sourced from a routable address when the interface has one. With

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -132,6 +132,13 @@ def send(args: argparse.Namespace) -> int:
                     sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, mreqn)
             else:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+                if sys.platform.startswith("freebsd14") and args.address == "255.255.255.255":
+                    # FreeBSD 14 puts the interface's directed broadcast on the wire for a send to
+                    # the all-ones address; IP_ONESBCAST keeps 255.255.255.255, as Linux does.
+                    # FreeBSD 15 sends all-ones as such and, with the option set, refuses the send
+                    # with ENETUNREACH. Python exposes no constant for it.
+                    IP_ONESBCAST = 23
+                    sock.setsockopt(socket.IPPROTO_IP, IP_ONESBCAST, 1)
             sock.sendto(payload, (args.address, args.port))
 
     print(f"sent {len(payload)} bytes to {args.address}:{args.port}: {packet_hex(payload)}", flush=True)

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -359,9 +359,16 @@ class TestCase:
     # netflector config file (relative to e2e/) mounted into the netflector container. Most cases share
     # config.toml; a case needing a distinct reflector set (e.g. single-family) names its own.
     config: str = "config.toml"
+    # An explicit destination for the send, overriding the group / link-wide default.
+    send_to: str | None = None
+    # A line netflector must have logged by the time the receiver's verdict is in, e.g. the
+    # destination it re-emitted to.
+    expect_netflector_log: str | None = None
 
     @property
     def send_address(self) -> str:
+        if self.send_to is not None:
+            return self.send_to
         if self.group is not None:
             return self.group
         return IPV6_ALL_NODES if self.family == 6 else "255.255.255.255"
@@ -416,6 +423,27 @@ TEST_CASES = [
         expect_mac=WRONG_MAC,
         timeout_seconds=5.0,
         send_mac=WRONG_MAC,
+    ),
+    # A wake to the source segment's directed broadcast re-emits to the target's own, not the
+    # limited broadcast; one to the limited broadcast stays limited.
+    TestCase(
+        name="reflects_magic_packet_to_directed_broadcast",
+        send_port=ANY_MAC_PORT,
+        receive_port=ANY_MAC_PORT,
+        expect_mac=WRONG_MAC,
+        timeout_seconds=5.0,
+        send_mac=WRONG_MAC,
+        send_to="192.0.2.255",
+        expect_netflector_log=f"to 198.51.100.255:{ANY_MAC_PORT}",
+    ),
+    TestCase(
+        name="reflects_magic_packet_to_limited_broadcast_as_sent",
+        send_port=ANY_MAC_PORT,
+        receive_port=ANY_MAC_PORT,
+        expect_mac=WRONG_MAC,
+        timeout_seconds=5.0,
+        send_mac=WRONG_MAC,
+        expect_netflector_log=f"to 255.255.255.255:{ANY_MAC_PORT}",
     ),
     # The same wake sent target->source, which the one-way entry would drop.
     TestCase(
@@ -2370,6 +2398,8 @@ class CaseRunner:
         if self.case.expect_payload_hex is None and self.case.expect_mac is None:
             self.close_expect_none_window()
         self.wait_for_result()
+        if self.case.expect_netflector_log is not None:
+            self.wait_for_log("netflector", self.case.expect_netflector_log, "netflector log line")
         print(f"PASS {self.case.name}", flush=True)
         if self.args.show_netflector_logs:
             time.sleep(0.5)

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -489,7 +489,12 @@ impl PacketDispatcher {
         ttl: u8,
         payload: &[u8],
     ) -> io::Result<()> {
-        let dst_mac = ethernet_dst(dst.ip()).map_err(io::Error::other)?;
+        let dst_mac = ethernet_dst(
+            dst.ip(),
+            self.egress_addrs(egress)
+                .and_then(InterfaceAddresses::v4_directed_broadcast),
+        )
+        .map_err(io::Error::other)?;
         self.send_udp(egress, dst, dst_mac, src_port, ttl, payload)
     }
 

--- a/src/dispatch/datagram.rs
+++ b/src/dispatch/datagram.rs
@@ -2,7 +2,7 @@
 //! egress's link type, sourcing from the egress's own address. The dispatcher send path's adapter over
 //! [`net::frame`](crate::net::frame).
 
-use std::net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use thiserror::Error;
 
@@ -29,12 +29,18 @@ pub(super) enum DatagramError {
 }
 
 /// The Ethernet destination MAC for an injected datagram to `dst`: the all-ones broadcast
-/// for the IPv4 limited broadcast, the RFC-derived group MAC for any multicast destination.
-/// Only broadcast/multicast destinations are injected here, so a unicast `dst` (whose MAC
-/// we would have to resolve) is a [`DatagramError::UnicastDestination`].
-pub(super) fn ethernet_dst(dst: IpAddr) -> Result<MacAddr, DatagramError> {
+/// for the IPv4 limited broadcast and for the egress's own directed broadcast
+/// (`v4_directed_broadcast`, when its prefix is known), the RFC-derived group MAC for any multicast
+/// destination. Only broadcast/multicast destinations are injected here, so a unicast `dst`
+/// (whose MAC we would have to resolve) is a [`DatagramError::UnicastDestination`].
+pub(super) fn ethernet_dst(
+    dst: IpAddr,
+    v4_directed_broadcast: Option<Ipv4Addr>,
+) -> Result<MacAddr, DatagramError> {
     match dst {
-        IpAddr::V4(v4) if v4.is_broadcast() => Ok(MacAddr::broadcast()),
+        IpAddr::V4(v4) if v4.is_broadcast() || Some(v4) == v4_directed_broadcast => {
+            Ok(MacAddr::broadcast())
+        }
         _ if dst.is_multicast() => Ok(MacAddr::multicast_for(dst)),
         _ => Err(DatagramError::UnicastDestination),
     }
@@ -150,20 +156,37 @@ mod tests {
     #[test]
     fn ethernet_dst_maps_address_classes() {
         assert_eq!(
-            ethernet_dst(IpAddr::V4(Ipv4Addr::BROADCAST)),
+            ethernet_dst(IpAddr::V4(Ipv4Addr::BROADCAST), None),
             Ok(MacAddr::broadcast())
         );
         let v4_group: IpAddr = "224.0.0.251".parse().unwrap();
-        assert_eq!(ethernet_dst(v4_group), Ok(MacAddr::multicast_for(v4_group)));
+        assert_eq!(
+            ethernet_dst(v4_group, None),
+            Ok(MacAddr::multicast_for(v4_group))
+        );
         let v6_group: IpAddr = "ff02::1".parse().unwrap();
-        assert_eq!(ethernet_dst(v6_group), Ok(MacAddr::multicast_for(v6_group)));
+        assert_eq!(
+            ethernet_dst(v6_group, None),
+            Ok(MacAddr::multicast_for(v6_group))
+        );
         // A unicast destination (either family) has no injectable L2 address.
         assert_eq!(
-            ethernet_dst("192.168.0.1".parse().unwrap()),
+            ethernet_dst("192.168.0.1".parse().unwrap(), None),
             Err(DatagramError::UnicastDestination)
         );
         assert_eq!(
-            ethernet_dst("fe80::1".parse().unwrap()),
+            ethernet_dst("fe80::1".parse().unwrap(), None),
+            Err(DatagramError::UnicastDestination)
+        );
+        // The egress's own directed broadcast is a broadcast; any other subnet's is not ours to
+        // resolve.
+        let directed = Ipv4Addr::new(192, 0, 2, 255);
+        assert_eq!(
+            ethernet_dst(IpAddr::V4(directed), Some(directed)),
+            Ok(MacAddr::broadcast())
+        );
+        assert_eq!(
+            ethernet_dst(IpAddr::V4(directed), Some(Ipv4Addr::new(10, 0, 0, 255))),
             Err(DatagramError::UnicastDestination)
         );
     }

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -490,7 +490,7 @@ fn inject(
         addrs,
         injector.link_type(),
         dst,
-        ethernet_dst(dst.ip()).expect("broadcast/multicast destination"),
+        ethernet_dst(dst.ip(), None).expect("broadcast/multicast destination"),
         INJECT_SRC_PORT,
         64,
         payload,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -31,6 +31,7 @@ pub(crate) use self::interface_monitor::{InterfaceEvent, InterfaceMonitor};
 pub(crate) struct InterfaceAddresses {
     mac: Option<MacAddr>,
     v4: Option<Ipv4Addr>,
+    v4_prefix: Option<u8>,
     v6: Option<Ipv6Addr>,
     v6_routable: Option<Ipv6Addr>,
 }
@@ -45,6 +46,16 @@ impl InterfaceAddresses {
     /// [`v6`](Self::v6) it needs no destination argument.
     pub(crate) fn v4(&self) -> Option<Ipv4Addr> {
         self.v4
+    }
+
+    /// The directed broadcast of the v4 address's subnet, when the prefix is known and the subnet
+    /// has one (a /31 or /32 do not).
+    pub(crate) fn v4_directed_broadcast(&self) -> Option<Ipv4Addr> {
+        let (addr, prefix) = (self.v4?, self.v4_prefix?);
+        if prefix > 30 {
+            return None;
+        }
+        Some(Ipv4Addr::from(u32::from(addr) | (u32::MAX >> prefix)))
     }
 
     /// The best v6 source for a destination of `dest_scope`: a link-local source for a link-local
@@ -77,9 +88,10 @@ impl fmt::Display for InterfaceAddresses {
             None => f.write_str("none")?,
         }
         f.write_str(", v4 ")?;
-        match self.v4 {
-            Some(v4) => write!(f, "{v4}")?,
-            None => f.write_str("none")?,
+        match (self.v4, self.v4_prefix) {
+            (Some(v4), Some(prefix)) => write!(f, "{v4}/{prefix}")?,
+            (Some(v4), None) => write!(f, "{v4}")?,
+            (None, _) => f.write_str("none")?,
         }
         f.write_str(", v6 ")?;
         match self.v6 {
@@ -358,10 +370,42 @@ mod tests {
             Self {
                 mac,
                 v4,
+                v4_prefix: None,
                 v6,
                 v6_routable,
             }
         }
+
+        /// The record with its v4 prefix length set.
+        pub(crate) fn with_v4_prefix(mut self, prefix: u8) -> Self {
+            self.v4_prefix = Some(prefix);
+            self
+        }
+    }
+
+    #[test]
+    fn v4_broadcast_needs_a_prefix_short_enough_for_one() {
+        let base = InterfaceAddresses::new(None, Some(Ipv4Addr::new(192, 0, 2, 2)), None, None);
+        assert_eq!(
+            base.v4_directed_broadcast(),
+            None,
+            "no prefix, no broadcast"
+        );
+        assert_eq!(
+            base.with_v4_prefix(24).v4_directed_broadcast(),
+            Some(Ipv4Addr::new(192, 0, 2, 255))
+        );
+        assert_eq!(
+            base.with_v4_prefix(30).v4_directed_broadcast(),
+            Some(Ipv4Addr::new(192, 0, 2, 3))
+        );
+        assert_eq!(
+            base.with_v4_prefix(0).v4_directed_broadcast(),
+            Some(Ipv4Addr::BROADCAST)
+        );
+        // Point-to-point prefixes have no directed broadcast.
+        assert_eq!(base.with_v4_prefix(31).v4_directed_broadcast(), None);
+        assert_eq!(base.with_v4_prefix(32).v4_directed_broadcast(), None);
     }
 
     #[test]

--- a/src/interface/getifaddrs.rs
+++ b/src/interface/getifaddrs.rs
@@ -61,8 +61,16 @@ pub(super) fn resolve(if_name: &str) -> io::Result<(InterfaceAddresses, Option<u
                 // secondary alias and the kernel's enumeration order flip the chosen v4 on unrelated
                 // alias churn, producing a spurious v4 delta that needlessly evicts DIAL proxies.
                 if addrs.v4.is_none() {
-                    log::trace!("{if_name}: v4 {v4}");
+                    // An `AF_INET` entry's netmask, when present, is a `sockaddr_in` like the address.
+                    let prefix = (!ifa.ifa_netmask.is_null())
+                        .then(|| prefix_len(read_v4(ifa.ifa_netmask)))
+                        .flatten();
+                    match prefix {
+                        Some(prefix) => log::trace!("{if_name}: v4 {v4}/{prefix}"),
+                        None => log::trace!("{if_name}: v4 {v4} (no netmask)"),
+                    }
                     addrs.v4 = Some(v4);
+                    addrs.v4_prefix = prefix;
                 } else {
                     log::trace!("{if_name}: v4 {v4} (ignored; already have one)");
                 }
@@ -116,6 +124,13 @@ fn read_v4(addr: *const libc::sockaddr) -> Ipv4Addr {
     let sin = unsafe { ptr::read_unaligned(addr.cast::<libc::sockaddr_in>()) };
     // `s_addr` is in network byte order, i.e. its in-memory bytes *are* the octets.
     Ipv4Addr::from(sin.sin_addr.s_addr.to_ne_bytes())
+}
+
+/// The prefix length a contiguous IPv4 netmask encodes, or `None` for a non-contiguous one.
+fn prefix_len(mask: Ipv4Addr) -> Option<u8> {
+    let bits = u32::from(mask);
+    let ones = bits.leading_ones();
+    (bits.count_ones() == ones).then(|| u8::try_from(ones).expect("at most 32"))
 }
 
 /// The MAC of an `AF_LINK` `sockaddr_dl`, or `None` if the link has none (e.g. loopback).
@@ -272,6 +287,15 @@ mod tests {
             read_mac(buf.as_ptr().cast::<libc::sockaddr>()),
             Some(MacAddr::from(mac))
         );
+    }
+
+    #[test]
+    fn prefix_len_reads_a_contiguous_mask_only() {
+        assert_eq!(prefix_len(Ipv4Addr::new(255, 255, 255, 0)), Some(24));
+        assert_eq!(prefix_len(Ipv4Addr::new(255, 255, 255, 252)), Some(30));
+        assert_eq!(prefix_len(Ipv4Addr::BROADCAST), Some(32));
+        assert_eq!(prefix_len(Ipv4Addr::UNSPECIFIED), Some(0));
+        assert_eq!(prefix_len(Ipv4Addr::new(255, 0, 255, 0)), None);
     }
 
     #[test]

--- a/src/interface/rtnetlink.rs
+++ b/src/interface/rtnetlink.rs
@@ -346,8 +346,9 @@ fn scan_addr(
         } else if addrs.v4.is_some() {
             log::trace!("{if_name}: v4 {v4} (ignored; already have one)");
         } else {
-            log::trace!("{if_name}: v4 {v4}");
+            log::trace!("{if_name}: v4 {v4}/{}", body.ifa_prefixlen);
             addrs.v4 = Some(v4);
+            addrs.v4_prefix = Some(body.ifa_prefixlen);
         }
     } else if let Ok(octets) = <[u8; 16]>::try_from(bytes) {
         let addr = Ipv6Addr::from(octets);
@@ -416,9 +417,20 @@ mod tests {
 
     /// An `RTM_NEWADDR` message: a zeroed nlmsghdr, an ifaddrmsg (family/flags/index), then `attrs`.
     fn addr_msg(family: c_int, index: u32, flags: u8, attrs: &[(u16, &[u8])]) -> Vec<u8> {
+        addr_msg_prefixed(family, index, 0, flags, attrs)
+    }
+
+    /// [`addr_msg`] with the ifaddrmsg's prefix length set.
+    fn addr_msg_prefixed(
+        family: c_int,
+        index: u32,
+        prefixlen: u8,
+        flags: u8,
+        attrs: &[(u16, &[u8])],
+    ) -> Vec<u8> {
         let mut m = vec![0u8; nl_align(size_of::<libc::nlmsghdr>())];
         m.push(u8::try_from(family).unwrap()); // family
-        m.extend_from_slice(&[0, flags, 0]); // prefixlen, flags, scope
+        m.extend_from_slice(&[prefixlen, flags, 0]); // prefixlen, flags, scope
         m.extend_from_slice(&index.to_ne_bytes()); // index
         push_attrs(&mut m, attrs);
         m
@@ -513,6 +525,23 @@ mod tests {
         let mut addrs = InterfaceAddresses::default();
         scan_addr(&msg, "eth0", 5, &mut addrs, &mut V6Pick::default());
         assert_eq!(addrs.v4, Some(Ipv4Addr::new(10, 0, 0, 1)));
+    }
+
+    #[test]
+    fn scan_addr_records_the_v4_prefix() {
+        let msg = addr_msg_prefixed(
+            libc::AF_INET,
+            5,
+            24,
+            0,
+            &[(libc::IFA_ADDRESS, &[192, 0, 2, 2])],
+        );
+        let mut addrs = InterfaceAddresses::default();
+        scan_addr(&msg, "eth0", 5, &mut addrs, &mut V6Pick::default());
+        assert_eq!(
+            addrs.v4_directed_broadcast(),
+            Some(Ipv4Addr::new(192, 0, 2, 255))
+        );
     }
 
     #[test]

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -12,6 +12,7 @@
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::dispatch::{CaptureKey, Outcome, PacketDispatcher, PacketHandler};
+use crate::interface::InterfaceAddresses;
 use crate::logging::log_rate;
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
@@ -166,7 +167,12 @@ impl<C: Classify> PacketHandler for SimpleReflector<C> {
             }
         };
 
-        let dest = link_destination(packet.dest);
+        let dest = link_destination(
+            packet.dest,
+            dispatcher
+                .egress_addrs(self.egress)
+                .and_then(InterfaceAddresses::v4_directed_broadcast),
+        );
 
         // A family the egress can't currently source is a quiet, transient drop (address
         // loss): a Stalled, not a genuine send failure.
@@ -232,19 +238,19 @@ impl<C: Classify> PacketHandler for SimpleReflector<C> {
 /// IPv6 link-local all-nodes group (`ff02::1`), the v6 equivalent of the IPv4 limited broadcast.
 const V6_ALL_NODES: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
 
-/// Where a re-emit of a packet captured to `dest` goes: a multicast group re-emits to itself (the
-/// dispatcher's filter pinned it); anything else, a limited or directed broadcast or a unicast wake
-/// aimed at this host, goes link-wide on the egress at the captured port, the IPv4 limited
-/// broadcast or the IPv6 all-nodes group.
-fn link_destination(dest: SocketAddr) -> SocketAddr {
+/// Where a re-emit of a packet captured to `dest` goes, at the captured port: a multicast group
+/// (the dispatcher's filter pinned it) and the IPv4 limited broadcast re-emit to themselves; any
+/// other IPv4 destination, a directed broadcast or a unicast wake aimed at this host, goes to the
+/// egress's own directed broadcast, or the limited broadcast while its prefix is unknown; any other
+/// IPv6 destination goes to the all-nodes group.
+fn link_destination(dest: SocketAddr, directed_broadcast: Option<Ipv4Addr>) -> SocketAddr {
     match dest {
-        SocketAddr::V4(v4) if !v4.ip().is_multicast() => {
-            SocketAddr::from((Ipv4Addr::BROADCAST, v4.port()))
+        SocketAddr::V4(v4) if v4.ip().is_multicast() || v4.ip().is_broadcast() => dest,
+        SocketAddr::V4(v4) => {
+            SocketAddr::from((directed_broadcast.unwrap_or(Ipv4Addr::BROADCAST), v4.port()))
         }
-        SocketAddr::V6(v6) if !v6.ip().is_multicast() => {
-            SocketAddr::from((V6_ALL_NODES, v6.port()))
-        }
-        group => group,
+        SocketAddr::V6(v6) if v6.ip().is_multicast() => dest,
+        SocketAddr::V6(v6) => SocketAddr::from((V6_ALL_NODES, v6.port())),
     }
 }
 
@@ -330,20 +336,31 @@ mod tests {
     #[test]
     fn link_destination_keeps_groups_and_broadcasts_the_rest() {
         let dest = |s: &str| s.parse::<SocketAddr>().unwrap();
-        assert_eq!(
-            dest("224.0.0.251:5353"),
-            link_destination(dest("224.0.0.251:5353"))
-        );
-        assert_eq!(
-            dest("[ff02::fb]:5353"),
-            link_destination(dest("[ff02::fb]:5353"))
-        );
-        // Limited and directed broadcasts, and a unicast wake aimed at this host, go link-wide at
-        // the captured port.
-        for captured in ["255.255.255.255:9", "10.0.0.255:9", "10.0.0.2:9"] {
-            assert_eq!(dest("255.255.255.255:9"), link_destination(dest(captured)));
+        let egress = Some(Ipv4Addr::new(192, 0, 2, 255));
+        for group in ["224.0.0.251:5353", "[ff02::fb]:5353"] {
+            assert_eq!(dest(group), link_destination(dest(group), egress));
         }
-        assert_eq!(dest("[ff02::1]:9"), link_destination(dest("[fe80::2]:9")));
+        // The limited broadcast stays limited; a directed broadcast or a unicast wake aimed at
+        // this host goes to the egress's own directed broadcast, at the captured port.
+        assert_eq!(
+            dest("255.255.255.255:9"),
+            link_destination(dest("255.255.255.255:9"), egress)
+        );
+        for captured in ["10.0.0.255:9", "10.0.0.2:9"] {
+            assert_eq!(
+                dest("192.0.2.255:9"),
+                link_destination(dest(captured), egress)
+            );
+            // Without the egress prefix, link-wide still means the limited broadcast.
+            assert_eq!(
+                dest("255.255.255.255:9"),
+                link_destination(dest(captured), None)
+            );
+        }
+        assert_eq!(
+            dest("[ff02::1]:9"),
+            link_destination(dest("[fe80::2]:9"), egress)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Increment 3 of the generic-relay work: the interface table records each IPv4 address's prefix length (`ifa_netmask` on BSD, converted only when contiguous; `ifa_prefixlen` from the netlink address message on Linux), and re-emits mirror a directed broadcast onto the egress's own. A wake sent to the source segment's directed broadcast, or to netflector's own address, now leaves as the target segment's directed broadcast instead of `255.255.255.255`; the limited broadcast stays limited, and so does everything sent to a multicast group. Without a known prefix the limited broadcast remains the fallback. The datagram builder accepts the egress's directed broadcast as a broadcast MAC and still refuses any other subnet's.

Testing: `cargo test --lib` green on macOS and Linux (`docker_test.sh`), clippy and doc clean on both. Unit tests cover the broadcast derivation across /0, /24, /30, /31 and /32, mask-to-prefix conversion with a non-contiguous rejection, the netlink prefix, the MAC derivation, and the destination mapping with and without a prefix. e2e: two new WoL cases assert the re-emitted destination through netflector's log line, `192.0.2.255 -> 198.51.100.255` and `255.255.255.255` unchanged, alongside the existing WoL, mDNS, SSDP, WSD, M-SEARCH round-trip and mirrored DIAL cases, 15 passing.
