### PR TITLE
Transparent UDP relay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,10 +424,13 @@ jobs:
         run: |
           triple='${{ matrix.target.triple }}'
           cargo build --release --locked ${triple:+--target "$triple"}
+      # qemu-user has no MCAST_JOIN_GROUP; the veth fabric delivers the groups' frames to the
+      # capture without a membership, so the emulated lanes run the daemon with --no-join.
       - name: Run e2e natively
         run: |
           triple='${{ matrix.target.triple }}'
-          sudo python3 e2e/run.py --backend native --binary "target/${triple:+$triple/}release/netflector"
+          sudo python3 e2e/run.py --backend native --binary "target/${triple:+$triple/}release/netflector" \
+            ${{ matrix.target.emulated && '--no-join' || '' }}
 
   # The unit suite under Miri, for every shipped target. Valgrind (below) catches accesses that are
   # actually invalid; it is blind to UB that performs no invalid access -- an unaligned read the hardware

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "netflector"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netflector"
-version = "0.15.3"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.93"
 license = "BSD-2-Clause"

--- a/README.md
+++ b/README.md
@@ -467,10 +467,11 @@ failure) is forwarded unchanged and logged, leaving on-subnet discovery unaffect
 `udp_ports` turns an entry into a transparent relay for any other UDP discovery a device or app does
 by multicast or broadcast. A datagram captured on `source_if` to one of the ports, sent to a group in
 `udp_groups` or, with `udp_broadcast = true`, to a broadcast, is re-emitted on `target_if` exactly as
-sent: same payload, same source address and port, same TTL. A group goes to the same group
-(netflector joins it on `source_if`), the source segment's directed broadcast to the target segment's
-own, and `255.255.255.255` stays `255.255.255.255`. Nothing is parsed, so nothing is proxied: replies
-are the receiver's business.
+sent: same payload, same source address and port, same TTL. A group goes to the same group, which
+netflector joins on `source_if`. A directed broadcast of any subnet on the source segment (on a link
+without MAC addresses, of its first subnet) goes to the target segment's directed broadcast of its
+first subnet. `255.255.255.255` stays `255.255.255.255`. Nothing is parsed, so nothing is proxied:
+replies are the receiver's business.
 
 That is the point of keeping the source. A device on the target segment answers a relayed query by
 unicast to the address it came from, on the other segment, and the firewall routes that reply like

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ talk to each other sit on different L2 segments that don't forward each other's 
 multicasts. The classic case: a router with a wired LAN on one side and a Wi-Fi or IoT VLAN on the
 other, where a phone on Wi-Fi can't discover or cast to a TV on the LAN.
 
-It reflects four link-local protocols, layers an optional DIAL proxy on top of SSDP, and relays any
-other UDP discovery protocol as sent:
+It reflects four link-local protocols, adds an optional DIAL proxy on top of SSDP, and can relay any
+other UDP discovery protocol unchanged:
 
 - **Wake-on-LAN**: magic packets sent on one interface are re-emitted on another, so a sender can
   wake a host on a different segment.
@@ -20,13 +20,13 @@ other UDP discovery protocol as sent:
   `dial = true` on an SSDP entry; see [DIAL](#dial).
 - **WS-Discovery (WSD)**: SOAP-over-UDP discovery is relayed both ways, so a client on one segment can
   discover ONVIF cameras or Windows devices (printers, scanners) on the other.
-- **UDP relay**: datagrams to configured ports, sent to configured multicast groups or, optionally,
-  broadcast, cross unchanged, source address and port included, so a protocol netflector does not
-  know (Roon's SOOD, Syncthing's local discovery) works across segments too; see
+- **UDP relay**: datagrams to the configured ports and multicast groups (and broadcasts, if enabled)
+  are copied to the other segment unchanged, source address and port included. This covers
+  protocols netflector knows nothing about, such as Roon's SOOD or Syncthing's local discovery. See
   [UDP relay](#udp-relay).
 
-Each named entry bridges one `source_if` → `target_if` interface pair and enables one or more of the
-four reflected protocols and the relay, in any mix; the DIAL proxy then layers onto SSDP.
+Each named entry bridges one `source_if` → `target_if` interface pair and enables any mix of the four
+reflected protocols and the relay; the DIAL proxy layers onto SSDP.
 
 ## Contents
 
@@ -259,7 +259,7 @@ wsd       = true                 # optional; enable WS-Discovery reflection (def
 wol_ports = [7, 9]               # optional; WoL UDP ports (default [7, 9]); only valid when wol = true
 address_family = "default"       # optional; default | dual | ipv4 | ipv6 (default "default")
 bidirectional = false            # optional; also relay every enabled protocol target -> source (default false)
-udp_ports = [9003]               # optional; UDP ports to relay as sent (see UDP relay); needs udp_groups or udp_broadcast
+udp_ports = [9003]               # optional; UDP ports to relay unchanged (see UDP relay); needs udp_groups or udp_broadcast
 udp_groups = ["239.255.90.90"]   # optional; multicast groups to join and relay on those ports
 udp_broadcast = true             # optional; also relay broadcasts on those ports (default false); needs IPv4
 ```
@@ -332,8 +332,7 @@ devices:
   `macs` at startup when the target link carries no MAC addresses (a BSD `DLT_NULL` link such as a
   loopback or an L3 tunnel) - it could never match. WoL is unaffected: it matches the MAC inside the
   magic packet's payload.
-- **The UDP relay** ignores the allow-set and carries every device's datagrams, so an entry enabling
-  only the relay may not set `macs`.
+- **The UDP relay** ignores the allow-set. An entry with only the relay enabled may not set `macs`.
 
 Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP/WSD relay
 every device's traffic rather than a chosen set (only the message kinds the corresponding direction
@@ -387,7 +386,7 @@ the periodic reconcile (up to ~30 s).
 | SSDP | 1900 | `239.255.255.250` / `ff02::c` + `ff05::c` | M-SEARCH source→target, NOTIFY target→source |
 | DIAL | 1900 + ephemeral TCP | (uses SSDP discovery) | terminating HTTP reverse proxy (IPv4 only) |
 | WSD | 3702 | `239.255.255.250` / `ff02::c` | Probe/Resolve source→target, Hello/Bye target→source |
-| UDP relay | `udp_ports` | `udp_groups`, broadcasts with `udp_broadcast` | everything source→target, as sent |
+| UDP relay | `udp_ports` | `udp_groups`, plus broadcasts if `udp_broadcast` | everything source→target, unchanged |
 
 WoL matching requires the magic-packet sequence (six `0xFF` bytes followed by the target MAC repeated 16
 times) at the start of the UDP payload; trailing bytes such as a SecureOn password are ignored when
@@ -464,25 +463,25 @@ failure) is forwarded unchanged and logged, leaving on-subnet discovery unaffect
 
 ### UDP relay
 
-`udp_ports` turns an entry into a transparent relay for any other UDP discovery a device or app does
-by multicast or broadcast. A datagram captured on `source_if` to one of the ports, sent to a group in
-`udp_groups` or, with `udp_broadcast = true`, to a broadcast, is re-emitted on `target_if` exactly as
-sent: same payload, same source address and port, same TTL. A group goes to the same group, which
-netflector joins on `source_if`. A directed broadcast of any subnet on the source segment (on a link
-without MAC addresses, of its first subnet) goes to the target segment's directed broadcast of its
-first subnet. `255.255.255.255` stays `255.255.255.255`. Nothing is parsed, so nothing is proxied:
-replies are the receiver's business.
+`udp_ports` turns an entry into a transparent relay for UDP discovery protocols netflector does not
+implement. A datagram that arrives on `source_if` for one of these ports is copied to `target_if`
+unchanged, with the original payload, source address, source port and TTL, if it was sent to a
+group listed in `udp_groups` or, with `udp_broadcast = true`, to a broadcast. Group datagrams go to
+the same group; netflector joins it on `source_if`. A directed broadcast goes to the target
+segment's directed broadcast (that of its first subnet). `255.255.255.255` stays
+`255.255.255.255`. On a link without MAC addresses only the interface's first subnet broadcast is
+recognized as one. Nothing is parsed and nothing is proxied.
 
-That is the point of keeping the source. A device on the target segment answers a relayed query by
-unicast to the address it came from, on the other segment, and the firewall routes that reply like
-any other packet. Allow it there: the reply is a new flow from the target segment to the source one,
-which no state from the multicast query covers. Two things follow from the source being off-subnet
-on the receiving segment: a host with strict reverse-path filtering (`rp_filter = 1` on Linux) drops
-the datagram, and a link-local IPv6 source is meaningless on the other link, so relay IPv6 only for
-protocols that use routable addresses.
+Keeping the source address is what makes replies work. A device on the target segment answers a
+query by unicast to the sender's address on the source segment, and that reply is routed like any
+other packet. The firewall has to allow it: it is a new flow from the target segment to the source
+segment, not a reply to a state the multicast query created. Two caveats follow from the source
+address being foreign to the receiving segment. A host with strict reverse path filtering
+(`rp_filter = 1` on Linux) drops the datagram. A link-local IPv6 source means nothing on the other
+link, so relay IPv6 only for protocols that use routable addresses.
 
-Roon, whose SOOD discovery queries `239.255.90.90` and the subnet broadcast on UDP 9003 from
-servers and endpoints alike, is the canonical recipe:
+The typical use is Roon. Its SOOD discovery sends to `239.255.90.90` and to the subnet broadcast on
+UDP 9003, from servers and endpoints alike:
 
 ```toml
 [reflectors.roon]
@@ -494,9 +493,11 @@ udp_broadcast = true
 bidirectional = true
 ```
 
-The relay ignores `macs` (a datagram to a group or a broadcast has no device to select) and admits
-every datagram it captures, so it may not overlap a protocol relaying the same ones; see
-[duplicate detection](#duplicate-detection). Its counters report as `UDP relay`.
+The relay ignores `macs`: a datagram to a group or a broadcast has no single target device. It admits
+every datagram it captures, so it must not overlap a protocol that relays the same datagrams; see
+[duplicate detection](#duplicate-detection). Its counters are reported as `UDP relay`. A group that
+cannot be joined on `source_if` is a startup error, as it is for the discovery protocols. The system
+limits memberships per interface: `net.ipv4.igmp_max_memberships` on Linux, 20 by default.
 
 ### Duplicate detection
 
@@ -504,16 +505,16 @@ Entry names must be unique across the file and the environment: a name that appe
 same name from both sources) is rejected at startup. Beyond that, two entries that enable the same
 protocol are rejected as a duplicate of that protocol only when they could reflect the same packet
 twice: a shared direction, overlapping MAC selection, overlapping address-family handling, and, for
-WoL, at least one shared port. The UDP relay admits every datagram it captures, so it duplicates a
-protocol (of another entry or its own) when both capture the same datagrams on the same leg: a shared
-port with a shared group or with broadcasts on both sides, or any shared port against WoL, which
-captures every destination on its ports. mDNS, SSDP and WSD capture on both interfaces whatever the
-entry's direction (queries on `source_if`, responses on `target_if`), so a relay on their group
-conflicts with them either way round, and since the relay ignores `macs` and queries admit every
-sender, a MAC selection never separates the two. A relay on 5353 listing `224.0.0.251` beside an
-mDNS entry is rejected as mDNS, a
-broadcast-only relay on 5353 is not, and neither is WoL on 1900 beside SSDP, since each of those
-admits only its own messages. An entry's directions are its
+WoL, at least one shared port. The UDP relay is different. It admits every datagram it captures, so it
+conflicts with any protocol, in another entry or in its own, that captures the same datagrams on the
+same leg: a shared port together with a shared group or with broadcasts on both sides, or any shared
+port with WoL, which captures every destination on its ports. mDNS, SSDP and WSD capture on both
+interfaces regardless of the entry's direction, queries on `source_if` and responses on `target_if`,
+so a relay on one of their groups conflicts with them in either direction. `macs` does not help
+here: queries are accepted from any sender and the relay ignores the list. Examples: a relay on 5353
+with group `224.0.0.251` next to an mDNS entry is rejected as a duplicate of mDNS; a broadcast-only
+relay on 5353 is fine; WoL on port 1900 next to SSDP is fine too, because each of them accepts only
+its own messages. An entry's directions are its
 `source_if` → `target_if`, plus the reverse when it is `bidirectional`, so a bidirectional `lan`/`iot`
 entry and a plain `iot` → `lan` one duplicate each other. MAC selection overlaps when the entries' allow-sets
 share at least one device, or when either omits its MAC filter (any device). Address-family handling overlaps when both can

--- a/README.md
+++ b/README.md
@@ -495,7 +495,8 @@ bidirectional = true
 
 The relay ignores `macs`: a datagram to a group or a broadcast has no single target device. It admits
 every datagram it captures, so it must not overlap a protocol that relays the same datagrams; see
-[duplicate detection](#duplicate-detection). Its counters are reported as `UDP relay`. A group that
+[duplicate detection](#duplicate-detection). Its counters are reported as `UDP relay`, except that a
+datagram a discovery protocol on the same interface also handles counts under that protocol. A group that
 cannot be joined on `source_if` is a startup error, as it is for the discovery protocols. The system
 limits memberships per interface: `net.ipv4.igmp_max_memberships` on Linux, 20 by default.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ talk to each other sit on different L2 segments that don't forward each other's 
 multicasts. The classic case: a router with a wired LAN on one side and a Wi-Fi or IoT VLAN on the
 other, where a phone on Wi-Fi can't discover or cast to a TV on the LAN.
 
-It reflects four link-local protocols and layers an optional DIAL proxy on top of SSDP:
+It reflects four link-local protocols, layers an optional DIAL proxy on top of SSDP, and relays any
+other UDP discovery protocol as sent:
 
 - **Wake-on-LAN**: magic packets sent on one interface are re-emitted on another, so a sender can
   wake a host on a different segment.
@@ -19,15 +20,19 @@ It reflects four link-local protocols and layers an optional DIAL proxy on top o
   `dial = true` on an SSDP entry; see [DIAL](#dial).
 - **WS-Discovery (WSD)**: SOAP-over-UDP discovery is relayed both ways, so a client on one segment can
   discover ONVIF cameras or Windows devices (printers, scanners) on the other.
+- **UDP relay**: datagrams to configured ports, sent to configured multicast groups or, optionally,
+  broadcast, cross unchanged, source address and port included, so a protocol netflector does not
+  know (Roon's SOOD, Syncthing's local discovery) works across segments too; see
+  [UDP relay](#udp-relay).
 
 Each named entry bridges one `source_if` → `target_if` interface pair and enables one or more of the
-four reflected protocols, in any mix; the DIAL proxy then layers onto SSDP.
+four reflected protocols and the relay, in any mix; the DIAL proxy then layers onto SSDP.
 
 ## Contents
 
 - [Platform support](#platform-support)
 - [Run](#run): [privileges](#runtime-privileges), [Docker](#run-in-docker), [MikroTik](#on-mikrotik-routeros), [FreeBSD/OPNsense packages](#install-on-freebsd-and-opnsense)
-- [Configuration](#configuration): [env vars](#environment-variables), [`macs`](#the-macs-field), [`address_family`](#address_family), [per-protocol behavior](#per-protocol-behavior), [DIAL](#dial), [duplicate detection](#duplicate-detection)
+- [Configuration](#configuration): [env vars](#environment-variables), [`macs`](#the-macs-field), [`address_family`](#address_family), [per-protocol behavior](#per-protocol-behavior), [DIAL](#dial), [UDP relay](#udp-relay), [duplicate detection](#duplicate-detection)
 - [Diagnostics](#diagnostics)
 - [Developing](#developing)
 - [License](#license)
@@ -382,6 +387,7 @@ the periodic reconcile (up to ~30 s).
 | SSDP | 1900 | `239.255.255.250` / `ff02::c` + `ff05::c` | M-SEARCH source→target, NOTIFY target→source |
 | DIAL | 1900 + ephemeral TCP | (uses SSDP discovery) | terminating HTTP reverse proxy (IPv4 only) |
 | WSD | 3702 | `239.255.255.250` / `ff02::c` | Probe/Resolve source→target, Hello/Bye target→source |
+| UDP relay | `udp_ports` | `udp_groups`, broadcasts with `udp_broadcast` | everything source→target, as sent |
 
 WoL matching requires the magic-packet sequence (six `0xFF` bytes followed by the target MAC repeated 16
 times) at the start of the UDP payload; trailing bytes such as a SecureOn password are ignored when
@@ -455,6 +461,41 @@ address); an `ipv6`-only entry with `dial = true` is rejected at startup. It is 
 every cap and timeout is a fixed constant. The proxy degrades benignly: a `LOCATION`/`Application-URL`
 netflector can't rewrite (an `https` URL, a hostname instead of an IPv4 literal, a listener cap/bind
 failure) is forwarded unchanged and logged, leaving on-subnet discovery unaffected.
+
+### UDP relay
+
+`udp_ports` turns an entry into a transparent relay for any other UDP discovery a device or app does
+by multicast or broadcast. A datagram captured on `source_if` to one of the ports, sent to a group in
+`udp_groups` or, with `udp_broadcast = true`, to a broadcast, is re-emitted on `target_if` exactly as
+sent: same payload, same source address and port, same TTL. A group goes to the same group
+(netflector joins it on `source_if`), the source segment's directed broadcast to the target segment's
+own, and `255.255.255.255` stays `255.255.255.255`. Nothing is parsed, so nothing is proxied: replies
+are the receiver's business.
+
+That is the point of keeping the source. A device on the target segment answers a relayed query by
+unicast to the address it came from, on the other segment, and the firewall routes that reply like
+any other packet. Allow it there: the reply is a new flow from the target segment to the source one,
+which no state from the multicast query covers. Two things follow from the source being off-subnet
+on the receiving segment: a host with strict reverse-path filtering (`rp_filter = 1` on Linux) drops
+the datagram, and a link-local IPv6 source is meaningless on the other link, so relay IPv6 only for
+protocols that use routable addresses.
+
+Roon, whose SOOD discovery queries `239.255.90.90` and the subnet broadcast on UDP 9003 from
+servers and endpoints alike, is the canonical recipe:
+
+```toml
+[reflectors.roon]
+source_if = "lan"
+target_if = "iot"
+udp_ports = [9003]
+udp_groups = ["239.255.90.90"]
+udp_broadcast = true
+bidirectional = true
+```
+
+The relay ignores `macs` (a datagram to a group or a broadcast has no device to select) and admits
+every datagram it captures, so it may not overlap a protocol relaying the same ones; see
+[duplicate detection](#duplicate-detection). Its counters report as `UDP relay`.
 
 ### Duplicate detection
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pinned in `ci/freebsd14.env` and running on that release or newer.
 ## Run
 
 ```sh
-netflector [--check-config] [--] [config.toml]
+netflector [--check-config] [--no-join] [--] [config.toml]
 ```
 
 Configuration comes from a TOML file, from environment variables, or from both. With a path argument
@@ -69,6 +69,7 @@ volumes.
 | Option | |
 | --- | --- |
 | `--check-config` | Load and validate the configuration, print a summary, exit. |
+| `--no-join` | Do not join multicast groups. Group traffic then reaches netflector only where the link delivers it without a membership, as an emulated or promiscuous fabric does. A warning is logged at startup. |
 | `-V`, `--version` | Print the version and exit. |
 | `-h`, `--help` | Print the usage and exit. |
 | `--` | End of options. Needed only for a config file whose name begins with a dash. |

--- a/README.md
+++ b/README.md
@@ -254,10 +254,13 @@ wsd       = true                 # optional; enable WS-Discovery reflection (def
 wol_ports = [7, 9]               # optional; WoL UDP ports (default [7, 9]); only valid when wol = true
 address_family = "default"       # optional; default | dual | ipv4 | ipv6 (default "default")
 bidirectional = false            # optional; also relay every enabled protocol target -> source (default false)
+udp_ports = [9003]               # optional; UDP ports to relay as sent (see UDP relay); needs udp_groups or udp_broadcast
+udp_groups = ["239.255.90.90"]   # optional; multicast groups to join and relay on those ports
+udp_broadcast = true             # optional; also relay broadcasts on those ports (default false); needs IPv4
 ```
 
-An entry must enable at least one protocol and expands into one reflector per enabled protocol, all
-sharing the entry's interfaces, MAC selection, and `address_family`. The same shape serves one or a few
+An entry must enable at least one protocol or set `udp_ports`, and expands into one reflector per
+enabled protocol, all sharing the entry's interfaces, MAC selection, and `address_family`. The same shape serves one or a few
 specific devices (set `macs`) or a whole network (omit it). No IP addresses ever appear in the config.
 `dial` is not a separate reflector; it augments the entry's SSDP reflector with the DIAL application
 proxy (so it requires `ssdp`; see [DIAL](#dial)).
@@ -278,11 +281,12 @@ then optional; with none, the environment is the whole configuration. Variables 
 - `<TAG>` ties one entry's parameters together: any alphanumeric string (`1`, `2`, `TV`, …). It also
   becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
 - `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
-  `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`, `BIDIRECTIONAL`), case-insensitive.
+  `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`, `BIDIRECTIONAL`, `UDP_PORTS`,
+  `UDP_GROUPS`, `UDP_BROADCAST`), case-insensitive.
 
 The globals are `NETFLECTOR_LOG_LEVEL`, `NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
 `NETFLECTOR_COUNTERS_INTERVAL_SECS`, so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are
-`true`/`false` or `1`/`0`; `WOL_PORTS`
+`true`/`false` or `1`/`0`; `WOL_PORTS`, `UDP_PORTS`, `UDP_GROUPS`
 and `MACS` are comma-separated (`7,9` / `B0:...,C4:...`). The `[reflectors.tv]` entry above looks like
 this in the environment:
 
@@ -323,6 +327,8 @@ devices:
   `macs` at startup when the target link carries no MAC addresses (a BSD `DLT_NULL` link such as a
   loopback or an L3 tunnel) - it could never match. WoL is unaffected: it matches the MAC inside the
   magic packet's payload.
+- **The UDP relay** ignores the allow-set and carries every device's datagrams, so an entry enabling
+  only the relay may not set `macs`.
 
 Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP/WSD relay
 every device's traffic rather than a chosen set (only the message kinds the corresponding direction
@@ -456,9 +462,18 @@ Entry names must be unique across the file and the environment: a name that appe
 same name from both sources) is rejected at startup. Beyond that, two entries that enable the same
 protocol are rejected as a duplicate of that protocol only when they could reflect the same packet
 twice: a shared direction, overlapping MAC selection, overlapping address-family handling, and, for
-WoL, at least one shared port. An entry's directions are its `source_if` → `target_if`, plus the reverse
-when it is `bidirectional`, so a bidirectional `lan`/`iot` entry and a plain `iot` → `lan` one duplicate
-each other. MAC selection overlaps when the entries' allow-sets
+WoL, at least one shared port. The UDP relay admits every datagram it captures, so it duplicates a
+protocol (of another entry or its own) when both capture the same datagrams on the same leg: a shared
+port with a shared group or with broadcasts on both sides, or any shared port against WoL, which
+captures every destination on its ports. mDNS, SSDP and WSD capture on both interfaces whatever the
+entry's direction (queries on `source_if`, responses on `target_if`), so a relay on their group
+conflicts with them either way round, and since the relay ignores `macs` and queries admit every
+sender, a MAC selection never separates the two. A relay on 5353 listing `224.0.0.251` beside an
+mDNS entry is rejected as mDNS, a
+broadcast-only relay on 5353 is not, and neither is WoL on 1900 beside SSDP, since each of those
+admits only its own messages. An entry's directions are its
+`source_if` → `target_if`, plus the reverse when it is `bidirectional`, so a bidirectional `lan`/`iot`
+entry and a plain `iot` → `lan` one duplicate each other. MAC selection overlaps when the entries' allow-sets
 share at least one device, or when either omits its MAC filter (any device). Address-family handling overlaps when both can
 handle the same IP version: an `ipv4`-only and an `ipv6`-only entry never overlap, while `default`/`dual`
 overlap with either. Entries that differ in interface, MAC, address family (or WoL ports), or that

--- a/e2e/config-relay.toml
+++ b/e2e/config-relay.toml
@@ -1,0 +1,17 @@
+log_level = "debug"
+
+# The transparent relay in the Roon shape: one port, its group, the broadcasts, both ways. The
+# one-way entry on the next port proves the reverse direction is a choice, not a given.
+[reflectors.relay]
+source_if = "nf_source"
+target_if = "nf_target"
+udp_ports = [9003]
+udp_groups = ["239.255.90.90", "ff02::5a5a"]
+udp_broadcast = true
+bidirectional = true
+
+[reflectors.relay-one-way]
+source_if = "nf_source"
+target_if = "nf_target"
+udp_ports = [9004]
+udp_groups = ["239.255.90.90"]

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -19,6 +19,7 @@ import argparse
 import binascii
 import errno
 import http.server
+import ipaddress
 import signal
 import socket
 import struct
@@ -115,6 +116,8 @@ def send(args: argparse.Namespace) -> int:
 
     if is_ipv6(args.address):
         with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
+            if args.source_port is not None:
+                sock.bind(("::", args.source_port))
             scope_id = 0
             if args.interface:
                 scope_id = socket.if_nametoindex(args.interface)
@@ -124,6 +127,8 @@ def send(args: argparse.Namespace) -> int:
             sock.sendto(payload, (args.address, args.port, 0, scope_id))
     else:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
+            if args.source_port is not None:
+                sock.bind(("0.0.0.0", args.source_port))
             if is_ipv4_multicast(args.address):
                 sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
                 if args.interface:
@@ -202,6 +207,8 @@ def _receive(args, expected, deadline, family, bind_address) -> int:
                 return 1
 
             if payload == expected:
+                if not source_as_expected(args, peer):
+                    return 1
                 if args.expect_source_not_link_local and peer[0].lower().startswith("fe80"):
                     print(
                         f"forwarded from link-local source {peer[0]}; expected a routable (non-fe80::) address",
@@ -224,6 +231,19 @@ def _receive(args, expected, deadline, family, bind_address) -> int:
 
     print(f"timed out waiting for expected packet after {args.timeout:.3f}s", file=sys.stderr, flush=True)
     return 1
+
+
+def source_as_expected(args: argparse.Namespace, peer: tuple) -> bool:
+    # The relay keeps the sender's own ip:port on the re-emit, so the receiver sees a peer from the
+    # other segment at the port the sender bound, not netflector's egress address.
+    address = ipaddress.ip_address(peer[0].split("%")[0])
+    if args.expect_source_net is not None and address not in ipaddress.ip_network(args.expect_source_net):
+        print(f"received from {peer[0]}; expected a source in {args.expect_source_net}", file=sys.stderr, flush=True)
+        return False
+    if args.expect_source_port is not None and peer[1] != args.expect_source_port:
+        print(f"received from port {peer[1]}; expected {args.expect_source_port}", file=sys.stderr, flush=True)
+        return False
+    return True
 
 
 def drain_for_duplicate(sock: socket.socket, expected: bytes) -> int:
@@ -731,6 +751,7 @@ def main() -> int:
     send_parser.add_argument("--port", required=True, type=int, help="destination UDP port")
     send_parser.add_argument("--address", default="255.255.255.255", help="destination IP address")
     send_parser.add_argument("--interface", help="egress interface (IPv6 link-local scope)")
+    send_parser.add_argument("--source-port", type=int, help="UDP port to send from")
     send_parser.set_defaults(func=send)
 
     receive_parser = subparsers.add_parser("receive", help="receive or reject UDP packets")
@@ -744,6 +765,8 @@ def main() -> int:
     expectation.add_argument("--expect-mac", help="MAC address whose magic packet must be received")
     expectation.add_argument("--expect-payload-hex", type=parse_payload_hex, help="exact UDP payload that must be received")
     expectation.add_argument("--expect-none", action="store_true", help="fail if any UDP packet is received")
+    receive_parser.add_argument("--expect-source-net", help="network the packet's source address must be in")
+    receive_parser.add_argument("--expect-source-port", type=int, help="port the packet's source must be")
     receive_parser.add_argument("--expect-source-not-link-local", action="store_true",
                                 help="also require the matched packet's source to be a routable (non-fe80::) address")
     receive_parser.set_defaults(func=receive)

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -1896,6 +1896,10 @@ class NativeBackend(Backend):
     def _netflector_command(self, config_path: Path) -> list[str]:
         raise NotImplementedError
 
+    def _netflector_args(self, config_path: Path) -> list[str]:
+        flags = ["--no-join"] if self.args.no_join else []
+        return [str(self.args.binary), *flags, str(config_path)]
+
     def _teardown_fabric(self) -> None:
         raise NotImplementedError
 
@@ -2123,7 +2127,7 @@ class NativeLinuxBackend(NativeBackend):
         return ["ip", "netns", "exec", self.ns[segment]]
 
     def _netflector_command(self, config_path: Path) -> list[str]:
-        return ["ip", "netns", "exec", self.ns["dut"], str(self.args.binary), str(config_path)]
+        return ["ip", "netns", "exec", self.ns["dut"], *self._netflector_args(config_path)]
 
     def admin(self, script: str, *, capture: bool = False) -> str:
         # The harness already runs as root, so netflector's network view is one netns exec
@@ -2273,7 +2277,7 @@ class NativeFreeBSDBackend(NativeBackend):
         return ["jexec", self.jails[segment]]
 
     def _netflector_command(self, config_path: Path) -> list[str]:
-        return ["jexec", self.jails["dut"], str(self.args.binary), str(config_path)]
+        return ["jexec", self.jails["dut"], *self._netflector_args(config_path)]
 
     def admin(self, script: str, *, capture: bool = False) -> str:
         result = run_command(["jexec", self.jails["dut"], "sh", "-ec", script])
@@ -3277,6 +3281,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--binary", type=Path, default=None,
         help="netflector binary to run (native backend, required); build it unprivileged first, "
              "e.g. cargo build --release --locked")
+    parser.add_argument("--no-join", action="store_true",
+        help="run netflector with --no-join (native backend); for a fabric whose kernel cannot join "
+             "groups but delivers their frames regardless, such as qemu-user")
     parser.add_argument("--keep-on-failure", action="store_true", help="leave resources behind after a failure")
     parser.add_argument("--keep-stale", action="store_true",
         help="skip the preflight sweep, keeping what an earlier --keep-on-failure run left behind")
@@ -3299,6 +3306,8 @@ def parse_args() -> argparse.Namespace:
                      "(cargo build --release --locked)")
     if args.backend == "docker" and args.binary is not None:
         parser.error("--binary only applies to --backend native")
+    if args.backend == "docker" and args.no_join:
+        parser.error("--no-join only applies to --backend native")
     return args
 
 

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -281,6 +281,28 @@ WSD_RESOLVEMATCHES_HEX = (
     "<d:MetadataVersion>1</d:MetadataVersion>"
     "</d:ResolveMatch></d:ResolveMatches></s:Body></s:Envelope>"
 ).encode().hex()
+RELAY_PORT = 9003
+RELAY_ONE_WAY_PORT = 9004
+RELAY_UNLISTED_PORT = 9005
+RELAY_GROUP_V4 = "239.255.90.90"
+RELAY_GROUP_V6 = "ff02::5a5a"
+RELAY_UNLISTED_GROUP_V4 = "239.255.91.91"
+RELAY_SOURCE_PORT = 9014  # below the ephemeral range, like the ports above
+
+
+def sood_query_hex(properties: dict[str, str]) -> str:
+    # A Roon SOOD query: `SOOD` 0x02 'Q', then per property a 1-byte key length, the key, a
+    # 2-byte big-endian value length and the value.
+    frame = b"SOOD\x02Q"
+    for key, value in properties.items():
+        frame += bytes([len(key)]) + key.encode() + len(value).to_bytes(2, "big") + value.encode()
+    return frame.hex()
+
+
+SOOD_QUERY_HEX = sood_query_hex({
+    "query_service_id": "00720724-5143-4a9b-abac-0e50cba674bb",
+    "_tid": "5a1c2e3d-4f60-4b7a-9c8d-0e1f2a3b4c5d",
+})
 # --- Address-change cases: knock out one (interface, family) source on netflector, prove
 # reflection of that family stops, then restore it and prove it resumes. netflector reacts on
 # its own event loop after the netlink notification, so each check polls across that async window.
@@ -364,6 +386,9 @@ class TestCase:
     # A line netflector must have logged by the time the receiver's verdict is in, e.g. the
     # destination it re-emitted to.
     expect_netflector_log: str | None = None
+    # Send from a fixed port and require the reflected packet to come from that port and from
+    # the sender's own segment: the UDP relay keeps the source as sent.
+    expect_source_preserved: bool = False
 
     @property
     def send_address(self) -> str:
@@ -950,6 +975,118 @@ WSD_CASES = [
     ),
 ]
 
+# The UDP relay carries a datagram on a listed port to a listed group or a broadcast across as
+# sent: payload, source ip:port and all. config-relay.toml relays port 9003 both ways and port
+# 9004 source->target only.
+RELAY_CASES = [
+    TestCase(
+        name="relays_udp_to_group",
+        send_port=RELAY_PORT,
+        receive_port=RELAY_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SOOD_QUERY_HEX,
+        expect_payload_hex=SOOD_QUERY_HEX,
+        group=RELAY_GROUP_V4,
+        config="config-relay.toml",
+        expect_source_preserved=True,
+        expect_netflector_log=f"to {RELAY_GROUP_V4}:{RELAY_PORT}",
+    ),
+    TestCase(
+        name="relays_udp_to_group_ipv6",
+        send_port=RELAY_PORT,
+        receive_port=RELAY_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SOOD_QUERY_HEX,
+        expect_payload_hex=SOOD_QUERY_HEX,
+        family=6,
+        group=RELAY_GROUP_V6,
+        config="config-relay.toml",
+        expect_netflector_log=f"to [{RELAY_GROUP_V6}]:{RELAY_PORT}",
+    ),
+    # The broadcast cases check the destination only: the docker host masquerades a bridged
+    # broadcast (bridge-nf-call-iptables), so the receiver sees its gateway as the source there.
+    TestCase(
+        name="relays_udp_to_directed_broadcast",
+        send_port=RELAY_PORT,
+        receive_port=RELAY_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SOOD_QUERY_HEX,
+        expect_payload_hex=SOOD_QUERY_HEX,
+        config="config-relay.toml",
+        send_to="192.0.2.255",
+        expect_netflector_log=f"to 198.51.100.255:{RELAY_PORT}",
+    ),
+    TestCase(
+        name="relays_udp_to_limited_broadcast_as_sent",
+        send_port=RELAY_PORT,
+        receive_port=RELAY_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SOOD_QUERY_HEX,
+        expect_payload_hex=SOOD_QUERY_HEX,
+        config="config-relay.toml",
+        expect_netflector_log=f"to 255.255.255.255:{RELAY_PORT}",
+    ),
+    TestCase(
+        name="relays_udp_from_target",
+        send_port=RELAY_PORT,
+        receive_port=RELAY_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SOOD_QUERY_HEX,
+        expect_payload_hex=SOOD_QUERY_HEX,
+        group=RELAY_GROUP_V4,
+        direction="reverse",
+        config="config-relay.toml",
+        expect_source_preserved=True,
+    ),
+    TestCase(
+        name="relays_udp_one_way",
+        send_port=RELAY_ONE_WAY_PORT,
+        receive_port=RELAY_ONE_WAY_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=SOOD_QUERY_HEX,
+        expect_payload_hex=SOOD_QUERY_HEX,
+        group=RELAY_GROUP_V4,
+        config="config-relay.toml",
+    ),
+    TestCase(
+        name="ignores_udp_one_way_from_target",
+        send_port=RELAY_ONE_WAY_PORT,
+        receive_port=RELAY_ONE_WAY_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=SOOD_QUERY_HEX,
+        group=RELAY_GROUP_V4,
+        direction="reverse",
+        config="config-relay.toml",
+    ),
+    TestCase(
+        name="ignores_udp_on_unlisted_port",
+        send_port=RELAY_UNLISTED_PORT,
+        receive_port=RELAY_UNLISTED_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=SOOD_QUERY_HEX,
+        group=RELAY_GROUP_V4,
+        config="config-relay.toml",
+    ),
+    TestCase(
+        name="ignores_udp_to_unlisted_group",
+        send_port=RELAY_PORT,
+        receive_port=RELAY_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=SOOD_QUERY_HEX,
+        group=RELAY_UNLISTED_GROUP_V4,
+        config="config-relay.toml",
+    ),
+]
+
 
 @dataclasses.dataclass(frozen=True)
 class RoundTripCase:
@@ -1202,7 +1339,8 @@ ALL_CASES: list[
     TestCase | RoundTripCase | SearchRecreateCase | DialCase | DialAddressChangeCase
     | AddressChangeCase | RecreateCase | DialRecreateCase
 ] = [
-    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *WSD_CASES, *ROUNDTRIP_CASES, *SEARCH_RECREATE_CASES,
+    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *WSD_CASES, *RELAY_CASES, *ROUNDTRIP_CASES,
+    *SEARCH_RECREATE_CASES,
     *DIAL_CASES, *DIAL_ADDRESS_CHANGE_CASES, *ADDRESS_CHANGE_CASES, *RECREATE_CASES,
     *DIAL_RECREATE_CASES]
 
@@ -2308,6 +2446,10 @@ class CaseRunner:
             probe_args.extend(["--join-group", case.group, "--interface", ifname])
         if case.expect_routable_source:
             probe_args.append("--expect-source-not-link-local")
+        if case.expect_source_preserved:
+            # v4 only: a send to a link-local v6 group is sourced from the sender's fe80::.
+            subnet = f"{SEGMENT_V4_SUBNET[self.sender_segment]}.0/24"
+            probe_args.extend(["--expect-source-net", subnet, "--expect-source-port", str(RELAY_SOURCE_PORT)])
 
         self.backend.start_probe("receiver", self.receiver_segment, ifname, probe_args)
         self.wait_for_receiver()
@@ -2325,6 +2467,7 @@ class CaseRunner:
             raise RuntimeError(f"case {case.name} has no send payload")
 
         ifname = self.backend.helper_ifname(self.sender_ifname)
+        source_args = ["--source-port", str(RELAY_SOURCE_PORT)] if case.expect_source_preserved else []
         self.backend.start_probe(
             "sender",
             self.sender_segment,
@@ -2332,6 +2475,7 @@ class CaseRunner:
             [
                 "send",
                 *payload_args,
+                *source_args,
                 "--port",
                 str(case.send_port),
                 "--address",

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -18,8 +18,9 @@
 relays link-local service-discovery traffic between two network interfaces:
 clients on the source interface discover, wake, and reach devices on the
 target interface, not the other way around.
-It reflects Wake-on-LAN, mDNS, SSDP, WS-Discovery, and DIAL; each is enabled
-per interface pair in the configuration.
+It reflects Wake-on-LAN, mDNS, SSDP, WS-Discovery, DIAL, and relays any
+other UDP protocol as sent; each is enabled per interface pair in the
+configuration.
 .Pp
 The daemon runs in the foreground and logs to standard error with UTC
 timestamps.

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl -check-config
+.Op Fl -no-join
 .Op Fl -
 .Op Ar config
 .Nm
@@ -52,6 +53,13 @@ report that an interface is missing or unreachable.
 On success it prints
 .Ql config ok: N reflector(s)
 and exits 0; on a rejected configuration it prints the reason and exits 1.
+.It Fl -no-join
+Do not join multicast groups.
+Group traffic then reaches
+.Nm
+only where the link delivers it without a membership, as an emulated or
+promiscuous fabric does.
+A warning is logged at startup.
 .It Fl V , Fl -version
 Print the version and exit.
 .It Fl h , Fl -help

--- a/man/netflector.8
+++ b/man/netflector.8
@@ -18,8 +18,8 @@
 relays link-local service-discovery traffic between two network interfaces:
 clients on the source interface discover, wake, and reach devices on the
 target interface, not the other way around.
-It reflects Wake-on-LAN, mDNS, SSDP, WS-Discovery, DIAL, and relays any
-other UDP protocol as sent; each is enabled per interface pair in the
+It reflects Wake-on-LAN, mDNS, SSDP, WS-Discovery, DIAL, and can relay any
+other UDP protocol unchanged; each is enabled per interface pair in the
 configuration.
 .Pp
 The daemon runs in the foreground and logs to standard error with UTC

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -166,7 +166,8 @@ uses.
 .It Ic udp_broadcast
 Also relay broadcasts on
 .Ic udp_ports :
-the limited broadcast and the segment's own directed one.
+the limited broadcast and the directed broadcast of any subnet on the segment
+(on a link without MAC addresses, of its first subnet).
 Boolean, default
 .Cm false ;
 requires an IPv4-capable

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -74,8 +74,8 @@ link carries no MAC addresses (a
 .Dv DLT_NULL
 link): the frame-source filter could never match there.
 Wake-on-LAN is unaffected; it matches the address inside the magic packet.
-The UDP relay ignores the list and carries every device's datagrams, so an
-entry enabling only the relay may not set one.
+The UDP relay ignores the list; an entry with only the relay enabled may not
+set one.
 .It Ic address_family
 .Cm default
 (the default) attempts both families, requires IPv4, and treats IPv6 as
@@ -147,15 +147,18 @@ per pair of network segments: two would relay each other's re-emits without end.
 Boolean, default
 .Cm false .
 .It Ic udp_ports
-Destination UDP ports whose datagrams are relayed as sent, source address and
-port included: to the same multicast group, to the target segment's directed
-broadcast for a directed one, and to the limited broadcast unchanged.
+Destination UDP ports to relay.
+A datagram to one of them is copied to the other segment unchanged, source
+address and port included: to the same multicast group, to the target
+segment's directed broadcast, or to the limited broadcast, whichever it was
+sent to.
 A list of unique ports in the range 1 to 65535.
 Requires
 .Ic udp_groups
 or
 .Ic udp_broadcast ,
-and may not capture what an enabled protocol of the entry already relays
+and must not cover datagrams a protocol enabled on the same entry already
+relays
 .Pq see Sx DUPLICATE DETECTION .
 .It Ic udp_groups
 Multicast groups to join and relay on
@@ -163,11 +166,14 @@ Multicast groups to join and relay on
 of either family the entry's
 .Ic address_family
 uses.
+Startup fails when a group cannot be joined on
+.Ic source_if .
 .It Ic udp_broadcast
-Also relay broadcasts on
+Also relay broadcasts to
 .Ic udp_ports :
-the limited broadcast and the directed broadcast of any subnet on the segment
-(on a link without MAC addresses, of its first subnet).
+the limited broadcast and the directed broadcast of any subnet on the segment.
+On a link without MAC addresses only the first subnet's directed broadcast is
+recognized as one.
 Boolean, default
 .Cm false ;
 requires an IPv4-capable
@@ -231,22 +237,22 @@ Beyond names, two entries that enable the same protocol are rejected only when
 they could reflect the same packet twice: a shared direction, overlapping MAC
 selection, overlapping address-family handling, and, for Wake-on-LAN, at least
 one shared port.
-The UDP relay admits every datagram it captures, so it duplicates a protocol,
-of another entry or of its own, when both capture the same datagrams on the
-same leg: a shared port with a shared group or with broadcasts on both sides,
-or any shared port against Wake-on-LAN, which captures every destination on
-its ports.
-mDNS, SSDP and WSD capture on both interfaces whatever the entry's direction,
-queries on
+The UDP relay admits every datagram it captures, so it conflicts with any
+protocol, in another entry or in its own, that captures the same datagrams on
+the same leg: a shared port together with a shared group or with broadcasts
+on both sides, or any shared port with Wake-on-LAN, which captures every
+destination on its ports.
+mDNS, SSDP and WSD capture on both interfaces regardless of the entry's
+direction, queries on
 .Ic source_if
 and responses on
 .Ic target_if ,
-so a relay on their group conflicts with them either way round; the relay
-ignores
+so a relay on one of their groups conflicts with them in either direction.
 .Ic macs
-and queries admit every sender, so a MAC selection never separates the two.
-Two discovery protocols on one port do not conflict, each admitting only its
-own messages.
+does not separate them: queries are accepted from any sender and the relay
+ignores the list.
+Two discovery protocols on one port do not conflict; each accepts only its own
+messages.
 An entry's directions are its
 .Ic source_if
 to
@@ -293,7 +299,7 @@ NETFLECTOR_TV_SSDP=true
 NETFLECTOR_TV_DIAL=true
 .Ed
 .Pp
-Roon discovery (SOOD) relayed between two segments, each hosting servers or
+Roon discovery (SOOD) relayed between two segments that both have servers or
 endpoints:
 .Bd -literal -offset indent
 [reflectors.roon]

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -291,5 +291,17 @@ NETFLECTOR_TV_MDNS=true
 NETFLECTOR_TV_SSDP=true
 NETFLECTOR_TV_DIAL=true
 .Ed
+.Pp
+Roon discovery (SOOD) relayed between two segments, each hosting servers or
+endpoints:
+.Bd -literal -offset indent
+[reflectors.roon]
+source_if     = "lan"
+target_if     = "iot"
+udp_ports     = [9003]
+udp_groups    = ["239.255.90.90"]
+udp_broadcast = true
+bidirectional = true
+.Ed
 .Sh SEE ALSO
 .Xr netflector 8

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -74,6 +74,8 @@ link carries no MAC addresses (a
 .Dv DLT_NULL
 link): the frame-source filter could never match there.
 Wake-on-LAN is unaffected; it matches the address inside the magic packet.
+The UDP relay ignores the list and carries every device's datagrams, so an
+entry enabling only the relay may not set one.
 .It Ic address_family
 .Cm default
 (the default) attempts both families, requires IPv4, and treats IPv6 as
@@ -144,9 +146,35 @@ Run one active
 per pair of network segments: two would relay each other's re-emits without end.
 Boolean, default
 .Cm false .
+.It Ic udp_ports
+Destination UDP ports whose datagrams are relayed as sent, source address and
+port included: to the same multicast group, to the target segment's directed
+broadcast for a directed one, and to the limited broadcast unchanged.
+A list of unique ports in the range 1 to 65535.
+Requires
+.Ic udp_groups
+or
+.Ic udp_broadcast ,
+and may not capture what an enabled protocol of the entry already relays
+.Pq see Sx DUPLICATE DETECTION .
+.It Ic udp_groups
+Multicast groups to join and relay on
+.Ic udp_ports ,
+of either family the entry's
+.Ic address_family
+uses.
+.It Ic udp_broadcast
+Also relay broadcasts on
+.Ic udp_ports :
+the limited broadcast and the segment's own directed one.
+Boolean, default
+.Cm false ;
+requires an IPv4-capable
+.Ic address_family .
 .El
 .Pp
-An entry must enable at least one protocol.
+An entry must enable at least one protocol or set
+.Ic udp_ports .
 .Sh ENVIRONMENT
 Every setting can come from the environment, which suits containers.
 Variables are named
@@ -161,7 +189,8 @@ parameter overrides it.
 .Ic NAME ,
 or any entry field:
 .Ic SOURCE_IF , TARGET_IF , MACS , WOL , MDNS , SSDP , WSD , DIAL ,
-.Ic WOL_PORTS , ADDRESS_FAMILY , BIDIRECTIONAL .
+.Ic WOL_PORTS , ADDRESS_FAMILY , BIDIRECTIONAL , UDP_PORTS , UDP_GROUPS ,
+.Ic UDP_BROADCAST .
 Case-insensitive.
 .El
 .Pp
@@ -179,9 +208,9 @@ Booleans are
 .Cm true Ns / Ns Cm false
 or
 .Cm 1 Ns / Ns Cm 0 ;
-.Ic MACS
+.Ic MACS , WOL_PORTS , UDP_PORTS ,
 and
-.Ic WOL_PORTS
+.Ic UDP_GROUPS
 are comma-separated.
 An unknown parameter, a non-alphanumeric or reserved tag, and a tag with no
 parameter are all rejected at startup.
@@ -201,6 +230,22 @@ Beyond names, two entries that enable the same protocol are rejected only when
 they could reflect the same packet twice: a shared direction, overlapping MAC
 selection, overlapping address-family handling, and, for Wake-on-LAN, at least
 one shared port.
+The UDP relay admits every datagram it captures, so it duplicates a protocol,
+of another entry or of its own, when both capture the same datagrams on the
+same leg: a shared port with a shared group or with broadcasts on both sides,
+or any shared port against Wake-on-LAN, which captures every destination on
+its ports.
+mDNS, SSDP and WSD capture on both interfaces whatever the entry's direction,
+queries on
+.Ic source_if
+and responses on
+.Ic target_if ,
+so a relay on their group conflicts with them either way round; the relay
+ignores
+.Ic macs
+and queries admit every sender, so a MAC selection never separates the two.
+Two discovery protocols on one port do not conflict, each admitting only its
+own messages.
 An entry's directions are its
 .Ic source_if
 to

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! Command-line parsing.
 //!
 //! Hand-rolled rather than pulled from a crate: the whole surface is one optional
-//! positional and three flags, and the binary ships to embedded ARM.
+//! positional and four flags, and the binary ships to embedded ARM.
 
 use std::ffi::OsString;
 use std::path::Path;
@@ -12,7 +12,11 @@ use crate::error::UsageError;
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Invocation<'a> {
     /// Run netflector, configured from the given file (if any) plus `NETFLECTOR_*`.
-    Run(Option<&'a Path>),
+    Run {
+        path: Option<&'a Path>,
+        /// Whether to join the multicast groups the reflectors capture; `--no-join` clears it.
+        join_groups: bool,
+    },
     /// Load and validate that same configuration, then exit.
     CheckConfig(Option<&'a Path>),
     Help,
@@ -34,6 +38,7 @@ pub(crate) enum Invocation<'a> {
 /// [`UsageError`] for an unknown option or a second positional argument.
 pub(crate) fn parse(args: &[OsString]) -> Result<Invocation<'_>, UsageError> {
     let mut check = false;
+    let mut join_groups = true;
     let mut path: Option<&Path> = None;
     let mut options_done = false;
 
@@ -53,6 +58,10 @@ pub(crate) fn parse(args: &[OsString]) -> Result<Invocation<'_>, UsageError> {
                 check = true;
                 continue;
             }
+            if arg == "--no-join" {
+                join_groups = false;
+                continue;
+            }
         }
         // A lone "-" stays a path (some callers mean stdin by it); anything else that leads with a
         // dash is an option we do not know, and guessing at it would be worse than saying so.
@@ -69,7 +78,7 @@ pub(crate) fn parse(args: &[OsString]) -> Result<Invocation<'_>, UsageError> {
     Ok(if check {
         Invocation::CheckConfig(path)
     } else {
-        Invocation::Run(path)
+        Invocation::Run { path, join_groups }
     })
 }
 
@@ -82,7 +91,7 @@ pub(crate) const HELP: &str = concat!(
 Reflects link-local service traffic (Wake-on-LAN, mDNS, SSDP, WS-Discovery, DIAL) between
 two network interfaces.
 
-usage: netflector [--check-config] [--] [CONFIG]
+usage: netflector [--check-config] [--no-join] [--] [CONFIG]
 
   CONFIG           TOML config file. NETFLECTOR_* environment variables are merged on top of
                    it. Omit it to configure from the environment alone. Put `--` first if the
@@ -91,6 +100,9 @@ usage: netflector [--check-config] [--] [CONFIG]
   --check-config   Load and validate the configuration, then exit. It parses only: no
                    interface is opened, so it needs no privileges and it cannot tell you that
                    an interface is missing or unreachable.
+  --no-join        Do not join multicast groups. Group traffic then reaches netflector only
+                   where the link delivers it without a membership, as an emulated or
+                   promiscuous fabric does.
   -V, --version    Print the version and exit.
   -h, --help       Print this help and exit.
 "
@@ -104,18 +116,34 @@ mod tests {
         list.iter().map(OsString::from).collect()
     }
 
+    fn run(path: Option<&str>) -> Invocation<'_> {
+        Invocation::Run {
+            path: path.map(Path::new),
+            join_groups: true,
+        }
+    }
+
     #[test]
     fn no_args_runs_from_the_environment() {
-        assert_eq!(parse(&[]).unwrap(), Invocation::Run(None));
+        assert_eq!(parse(&[]).unwrap(), run(None));
+    }
+
+    #[test]
+    fn no_join_clears_the_group_joins() {
+        let a = args(&["--no-join", "netflector.toml"]);
+        assert_eq!(
+            parse(&a).unwrap(),
+            Invocation::Run {
+                path: Some(Path::new("netflector.toml")),
+                join_groups: false,
+            }
+        );
     }
 
     #[test]
     fn a_lone_positional_is_the_config_path() {
         let a = args(&["netflector.toml"]);
-        assert_eq!(
-            parse(&a).unwrap(),
-            Invocation::Run(Some(Path::new("netflector.toml")))
-        );
+        assert_eq!(parse(&a).unwrap(), run(Some("netflector.toml")));
     }
 
     #[test]
@@ -162,7 +190,7 @@ mod tests {
     #[test]
     fn a_lone_dash_is_a_path_not_an_option() {
         let a = args(&["-"]);
-        assert_eq!(parse(&a).unwrap(), Invocation::Run(Some(Path::new("-"))));
+        assert_eq!(parse(&a).unwrap(), run(Some("-")));
     }
 
     #[test]
@@ -170,15 +198,9 @@ mod tests {
         // Without the separator these paths are unreachable: every leading-dash argument would be
         // read as an option, a known one or an error.
         let a = args(&["--", "--check-config"]);
-        assert_eq!(
-            parse(&a).unwrap(),
-            Invocation::Run(Some(Path::new("--check-config")))
-        );
+        assert_eq!(parse(&a).unwrap(), run(Some("--check-config")));
         let b = args(&["--", "--nonsense"]);
-        assert_eq!(
-            parse(&b).unwrap(),
-            Invocation::Run(Some(Path::new("--nonsense")))
-        );
+        assert_eq!(parse(&b).unwrap(), run(Some("--nonsense")));
     }
 
     #[test]
@@ -198,7 +220,14 @@ mod tests {
     fn help_names_every_flag_it_accepts() {
         // The help is the only place the flags are documented, so a flag the parser takes but the
         // help omits is a bug the user pays for.
-        for flag in ["--check-config", "--version", "-V", "--help", "-h"] {
+        for flag in [
+            "--check-config",
+            "--no-join",
+            "--version",
+            "-V",
+            "--help",
+            "-h",
+        ] {
             assert!(HELP.contains(flag), "help does not mention {flag}");
         }
         // The separator needs its own check: a bare "--" is a substring of every long flag, so

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 //! TOML is deserialized into a raw form (`RawConfig`/`RawReflector`) and then
 //! validated into the strongly-typed [`Config`]. Typed values make illegal states
 //! unrepresentable ([`Wol::ports`] exists only when `WoL` is enabled;
-//! [`InterfaceName`]/[`WolPorts`] can't be empty).
+//! [`InterfaceName`]/[`PortList`] can't be empty).
 //!
 //! Submodules: value types in `value`, errors in `error`, the serde layer in
 //! `raw`, the environment parser in `env`. Each value type pairs `FromStr` with a
@@ -22,8 +22,12 @@ mod raw;
 mod value;
 
 pub(crate) use self::error::{ConfigError, Protocol};
-pub(crate) use self::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
+pub(crate) use self::value::{
+    AddressFamily, GroupList, InterfaceName, LogLevel, PortList, ReflectorName,
+};
 
+use std::net::IpAddr;
+use std::num::NonZeroU16;
 use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
@@ -32,12 +36,101 @@ use serde::Deserialize;
 
 use self::raw::{RawConfig, RawReflector};
 use crate::net::mac::MacSet;
+use crate::net::mdns::{MDNS_GROUP_V4, MDNS_GROUP_V6, MDNS_PORT};
+use crate::net::ssdp::{
+    SSDP_GROUP_V4, SSDP_GROUP_V6_LINK_LOCAL, SSDP_GROUP_V6_SITE_LOCAL, SSDP_PORT,
+};
+use crate::net::wsd::{WSD_GROUP_V4, WSD_GROUP_V6, WSD_PORT};
 
 /// Wake-on-LAN settings (present only when `WoL` is enabled for the reflector).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Wol {
     /// UDP destination ports whose magic packets are reflected.
-    pub(crate) ports: WolPorts,
+    pub(crate) ports: PortList,
+}
+
+/// The ports a `wol = true` entry relays when `wol_ports` is absent.
+const WOL_DEFAULT_PORTS: [NonZeroU16; 2] =
+    [NonZeroU16::new(7).unwrap(), NonZeroU16::new(9).unwrap()];
+
+impl Wol {
+    fn default_ports() -> PortList {
+        PortList::try_from(WOL_DEFAULT_PORTS.to_vec()).expect("two distinct ports")
+    }
+}
+
+/// The destinations a protocol's filter admits on one port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Reach {
+    /// Any address the family uses: the Wake-on-LAN filter pins the port alone.
+    Any(AddressFamily),
+    Group(IpAddr),
+    /// The limited broadcast and the segment's directed one.
+    Broadcast,
+}
+
+impl Reach {
+    /// Whether a datagram exists that both admit.
+    fn overlaps(self, other: Reach) -> bool {
+        match (self, other) {
+            (Self::Any(a), Self::Any(b)) => families_overlap(a, b),
+            (Self::Any(family), Self::Group(group)) | (Self::Group(group), Self::Any(family)) => {
+                family_uses(family, group)
+            }
+            (Self::Any(family), Self::Broadcast) | (Self::Broadcast, Self::Any(family)) => {
+                family.uses_ipv4()
+            }
+            (Self::Group(a), Self::Group(b)) => a == b,
+            (Self::Broadcast, Self::Broadcast) => true,
+            (Self::Group(_), Self::Broadcast) | (Self::Broadcast, Self::Group(_)) => false,
+        }
+    }
+}
+
+/// A class of datagrams an entry relays: those to `port` and `reach` arriving on `ingress`,
+/// re-emitted on `egress`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Flow<'a> {
+    protocol: Protocol,
+    ingress: &'a InterfaceName,
+    egress: &'a InterfaceName,
+    port: u16,
+    reach: Reach,
+}
+
+impl Flow<'_> {
+    /// Whether a datagram exists in both flows.
+    fn overlaps(&self, other: &Flow<'_>) -> bool {
+        self.ingress == other.ingress
+            && self.egress == other.egress
+            && self.port == other.port
+            && self.reach.overlaps(other.reach)
+    }
+}
+
+/// The transparent UDP relay's settings (present only when `udp_ports` is set).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UdpRelay {
+    /// Destination ports whose datagrams are relayed as sent.
+    pub(crate) ports: PortList,
+    /// Multicast groups to join and relay on those ports.
+    pub(crate) groups: Option<GroupList>,
+    /// Whether broadcasts on those ports are relayed too.
+    pub(crate) broadcast: bool,
+}
+
+impl UdpRelay {
+    fn destinations(&self) -> Vec<(u16, Reach)> {
+        let groups = self.groups.as_deref().unwrap_or(&[]);
+        self.ports
+            .iter()
+            .map(|port| port.get())
+            .flat_map(|port| {
+                let groups = groups.iter().map(move |group| (port, Reach::Group(*group)));
+                groups.chain(self.broadcast.then_some((port, Reach::Broadcast)))
+            })
+            .collect()
+    }
 }
 
 /// SSDP settings (present only when SSDP is enabled for the reflector).
@@ -71,6 +164,8 @@ pub(crate) struct Reflector {
     /// Also relay every enabled protocol target → source: the entry is built a second time with
     /// its interfaces swapped.
     pub(crate) bidirectional: bool,
+    /// The transparent UDP relay, or `None` when `udp_ports` is unset.
+    pub(crate) udp: Option<UdpRelay>,
 }
 
 impl Reflector {
@@ -93,10 +188,83 @@ impl Reflector {
         )
     }
 
-    /// The protocol on which `self` and `other` would reflect the same packet
-    /// twice, if any: a shared direction, overlapping MAC selection and address
-    /// family, and a shared enabled protocol (for `WoL`, also a shared port).
+    /// Every flow the entry's protocols relay. mDNS, SSDP and WSD capture on both interfaces
+    /// whatever the entry's direction, queries on the source and responses on the target, for
+    /// the groups of the families the entry uses; Wake-on-LAN admits anything on its ports and
+    /// the relay its groups and broadcast, each on the entry's directions.
+    fn flows(&self) -> Vec<Flow<'_>> {
+        let family = self.address_family;
+        let mut flows = Vec::new();
+        let mut discovery = |protocol, port, groups: &[IpAddr]| {
+            for group in groups.iter().filter(|group| family_uses(family, **group)) {
+                let legs = [
+                    (&self.source_if, &self.target_if),
+                    (&self.target_if, &self.source_if),
+                ];
+                flows.extend(legs.map(|(ingress, egress)| Flow {
+                    protocol,
+                    ingress,
+                    egress,
+                    port,
+                    reach: Reach::Group(*group),
+                }));
+            }
+        };
+        if self.mdns {
+            let v4 = IpAddr::V4(MDNS_GROUP_V4);
+            let v6 = IpAddr::V6(MDNS_GROUP_V6);
+            discovery(Protocol::Mdns, MDNS_PORT, &[v4, v6]);
+        }
+        if self.ssdp.is_some() {
+            let v4 = IpAddr::V4(SSDP_GROUP_V4);
+            let link_local = IpAddr::V6(SSDP_GROUP_V6_LINK_LOCAL);
+            let site_local = IpAddr::V6(SSDP_GROUP_V6_SITE_LOCAL);
+            discovery(Protocol::Ssdp, SSDP_PORT, &[v4, link_local, site_local]);
+        }
+        if self.wsd {
+            let v4 = IpAddr::V4(WSD_GROUP_V4);
+            let v6 = IpAddr::V6(WSD_GROUP_V6);
+            discovery(Protocol::Wsd, WSD_PORT, &[v4, v6]);
+        }
+        for (ingress, egress) in self.directions() {
+            if let Some(wol) = &self.wol {
+                flows.extend(wol.ports.iter().map(|port| Flow {
+                    protocol: Protocol::Wol,
+                    ingress,
+                    egress,
+                    port: port.get(),
+                    reach: Reach::Any(family),
+                }));
+            }
+            if let Some(udp) = &self.udp {
+                flows.extend(udp.destinations().into_iter().map(|(port, reach)| Flow {
+                    protocol: Protocol::Udp,
+                    ingress,
+                    egress,
+                    port,
+                    reach,
+                }));
+            }
+        }
+        flows
+    }
+
+    /// The protocol on which `self` and `other` would reflect the same packet twice, if any: a
+    /// protocol both enable, or a flow of one the UDP relay of the other overlaps. Two
+    /// discovery protocols on one port don't duplicate: each classifier admits only its own
+    /// messages. The relay admits every datagram it captures, so it duplicates any protocol
+    /// capturing the same on the same leg, and the conflict is named after that protocol.
     fn conflicts_with(&self, other: &Reflector) -> Option<Protocol> {
+        self.shared_protocol(other).or_else(|| {
+            self.relay_overlap(other.flows())
+                .or_else(|| other.relay_overlap(self.flows()))
+                .map(|(protocol, _)| protocol)
+        })
+    }
+
+    /// A protocol both enable on a shared direction with overlapping MAC selection and address
+    /// family (for `WoL`, also a shared port).
+    fn shared_protocol(&self, other: &Reflector) -> Option<Protocol> {
         if !self
             .directions()
             .any(|mine| other.directions().any(|theirs| theirs == mine))
@@ -124,6 +292,28 @@ impl Reflector {
         }
         None
     }
+
+    /// The first of `others` whose datagrams the entry's UDP relay would carry a second time,
+    /// as its protocol and port.
+    fn relay_overlap<'a>(
+        &self,
+        others: impl IntoIterator<Item = Flow<'a>>,
+    ) -> Option<(Protocol, u16)> {
+        let mine = self.flows();
+        let relay = || mine.iter().filter(|flow| flow.protocol == Protocol::Udp);
+        others
+            .into_iter()
+            .find(|other| relay().any(|mine| mine.overlaps(other)))
+            .map(|other| (other.protocol, other.port))
+    }
+}
+
+/// Whether `family` handles `ip`'s IP version.
+fn family_uses(family: AddressFamily, ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(_) => family.uses_ipv4(),
+        IpAddr::V6(_) => family.uses_ipv6(),
+    }
 }
 
 impl TryFrom<(String, RawReflector)> for Reflector {
@@ -146,18 +336,49 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             });
         }
 
-        if !raw.wol && !raw.mdns && !raw.ssdp && !raw.wsd {
+        // The relay's own checks come first: an entry that sets only udp_groups is a relay
+        // missing its ports, not an entry with no protocol.
+        let udp = match (raw.udp_ports, raw.udp_groups, raw.udp_broadcast) {
+            (None, None, false) => None,
+            (None, _, _) => return Err(ConfigError::UdpRelayWithoutPorts { name }),
+            (Some(_), None, false) => return Err(ConfigError::UdpRelayNoDestination { name }),
+            (Some(ports), groups, broadcast) => {
+                if broadcast && !raw.address_family.uses_ipv4() {
+                    return Err(ConfigError::UdpBroadcastFamily { name });
+                }
+                let foreign = groups
+                    .as_deref()
+                    .unwrap_or(&[])
+                    .iter()
+                    .find(|group| !family_uses(raw.address_family, **group));
+                if let Some(group) = foreign {
+                    return Err(ConfigError::UdpGroupFamily {
+                        name,
+                        group: *group,
+                    });
+                }
+                Some(UdpRelay {
+                    ports,
+                    groups,
+                    broadcast,
+                })
+            }
+        };
+        if !raw.wol && !raw.mdns && !raw.ssdp && !raw.wsd && udp.is_none() {
             return Err(ConfigError::NoProtocol { name });
         }
         if raw.wol_ports.is_some() && !raw.wol {
             return Err(ConfigError::WolPortsWithoutWol { name });
+        }
+        if raw.macs.is_some() && !raw.wol && !raw.mdns && !raw.ssdp && !raw.wsd {
+            return Err(ConfigError::MacsUnused { name });
         }
         if raw.dial && !raw.ssdp {
             return Err(ConfigError::DialWithoutSsdp { name });
         }
 
         let wol = if raw.wol {
-            let ports = raw.wol_ports.unwrap_or_default();
+            let ports = raw.wol_ports.unwrap_or_else(Wol::default_ports);
             Some(Wol { ports })
         } else {
             None
@@ -172,7 +393,7 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             None
         };
 
-        Ok(Reflector {
+        let reflector = Reflector {
             name,
             source_if,
             target_if,
@@ -183,7 +404,24 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             ssdp,
             wsd: raw.wsd,
             bidirectional: raw.bidirectional,
-        })
+            udp,
+        };
+        let duplicated = {
+            let flows = reflector.flows();
+            let others = flows
+                .iter()
+                .copied()
+                .filter(|flow| flow.protocol != Protocol::Udp);
+            reflector.relay_overlap(others)
+        };
+        if let Some((protocol, port)) = duplicated {
+            return Err(ConfigError::UdpRelayDuplicates {
+                name: reflector.name,
+                port,
+                protocol,
+            });
+        }
+        Ok(reflector)
     }
 }
 
@@ -326,7 +564,7 @@ pub(crate) fn resolve_log_level(
 }
 
 /// The enabled protocols of `reflector` as a comma-separated summary for logging,
-/// with `WoL` ports and the SSDP DIAL flag.
+/// with `WoL` ports, the SSDP DIAL flag, and the relay's ports and destinations.
 fn protocol_list(reflector: &Reflector) -> String {
     let mut protocols: Vec<String> = Vec::new();
     if let Some(wol) = &reflector.wol {
@@ -345,6 +583,19 @@ fn protocol_list(reflector: &Reflector) -> String {
     }
     if reflector.wsd {
         protocols.push("wsd".to_owned());
+    }
+    if let Some(udp) = &reflector.udp {
+        let ports: Vec<String> = udp.ports.iter().map(ToString::to_string).collect();
+        let groups = udp.groups.as_deref().unwrap_or(&[]);
+        let mut destinations: Vec<String> = groups.iter().map(ToString::to_string).collect();
+        if udp.broadcast {
+            destinations.push("broadcast".to_owned());
+        }
+        protocols.push(format!(
+            "udp({} on {})",
+            ports.join(","),
+            destinations.join(",")
+        ));
     }
     protocols.join(", ")
 }
@@ -444,6 +695,180 @@ mod tests {
         assert!(r.wol.is_none());
         assert!(r.ssdp.is_none());
         assert!(!r.bidirectional);
+    }
+
+    #[test]
+    fn wol_relays_ports_7_and_9_by_default() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.pc]
+            source_if = "lan"
+            target_if = "iot"
+            wol = true
+            "#,
+        )
+        .unwrap();
+        let ports = &cfg.reflectors[0].wol.as_ref().unwrap().ports;
+        assert_eq!(ports.iter().map(|p| p.get()).collect::<Vec<_>>(), [7, 9]);
+    }
+
+    #[test]
+    fn udp_relay_parses() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9003]
+            udp_groups = ["239.255.90.90"]
+            udp_broadcast = true
+            "#,
+        )
+        .unwrap();
+        let udp = cfg.reflectors[0].udp.as_ref().unwrap();
+        assert_eq!(
+            udp.ports.iter().map(|p| p.get()).collect::<Vec<_>>(),
+            [9003]
+        );
+        assert_eq!(
+            udp.groups.as_ref().unwrap().to_vec(),
+            ["239.255.90.90".parse::<IpAddr>().unwrap()]
+        );
+        assert!(udp.broadcast);
+        assert!(cfg.reflectors[0].wol.is_none());
+    }
+
+    #[test]
+    fn macs_need_a_protocol_that_applies_them() {
+        let text = r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "iot"
+            macs = ["00:00:00:00:00:01"]
+            udp_ports = [9003]
+            udp_broadcast = true
+        "#;
+        assert!(matches!(err(text), ConfigError::MacsUnused { .. }));
+        let cfg = from_toml(
+            r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "iot"
+            macs = ["00:00:00:00:00:01"]
+            wol = true
+            udp_ports = [9003]
+            udp_broadcast = true
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.reflectors[0].macs.is_some());
+    }
+
+    #[test]
+    fn udp_relay_needs_ports_and_a_destination() {
+        // Groups or broadcast without ports: nothing says which datagrams to relay.
+        let text = r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "iot"
+            udp_groups = ["239.255.90.90"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::UdpRelayWithoutPorts { .. }
+        ));
+        // Ports without groups or broadcast: nothing to capture.
+        let text = r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9003]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::UdpRelayNoDestination { .. }
+        ));
+    }
+
+    #[test]
+    fn udp_group_must_be_of_a_used_family() {
+        let text = r#"
+            [reflectors.sync]
+            source_if = "lan"
+            target_if = "iot"
+            address_family = "ipv4"
+            udp_ports = [21027]
+            udp_groups = ["ff12::8384"]
+        "#;
+        assert!(matches!(err(text), ConfigError::UdpGroupFamily { .. }));
+    }
+
+    #[test]
+    fn udp_broadcast_needs_ipv4() {
+        let text = r#"
+            [reflectors.sync]
+            source_if = "lan"
+            target_if = "iot"
+            address_family = "ipv6"
+            udp_ports = [21027]
+            udp_groups = ["ff12::8384"]
+            udp_broadcast = true
+        "#;
+        assert!(matches!(err(text), ConfigError::UdpBroadcastFamily { .. }));
+    }
+
+    #[test]
+    fn udp_relay_on_a_group_of_the_entrys_own_protocol_rejected() {
+        let text = r#"
+            [reflectors.lan]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            udp_ports = [5353]
+            udp_groups = ["224.0.0.251"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::UdpRelayDuplicates {
+                port: 5353,
+                protocol: Protocol::Mdns,
+                ..
+            }
+        ));
+        // Wake-on-LAN captures every destination on its ports.
+        let text = r#"
+            [reflectors.lan]
+            source_if = "lan"
+            target_if = "iot"
+            wol = true
+            udp_ports = [9]
+            udp_groups = ["239.255.90.90"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::UdpRelayDuplicates {
+                port: 9,
+                protocol: Protocol::Wol,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn udp_relay_off_the_entrys_own_groups_parses() {
+        // mDNS never captures a broadcast, so the relay on its port duplicates nothing.
+        let cfg = from_toml(
+            r#"
+            [reflectors.lan]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            udp_ports = [5353]
+            udp_broadcast = true
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.reflectors[0].udp.is_some());
     }
 
     #[test]
@@ -1000,6 +1425,250 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn udp_relays_conflict_on_a_shared_port_and_destination() {
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9003, 9004]
+            udp_groups = ["239.255.90.90"]
+            udp_broadcast = true
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9004]
+            udp_groups = ["239.255.90.90"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Udp,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn udp_relays_on_one_port_with_disjoint_destinations_coexist() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9003]
+            udp_broadcast = true
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9003]
+            udp_groups = ["239.255.90.90"]
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.reflectors.len(), 2);
+    }
+
+    #[test]
+    fn udp_relay_on_a_protocols_group_conflicts_with_it() {
+        // The relay on 5353 would carry mDNS a second time; the conflict names mDNS.
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [5353]
+            udp_groups = ["224.0.0.251"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Mdns,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn udp_relay_on_a_protocols_group_conflicts_either_way_round() {
+        // mDNS relays responses iot -> lan whatever the entry's direction.
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+
+            [reflectors.b]
+            source_if = "iot"
+            target_if = "lan"
+            udp_ports = [5353]
+            udp_groups = ["224.0.0.251"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Mdns,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn macs_never_separate_a_discovery_protocol_from_a_udp_relay() {
+        // Queries from any client are relayed regardless of `macs`.
+        let text = r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+            macs = ["00:00:00:00:00:01"]
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [5353]
+            udp_groups = ["224.0.0.251"]
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Mdns,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn udp_relay_on_a_wol_port_in_the_other_direction_coexists() {
+        // Wake-on-LAN relays source -> target only.
+        let cfg = from_toml(
+            r#"
+            [reflectors.wake]
+            source_if = "lan"
+            target_if = "iot"
+            wol = true
+
+            [reflectors.relay]
+            source_if = "iot"
+            target_if = "lan"
+            udp_ports = [9]
+            udp_broadcast = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.reflectors.len(), 2);
+    }
+
+    #[test]
+    fn udp_relay_off_a_protocols_groups_coexists_with_it() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.a]
+            source_if = "lan"
+            target_if = "iot"
+            mdns = true
+
+            [reflectors.b]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [5353]
+            udp_broadcast = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.reflectors.len(), 2);
+    }
+
+    #[test]
+    fn udp_relay_on_a_wol_port_conflicts_in_a_family_wol_uses() {
+        let text = r#"
+            [reflectors.wake]
+            source_if = "lan"
+            target_if = "iot"
+            wol = true
+
+            [reflectors.relay]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9]
+            udp_broadcast = true
+        "#;
+        assert!(matches!(
+            err(text),
+            ConfigError::ConflictingReflectors {
+                protocol: Protocol::Wol,
+                ..
+            }
+        ));
+        // An IPv4-only WoL entry never relays a v6 magic packet.
+        let cfg = from_toml(
+            r#"
+            [reflectors.wake]
+            source_if = "lan"
+            target_if = "iot"
+            address_family = "ipv4"
+            wol = true
+
+            [reflectors.relay]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9]
+            udp_groups = ["ff02::1"]
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.reflectors.len(), 2);
+    }
+
+    #[test]
+    fn different_protocols_on_one_port_coexist() {
+        // WoL admits only magic packets and SSDP only its own messages, so port 1900 shared
+        // between them relays nothing twice.
+        let cfg = from_toml(
+            r#"
+            [reflectors.wake]
+            source_if = "lan"
+            target_if = "iot"
+            wol = true
+            wol_ports = [1900]
+
+            [reflectors.discovery]
+            source_if = "lan"
+            target_if = "iot"
+            ssdp = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.reflectors.len(), 2);
+    }
+
+    #[test]
+    fn udp_relays_on_disjoint_ports_coexist() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [9003]
+            udp_broadcast = true
+
+            [reflectors.squeezebox]
+            source_if = "lan"
+            target_if = "iot"
+            udp_ports = [3483]
+            udp_broadcast = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.reflectors.len(), 2);
     }
 
     #[test]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use super::error::{ConfigError, ParseBoolError, ParseValueError, RequiredField};
 use super::raw::{RawConfig, RawReflector};
-use super::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
+use super::value::{AddressFamily, GroupList, InterfaceName, LogLevel, PortList, ReflectorName};
 use crate::net::mac::MacSet;
 
 /// Accumulates a reflector's fields across its `NETFLECTOR_<tag>_<param>` variables,
@@ -26,7 +26,10 @@ struct PartialReflector {
     dial: Option<bool>,
     wsd: Option<bool>,
     bidirectional: Option<bool>,
-    wol_ports: Option<WolPorts>,
+    wol_ports: Option<PortList>,
+    udp_ports: Option<PortList>,
+    udp_groups: Option<GroupList>,
+    udp_broadcast: Option<bool>,
     address_family: Option<AddressFamily>,
 }
 
@@ -63,6 +66,9 @@ impl PartialReflector {
             "dial" => put(&mut self.dial, env_bool(value, var)?, param, var),
             "wsd" => put(&mut self.wsd, env_bool(value, var)?, param, var),
             "bidirectional" => put(&mut self.bidirectional, env_bool(value, var)?, param, var),
+            "udp_ports" => put(&mut self.udp_ports, env_value(value, var)?, param, var),
+            "udp_groups" => put(&mut self.udp_groups, env_value(value, var)?, param, var),
+            "udp_broadcast" => put(&mut self.udp_broadcast, env_bool(value, var)?, param, var),
             _ => Err(ConfigError::EnvUnknownParam {
                 var: var.to_owned(),
                 param: param.to_owned(),
@@ -90,6 +96,9 @@ impl PartialReflector {
             wsd: self.wsd.unwrap_or(false),
             bidirectional: self.bidirectional.unwrap_or(false),
             wol_ports: self.wol_ports,
+            udp_ports: self.udp_ports,
+            udp_groups: self.udp_groups,
+            udp_broadcast: self.udp_broadcast.unwrap_or(false),
             address_family: self.address_family.unwrap_or_default(),
         })
     }
@@ -276,6 +285,25 @@ mod tests {
         let r = &cfg.reflectors[0];
         assert!(r.wol.is_some());
         assert!(!r.mdns);
+    }
+
+    #[test]
+    fn env_udp_relay_fields() {
+        let cfg = from_env(&[
+            ("NETFLECTOR_ROON_SOURCE_IF", "lan"),
+            ("NETFLECTOR_ROON_TARGET_IF", "iot"),
+            ("NETFLECTOR_ROON_UDP_PORTS", "9003,9004"),
+            ("NETFLECTOR_ROON_UDP_GROUPS", "239.255.90.90"),
+            ("NETFLECTOR_ROON_UDP_BROADCAST", "1"),
+        ])
+        .unwrap();
+        let udp = cfg.reflectors[0].udp.as_ref().unwrap();
+        assert_eq!(
+            udp.ports.iter().map(|p| p.get()).collect::<Vec<_>>(),
+            [9003, 9004]
+        );
+        assert_eq!(udp.groups.as_ref().unwrap().len(), 1);
+        assert!(udp.broadcast);
     }
 
     #[test]

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -5,12 +5,13 @@
 //! matchable while naming the variable that carried it.
 
 use std::fmt;
+use std::net::IpAddr;
 
 use thiserror::Error;
 
 use super::value::{
-    InterfaceName, ParseAddressFamilyError, ParseInterfaceNameError, ParseLogLevelError,
-    ParseReflectorNameError, ReflectorName, WolPortsError,
+    GroupListError, InterfaceName, ParseAddressFamilyError, ParseInterfaceNameError,
+    ParseLogLevelError, ParseReflectorNameError, PortListError, ReflectorName,
 };
 use crate::net::mac::MacSetError;
 
@@ -44,11 +45,39 @@ pub(crate) enum ConfigError {
         value: InterfaceName,
     },
 
-    #[error("reflector \"{name}\" enables no protocol (set wol, mdns, ssdp, or wsd)")]
+    #[error("reflector \"{name}\" enables no protocol (set wol, mdns, ssdp, wsd, or udp_ports)")]
     NoProtocol { name: ReflectorName },
+
+    #[error("reflector \"{name}\" sets udp_groups or udp_broadcast but not udp_ports")]
+    UdpRelayWithoutPorts { name: ReflectorName },
+
+    #[error("reflector \"{name}\" sets udp_ports but neither udp_groups nor udp_broadcast")]
+    UdpRelayNoDestination { name: ReflectorName },
+
+    #[error(
+        "reflector \"{name}\" lists UDP group {group}, whose family its address_family does not use"
+    )]
+    UdpGroupFamily { name: ReflectorName, group: IpAddr },
+
+    #[error("reflector \"{name}\" sets udp_broadcast but its address_family has no IPv4")]
+    UdpBroadcastFamily { name: ReflectorName },
+
+    #[error(
+        "reflector \"{name}\" would relay {protocol} on port {port} twice, through udp_ports as well"
+    )]
+    UdpRelayDuplicates {
+        name: ReflectorName,
+        port: u16,
+        protocol: Protocol,
+    },
 
     #[error("reflector \"{name}\" sets wol_ports but does not enable wol")]
     WolPortsWithoutWol { name: ReflectorName },
+
+    #[error(
+        "reflector \"{name}\" lists macs but enables only the UDP relay, which does not apply them"
+    )]
+    MacsUnused { name: ReflectorName },
 
     #[error("reflector \"{name}\" sets dial but does not enable ssdp")]
     DialWithoutSsdp { name: ReflectorName },
@@ -143,6 +172,7 @@ pub(crate) enum Protocol {
     Mdns,
     Ssdp,
     Wsd,
+    Udp,
 }
 
 impl fmt::Display for Protocol {
@@ -152,6 +182,7 @@ impl fmt::Display for Protocol {
             Self::Mdns => "mDNS",
             Self::Ssdp => "SSDP",
             Self::Wsd => "WSD",
+            Self::Udp => "UDP relay",
         })
     }
 }
@@ -174,9 +205,12 @@ pub(crate) enum ParseValueError {
     /// `SOURCE_IF`/`TARGET_IF`.
     #[error(transparent)]
     Interface(#[from] ParseInterfaceNameError),
-    /// `WOL_PORTS`.
+    /// `WOL_PORTS` / `UDP_PORTS`.
     #[error(transparent)]
-    WolPorts(#[from] WolPortsError),
+    PortList(#[from] PortListError),
+    /// `UDP_GROUPS`.
+    #[error(transparent)]
+    GroupList(#[from] GroupListError),
     /// `NAME`.
     #[error(transparent)]
     ReflectorName(#[from] ParseReflectorNameError),

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use serde::Deserialize;
 
 use super::error::ConfigError;
-use super::value::{AddressFamily, InterfaceName, LogLevel, ReflectorName, WolPorts};
+use super::value::{AddressFamily, GroupList, InterfaceName, LogLevel, PortList, ReflectorName};
 use crate::net::mac::MacSet;
 
 #[derive(Debug, Default, Deserialize)]
@@ -42,7 +42,7 @@ pub(super) struct RawReflector {
     pub(super) address_family: AddressFamily,
     #[serde(default)]
     pub(super) wol: bool,
-    pub(super) wol_ports: Option<WolPorts>,
+    pub(super) wol_ports: Option<PortList>,
     #[serde(default)]
     pub(super) mdns: bool,
     #[serde(default)]
@@ -53,6 +53,10 @@ pub(super) struct RawReflector {
     pub(super) wsd: bool,
     #[serde(default)]
     pub(super) bidirectional: bool,
+    pub(super) udp_ports: Option<PortList>,
+    pub(super) udp_groups: Option<GroupList>,
+    #[serde(default)]
+    pub(super) udp_broadcast: bool,
 }
 
 impl RawConfig {

--- a/src/config/value.rs
+++ b/src/config/value.rs
@@ -6,6 +6,7 @@
 //! The newtypes make illegal values unrepresentable.
 
 use std::fmt;
+use std::net::IpAddr;
 use std::num::NonZeroU16;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -194,18 +195,11 @@ impl FromStr for ReflectorName {
     }
 }
 
-/// A non-empty, duplicate-free list of Wake-on-LAN destination ports.
+/// A non-empty, duplicate-free list of UDP ports.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WolPorts(Vec<NonZeroU16>);
+pub(crate) struct PortList(Vec<NonZeroU16>);
 
-impl Default for WolPorts {
-    fn default() -> Self {
-        const PORTS: [NonZeroU16; 2] = [NonZeroU16::new(7).unwrap(), NonZeroU16::new(9).unwrap()];
-        Self(PORTS.to_vec())
-    }
-}
-
-impl Deref for WolPorts {
+impl Deref for PortList {
     type Target = [NonZeroU16];
 
     fn deref(&self) -> &Self::Target {
@@ -214,34 +208,34 @@ impl Deref for WolPorts {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub(crate) enum WolPortsError {
-    #[error("wol_ports must not be empty")]
+pub(crate) enum PortListError {
+    #[error("port list must not be empty")]
     Empty,
-    #[error("wol_ports contains duplicate port {0}")]
+    #[error("duplicate port {0}")]
     Duplicate(u16),
     /// A comma-separated token was not a port in 1..=65535.
-    #[error("wol_ports has an invalid port \"{0}\"")]
+    #[error("invalid port \"{0}\"")]
     BadPort(String),
 }
 
-impl TryFrom<Vec<NonZeroU16>> for WolPorts {
-    type Error = WolPortsError;
+impl TryFrom<Vec<NonZeroU16>> for PortList {
+    type Error = PortListError;
 
     fn try_from(ports: Vec<NonZeroU16>) -> Result<Self, Self::Error> {
         if ports.is_empty() {
-            return Err(WolPortsError::Empty);
+            return Err(PortListError::Empty);
         }
         for (i, port) in ports.iter().enumerate() {
             if ports[..i].contains(port) {
-                return Err(WolPortsError::Duplicate(port.get()));
+                return Err(PortListError::Duplicate(port.get()));
             }
         }
         Ok(Self(ports))
     }
 }
 
-impl FromStr for WolPorts {
-    type Err = WolPortsError;
+impl FromStr for PortList {
+    type Err = PortListError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ports = s
@@ -250,16 +244,85 @@ impl FromStr for WolPorts {
                 let token = token.trim();
                 token
                     .parse::<NonZeroU16>()
-                    .map_err(|_| WolPortsError::BadPort(token.to_owned()))
+                    .map_err(|_| PortListError::BadPort(token.to_owned()))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        WolPorts::try_from(ports)
+        PortList::try_from(ports)
     }
 }
 
-impl<'de> Deserialize<'de> for WolPorts {
+impl<'de> Deserialize<'de> for PortList {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Vec::<NonZeroU16>::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// A non-empty, duplicate-free list of multicast groups, of either family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GroupList(Vec<IpAddr>);
+
+impl Deref for GroupList {
+    type Target = [IpAddr];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum GroupListError {
+    #[error("group list must not be empty")]
+    Empty,
+    #[error("duplicate group {0}")]
+    Duplicate(IpAddr),
+    #[error("{0} is not a multicast address")]
+    NotMulticast(IpAddr),
+    /// A comma-separated token was not an IP address.
+    #[error("invalid group \"{0}\"")]
+    BadAddress(String),
+}
+
+impl TryFrom<Vec<IpAddr>> for GroupList {
+    type Error = GroupListError;
+
+    fn try_from(groups: Vec<IpAddr>) -> Result<Self, Self::Error> {
+        if groups.is_empty() {
+            return Err(GroupListError::Empty);
+        }
+        for (i, group) in groups.iter().enumerate() {
+            if !group.is_multicast() {
+                return Err(GroupListError::NotMulticast(*group));
+            }
+            if groups[..i].contains(group) {
+                return Err(GroupListError::Duplicate(*group));
+            }
+        }
+        Ok(Self(groups))
+    }
+}
+
+impl FromStr for GroupList {
+    type Err = GroupListError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let groups = s
+            .split(',')
+            .map(|token| {
+                let token = token.trim();
+                token
+                    .parse::<IpAddr>()
+                    .map_err(|_| GroupListError::BadAddress(token.to_owned()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        GroupList::try_from(groups)
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupList {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Vec::<IpAddr>::deserialize(deserializer)?
             .try_into()
             .map_err(serde::de::Error::custom)
     }
@@ -335,30 +398,50 @@ mod tests {
     }
 
     #[test]
-    fn wol_ports_parse_via_fromstr() {
-        let ports = "7, 9, 4000".parse::<WolPorts>().unwrap();
+    fn port_list_parses_via_fromstr() {
+        let ports = "7, 9, 4000".parse::<PortList>().unwrap();
         assert_eq!(
             ports.iter().map(|p| p.get()).collect::<Vec<_>>(),
             [7, 9, 4000]
         );
         assert!(matches!(
-            "7,7".parse::<WolPorts>(),
-            Err(WolPortsError::Duplicate(7))
+            "7,7".parse::<PortList>(),
+            Err(PortListError::Duplicate(7))
         ));
         assert!(matches!(
-            "0".parse::<WolPorts>(),
-            Err(WolPortsError::BadPort(_))
+            "0".parse::<PortList>(),
+            Err(PortListError::BadPort(_))
         ));
         assert!(matches!(
-            "abc".parse::<WolPorts>(),
-            Err(WolPortsError::BadPort(_))
+            "abc".parse::<PortList>(),
+            Err(PortListError::BadPort(_))
+        ));
+    }
+
+    #[test]
+    fn group_list_parses_multicast_groups_only() {
+        let groups = "239.255.90.90, ff12::8384".parse::<GroupList>().unwrap();
+        assert_eq!(
+            groups.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            ["239.255.90.90", "ff12::8384"]
+        );
+        let unicast: IpAddr = "192.0.2.1".parse().unwrap();
+        assert_eq!(
+            "192.0.2.1".parse::<GroupList>(),
+            Err(GroupListError::NotMulticast(unicast))
+        );
+        let group: IpAddr = "239.255.90.90".parse().unwrap();
+        assert_eq!(
+            "239.255.90.90,239.255.90.90".parse::<GroupList>(),
+            Err(GroupListError::Duplicate(group))
+        );
+        assert!(matches!(
+            "roon".parse::<GroupList>(),
+            Err(GroupListError::BadAddress(_))
         ));
         assert_eq!(
-            WolPorts::default()
-                .iter()
-                .map(|p| p.get())
-                .collect::<Vec<_>>(),
-            [7, 9]
+            GroupList::try_from(Vec::<IpAddr>::new()),
+            Err(GroupListError::Empty)
         );
     }
 
@@ -373,11 +456,11 @@ mod tests {
     }
 
     #[test]
-    fn wol_ports_reject_an_empty_list() {
+    fn port_list_rejects_an_empty_list() {
         // FromStr can't yield an empty list, so Empty is reachable only via the TryFrom path.
         assert!(matches!(
-            WolPorts::try_from(Vec::<NonZeroU16>::new()),
-            Err(WolPortsError::Empty)
+            PortList::try_from(Vec::<NonZeroU16>::new()),
+            Err(PortListError::Empty)
         ));
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -29,7 +29,7 @@ mod pair_tests;
 pub(crate) use self::counters::{MessageType, Outcome};
 pub(crate) use self::datagram::DatagramSource;
 pub(crate) use self::dial_context::{DialContext, DialProxyKey};
-pub(crate) use self::multicast::join_deferrable;
+pub(crate) use self::multicast::{join_capped, join_deferrable};
 
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -152,19 +152,15 @@ pub(crate) struct Filter {
     /// Allow-set on the source MAC: the packet's source must be a member.
     pub(crate) src_mac: Option<MacSet>,
     pub(crate) dst_mac: Option<MacAddr>,
-    /// Require an IPv4 broadcast destination: the ingress's own directed broadcast or the limited
-    /// one. Resolved against the ingress's addresses at match time, so it follows a prefix change
-    /// without re-registering.
+    /// Require an IPv4 broadcast destination, see [`Packet::is_broadcast`].
     pub(crate) broadcast: bool,
 }
 
 impl Filter {
     /// Whether `p` satisfies every set field (an unset field matches anything), given the ingress's
-    /// current directed broadcast for the `broadcast` field.
+    /// directed broadcast for the `broadcast` field on a link without MACs.
     fn matches(&self, p: &Packet, ingress_directed_broadcast: Option<Ipv4Addr>) -> bool {
-        (!self.broadcast
-            || matches!(p.dest.ip(), IpAddr::V4(v4)
-                if v4.is_broadcast() || Some(v4) == ingress_directed_broadcast))
+        (!self.broadcast || p.is_broadcast(ingress_directed_broadcast))
             && self.src_ip.is_none_or(|ip| p.source.ip() == ip)
             && self
                 .dst_ip
@@ -1263,24 +1259,35 @@ mod tests {
     }
 
     #[test]
-    fn filter_broadcast_takes_the_ingress_directed_or_limited_broadcast() {
+    fn filter_broadcast_takes_the_all_ones_mac_or_the_limited_broadcast() {
         let f = Filter {
             broadcast: true,
             ..Filter::default()
         };
-        let directed = Some(Ipv4Addr::new(10, 0, 0, 255));
+        let all_ones = Some(MacAddr::broadcast());
+        let unicast = Some(MacAddr::from([0x02, 0, 0, 0, 0, 1]));
+        let own = Some(Ipv4Addr::new(10, 0, 0, 255));
+        // On the all-ones MAC every subnet's directed broadcast qualifies, the limited one too.
+        assert!(f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", all_ones, None), own));
+        assert!(f.matches(&packet("10.0.1.1:1", "10.0.1.255:9", all_ones, None), own));
         assert!(f.matches(
-            &packet("10.0.0.1:1", "255.255.255.255:9", None, None),
-            directed
+            &packet("10.0.0.1:1", "255.255.255.255:9", all_ones, None),
+            own
         ));
-        assert!(f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", None, None), directed));
-        // Another subnet's broadcast, a unicast, and a group are not broadcasts here; without a
-        // known prefix only the limited broadcast qualifies.
-        assert!(!f.matches(&packet("10.0.0.1:1", "10.0.1.255:9", None, None), directed));
-        assert!(!f.matches(&packet("10.0.0.1:1", "10.0.0.2:9", None, None), directed));
-        assert!(!f.matches(&packet("10.0.0.1:1", "224.0.0.251:9", None, None), directed));
+        // Without MACs (DLT_NULL) the address decides: the limited broadcast, or the link's own.
+        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:9", None, None), own));
+        assert!(f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", None, None), own));
+        assert!(!f.matches(&packet("10.0.1.1:1", "10.0.1.255:9", None, None), own));
         assert!(!f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", None, None), None));
-        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:9", None, None), None));
+        // The frame decides, not the address's shape: a broadcast-looking address on a unicast
+        // frame is unicast, a unicast-looking one on the all-ones MAC is a broadcast of a subnet
+        // the sender knows.
+        assert!(!f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", unicast, None), own));
+        assert!(f.matches(&packet("10.0.0.1:1", "10.0.0.2:9", all_ones, None), own));
+        assert!(!f.matches(&packet("10.0.0.1:1", "224.0.0.251:9", None, None), own));
+        // A group on the all-ones MAC is still a group: the group handler's, not this one's.
+        assert!(!f.matches(&packet("10.0.0.1:1", "224.0.0.251:9", all_ones, None), own));
+        assert!(!f.matches(&packet("[fe80::1]:1", "[ff02::1]:9", all_ones, None), own));
     }
 
     #[test]

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -27,11 +27,12 @@ mod multicast;
 mod pair_tests;
 
 pub(crate) use self::counters::{MessageType, Outcome};
+pub(crate) use self::datagram::DatagramSource;
 pub(crate) use self::dial_context::{DialContext, DialProxyKey};
 pub(crate) use self::multicast::join_deferrable;
 
 use std::io;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::Deref;
 use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
@@ -151,12 +152,20 @@ pub(crate) struct Filter {
     /// Allow-set on the source MAC: the packet's source must be a member.
     pub(crate) src_mac: Option<MacSet>,
     pub(crate) dst_mac: Option<MacAddr>,
+    /// Require an IPv4 broadcast destination: the ingress's own directed broadcast or the limited
+    /// one. Resolved against the ingress's addresses at match time, so it follows a prefix change
+    /// without re-registering.
+    pub(crate) broadcast: bool,
 }
 
 impl Filter {
-    /// Whether `p` satisfies every set field (an unset field matches anything).
-    fn matches(&self, p: &Packet) -> bool {
-        self.src_ip.is_none_or(|ip| p.source.ip() == ip)
+    /// Whether `p` satisfies every set field (an unset field matches anything), given the ingress's
+    /// current directed broadcast for the `broadcast` field.
+    fn matches(&self, p: &Packet, ingress_directed_broadcast: Option<Ipv4Addr>) -> bool {
+        (!self.broadcast
+            || matches!(p.dest.ip(), IpAddr::V4(v4)
+                if v4.is_broadcast() || Some(v4) == ingress_directed_broadcast))
+            && self.src_ip.is_none_or(|ip| p.source.ip() == ip)
             && self
                 .dst_ip
                 .as_ref()
@@ -431,23 +440,23 @@ impl PacketDispatcher {
         self.table.capture(egress).map(Capture::link_type)
     }
 
-    /// Build a UDP datagram, sourced from the egress's own address, with `dst_mac` as the L2
-    /// destination, and inject it on `egress`. The caller supplies the L2 MAC, so this serves
-    /// unicast, multicast, and broadcast alike; the link framing (Ethernet vs `DLT_NULL`) follows
-    /// the egress's link type, and the source port, `ttl`, and `payload` are carried verbatim.
-    /// Builds into the dispatcher's reused scratch buffer, so the data path never allocates. An
-    /// unknown or draining egress is a logged drop, like [`send`](Self::send).
+    /// Build a UDP datagram from `source` with `dst_mac` as the L2 destination, and inject it on
+    /// `egress`. The caller supplies the L2 MAC, so this serves unicast, multicast, and broadcast
+    /// alike; the link framing (Ethernet vs `DLT_NULL`) follows the egress's link type, and `ttl`
+    /// and `payload` are carried verbatim. Builds into the dispatcher's reused scratch buffer, so
+    /// the data path never allocates. An unknown or draining egress is a logged drop, like
+    /// [`send`](Self::send).
     ///
     /// # Errors
     /// Propagates a send failure, and reports a frame that can't be built from the egress's
-    /// current state: no source address/MAC for the datagram, or a payload that overflows
-    /// the scratch buffer or the datagram length fields.
+    /// current state: no source address/MAC for the datagram, a captured source of the other
+    /// family, or a payload that overflows the scratch buffer or the datagram length fields.
     pub(crate) fn send_udp(
         &mut self,
         egress: CaptureKey,
         dst: SocketAddr,
         dst_mac: MacAddr,
-        src_port: u16,
+        source: DatagramSource,
         ttl: u8,
         payload: &[u8],
     ) -> io::Result<()> {
@@ -464,7 +473,7 @@ impl PacketDispatcher {
             link,
             dst,
             dst_mac,
-            src_port,
+            source,
             ttl,
             payload,
             &mut self.scratch,
@@ -485,17 +494,23 @@ impl PacketDispatcher {
         &mut self,
         egress: CaptureKey,
         dst: SocketAddr,
-        src_port: u16,
+        source: DatagramSource,
         ttl: u8,
         payload: &[u8],
     ) -> io::Result<()> {
-        let dst_mac = ethernet_dst(
+        let dst_mac = self.group_mac(egress, dst)?;
+        self.send_udp(egress, dst, dst_mac, source, ttl, payload)
+    }
+
+    /// The L2 destination for a broadcast/multicast `dst` on `egress`: its own directed broadcast
+    /// counts as broadcast there.
+    fn group_mac(&self, egress: CaptureKey, dst: SocketAddr) -> io::Result<MacAddr> {
+        ethernet_dst(
             dst.ip(),
             self.egress_addrs(egress)
                 .and_then(InterfaceAddresses::v4_directed_broadcast),
         )
-        .map_err(io::Error::other)?;
-        self.send_udp(egress, dst, dst_mac, src_port, ttl, payload)
+        .map_err(io::Error::other)
     }
 
     /// Drain the capture `ingress` addresses and route each parsed packet. Reads up to
@@ -612,13 +627,16 @@ impl PacketDispatcher {
                 .iter()
                 .map(|(key, _)| RegistrationKey(key)),
         );
+        let ingress_directed_broadcast = self
+            .table
+            .egress_addrs(ingress)
+            .and_then(InterfaceAddresses::v4_directed_broadcast);
         let mut final_outcome: Option<Outcome> = None;
         for i in 0..self.route_keys.len() {
             let key = self.route_keys[i];
-            let applies = self
-                .registrations
-                .get(key.0)
-                .is_some_and(|reg| reg.ingress == ingress && reg.filter.matches(packet));
+            let applies = self.registrations.get(key.0).is_some_and(|reg| {
+                reg.ingress == ingress && reg.filter.matches(packet, ingress_directed_broadcast)
+            });
             if !applies {
                 continue;
             }
@@ -1219,7 +1237,7 @@ mod tests {
 
     #[test]
     fn wildcard_filter_matches_anything() {
-        assert!(Filter::default().matches(&packet("10.0.0.1:1", "10.0.0.2:2", None, None)));
+        assert!(Filter::default().matches(&packet("10.0.0.1:1", "10.0.0.2:2", None, None), None));
     }
 
     #[test]
@@ -1229,10 +1247,40 @@ mod tests {
             dst_port: Some(5353.into()),
             ..Filter::default()
         };
-        assert!(f.matches(&packet("10.0.0.1:5353", "224.0.0.251:5353", None, None)));
+        assert!(f.matches(
+            &packet("10.0.0.1:5353", "224.0.0.251:5353", None, None),
+            None
+        ));
         // Wrong group, and wrong port, each miss.
-        assert!(!f.matches(&packet("10.0.0.1:5353", "224.0.0.252:5353", None, None)));
-        assert!(!f.matches(&packet("10.0.0.1:5353", "224.0.0.251:1900", None, None)));
+        assert!(!f.matches(
+            &packet("10.0.0.1:5353", "224.0.0.252:5353", None, None),
+            None
+        ));
+        assert!(!f.matches(
+            &packet("10.0.0.1:5353", "224.0.0.251:1900", None, None),
+            None
+        ));
+    }
+
+    #[test]
+    fn filter_broadcast_takes_the_ingress_directed_or_limited_broadcast() {
+        let f = Filter {
+            broadcast: true,
+            ..Filter::default()
+        };
+        let directed = Some(Ipv4Addr::new(10, 0, 0, 255));
+        assert!(f.matches(
+            &packet("10.0.0.1:1", "255.255.255.255:9", None, None),
+            directed
+        ));
+        assert!(f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", None, None), directed));
+        // Another subnet's broadcast, a unicast, and a group are not broadcasts here; without a
+        // known prefix only the limited broadcast qualifies.
+        assert!(!f.matches(&packet("10.0.0.1:1", "10.0.1.255:9", None, None), directed));
+        assert!(!f.matches(&packet("10.0.0.1:1", "10.0.0.2:9", None, None), directed));
+        assert!(!f.matches(&packet("10.0.0.1:1", "224.0.0.251:9", None, None), directed));
+        assert!(!f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", None, None), None));
+        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:9", None, None), None));
     }
 
     #[test]
@@ -1249,11 +1297,23 @@ mod tests {
             dst_port: Some(5353.into()),
             ..Filter::default()
         };
-        assert!(f.matches(&packet("10.0.0.1:5353", "224.0.0.251:5353", None, None)));
-        assert!(f.matches(&packet("[fe80::1]:5353", "[ff02::fb]:5353", None, None)));
+        assert!(f.matches(
+            &packet("10.0.0.1:5353", "224.0.0.251:5353", None, None),
+            None
+        ));
+        assert!(f.matches(
+            &packet("[fe80::1]:5353", "[ff02::fb]:5353", None, None),
+            None
+        ));
         // A group outside the set, and a member on the wrong port, each miss.
-        assert!(!f.matches(&packet("10.0.0.1:5353", "239.255.255.250:5353", None, None)));
-        assert!(!f.matches(&packet("10.0.0.1:5353", "224.0.0.251:1900", None, None)));
+        assert!(!f.matches(
+            &packet("10.0.0.1:5353", "239.255.255.250:5353", None, None),
+            None
+        ));
+        assert!(!f.matches(
+            &packet("10.0.0.1:5353", "224.0.0.251:1900", None, None),
+            None
+        ));
     }
 
     #[test]
@@ -1263,10 +1323,10 @@ mod tests {
             dst_port: Some([7u16, 9].into()),
             ..Filter::default()
         };
-        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:7", None, None)));
-        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:9", None, None)));
+        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:7", None, None), None));
+        assert!(f.matches(&packet("10.0.0.1:1", "255.255.255.255:9", None, None), None));
         // A port outside the set misses.
-        assert!(!f.matches(&packet("10.0.0.1:1", "255.255.255.255:8", None, None)));
+        assert!(!f.matches(&packet("10.0.0.1:1", "255.255.255.255:8", None, None), None));
     }
 
     #[test]
@@ -1276,16 +1336,17 @@ mod tests {
             src_mac: Some(MacSet::from(device)),
             ..Filter::default()
         };
-        assert!(f.matches(&packet(
-            "10.0.0.1:5353",
-            "10.0.0.2:5353",
-            None,
-            Some(device)
-        )));
+        assert!(f.matches(
+            &packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(device)),
+            None
+        ));
         // A different device, and a MAC-less (DLT_NULL) packet, both miss.
         let other = MacAddr::from([0x02, 0, 0, 0, 0, 0x02]);
-        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(other))));
-        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, None)));
+        assert!(!f.matches(
+            &packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(other)),
+            None
+        ));
+        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, None), None));
     }
 
     #[test]
@@ -1296,11 +1357,20 @@ mod tests {
             src_mac: Some(MacSet::try_from(vec![a, b]).unwrap()),
             ..Filter::default()
         };
-        assert!(f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(a))));
-        assert!(f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(b))));
+        assert!(f.matches(
+            &packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(a)),
+            None
+        ));
+        assert!(f.matches(
+            &packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(b)),
+            None
+        ));
         // A device outside the set misses.
         let other = MacAddr::from([0x02, 0, 0, 0, 0, 0x03]);
-        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(other))));
+        assert!(!f.matches(
+            &packet("10.0.0.1:5353", "10.0.0.2:5353", None, Some(other)),
+            None
+        ));
     }
 
     #[test]
@@ -1310,15 +1380,16 @@ mod tests {
             dst_mac: Some(device),
             ..Filter::default()
         };
-        assert!(f.matches(&packet(
-            "10.0.0.1:5353",
-            "10.0.0.2:5353",
-            Some(device),
+        assert!(f.matches(
+            &packet("10.0.0.1:5353", "10.0.0.2:5353", Some(device), None),
             None
-        )));
+        ));
         let other = MacAddr::from([0x02, 0, 0, 0, 0, 0x0b]);
-        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", Some(other), None)));
-        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, None)));
+        assert!(!f.matches(
+            &packet("10.0.0.1:5353", "10.0.0.2:5353", Some(other), None),
+            None
+        ));
+        assert!(!f.matches(&packet("10.0.0.1:5353", "10.0.0.2:5353", None, None), None));
     }
 
     // An IP filter is family-specific: a v4 criterion can't match a v6 packet, or vice
@@ -1329,12 +1400,18 @@ mod tests {
             dst_ip: Some("224.0.0.251".parse::<IpAddr>().unwrap().into()),
             ..Filter::default()
         };
-        assert!(!v4.matches(&packet("[fe80::1]:5353", "[ff02::fb]:5353", None, None)));
+        assert!(!v4.matches(
+            &packet("[fe80::1]:5353", "[ff02::fb]:5353", None, None),
+            None
+        ));
         let v6 = Filter {
             dst_ip: Some("ff02::fb".parse::<IpAddr>().unwrap().into()),
             ..Filter::default()
         };
-        assert!(!v6.matches(&packet("10.0.0.1:5353", "224.0.0.251:5353", None, None)));
+        assert!(!v6.matches(
+            &packet("10.0.0.1:5353", "224.0.0.251:5353", None, None),
+            None
+        ));
     }
 
     const PROBE: &[u8] = b"netflector-dispatch-probe";
@@ -1371,7 +1448,7 @@ mod tests {
                     self.egress,
                     dst,
                     MacAddr::from([0xff; 6]),
-                    src.port(),
+                    DatagramSource::Egress { port: src.port() },
                     packet.ttl,
                     packet.payload,
                 )
@@ -1999,7 +2076,11 @@ mod tests {
         assert!(dispatcher.send(bogus, b"x").is_ok());
         // send_udp_group on an unknown egress is the same logged drop, not a build attempt.
         let dst = SocketAddr::from((Ipv4Addr::BROADCAST, 9));
-        assert!(dispatcher.send_udp_group(bogus, dst, 1, 64, b"x").is_ok());
+        assert!(
+            dispatcher
+                .send_udp_group(bogus, dst, DatagramSource::Egress { port: 1 }, 64, b"x")
+                .is_ok()
+        );
         Ok(())
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -274,8 +274,17 @@ impl PacketDispatcher {
     /// first [`add_capture`](Self::add_capture) resolve, so a change during startup is
     /// already queued rather than missed.
     pub(crate) fn new() -> Self {
+        Self::with_table(InterfaceTable::new())
+    }
+
+    /// A dispatcher that joins no multicast group: `--no-join`.
+    pub(crate) fn without_group_joins() -> Self {
+        Self::with_table(InterfaceTable::without_group_joins())
+    }
+
+    fn with_table(table: InterfaceTable) -> Self {
         Self {
-            table: InterfaceTable::new(),
+            table,
             registrations: Arena::new(),
             route_keys: Vec::new(),
             monitor: Self::open_monitor(),

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -57,6 +57,7 @@ message_types! {
     WsdSearch => ("WSD", "search"),
     WsdResponse => ("WSD", "response"),
     WakeOnLan => ("WoL", ""),
+    UdpDatagram => ("UDP relay", ""),
 }
 
 impl fmt::Display for MessageType {

--- a/src/dispatch/counters.rs
+++ b/src/dispatch/counters.rs
@@ -39,6 +39,12 @@ macro_rules! message_types {
                     $(Self::$variant => ($protocol, $direction)),+
                 }
             }
+
+            /// Whether the type names a protocol. The UDP relay's does not: it types a packet as
+            /// whatever it is, and yields to a protocol handler's verdict on the same packet.
+            fn is_specific(self) -> bool {
+                self != Self::UdpDatagram
+            }
         }
 
         /// The number of [`MessageType`] variants: the width of a per-interface counter row. Derived
@@ -87,7 +93,8 @@ enum Disposition {
 /// dispatcher logs them rather than silently miscounting.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct Anomalies {
-    /// Two handlers classified one packet to different message types: a classifier or config bug.
+    /// Two handlers classified one packet to different protocols: a classifier or config bug. The
+    /// relay's datagram type does not count; it yields to a protocol's.
     pub(crate) type_mismatch: bool,
 }
 
@@ -128,20 +135,39 @@ impl Outcome {
         }
     }
 
+    /// This outcome carrying `message_type` instead of its own.
+    fn with_type(self, message_type: MessageType) -> Outcome {
+        match self {
+            Self::Reflected(_) => Self::Reflected(message_type),
+            Self::Skipped(_) => Self::Skipped(message_type),
+            Self::Dropped(_) => Self::Dropped(message_type),
+            Self::Stalled(_) => Self::Stalled(message_type),
+            Self::Filtered => Self::Filtered,
+        }
+    }
+
     /// Fold another handler's outcome for the *same* packet into this running one: keep the
-    /// higher-precedence disposition, and report any invariant [`Anomalies`]. Order-independent (a max
-    /// over [`disposition`](Self::disposition)), so handler visitation order doesn't change the result.
+    /// higher-precedence disposition under the protocol's type when one handler is the relay, and
+    /// report any invariant [`Anomalies`]. Order-independent (a max over
+    /// [`disposition`](Self::disposition)), so handler visitation order doesn't change the result.
     pub(crate) fn combine(self, other: Outcome) -> (Outcome, Anomalies) {
+        let types = (self.message_type(), other.message_type());
         let anomalies = Anomalies {
             type_mismatch: matches!(
-                (self.message_type(), other.message_type()),
-                (Some(a), Some(b)) if a != b
+                types,
+                (Some(a), Some(b)) if a != b && a.is_specific() && b.is_specific()
             ),
         };
         let merged = if other.disposition() > self.disposition() {
             other
         } else {
             self
+        };
+        let merged = match types {
+            (Some(a), Some(b)) if a.is_specific() != b.is_specific() => {
+                merged.with_type(if a.is_specific() { a } else { b })
+            }
+            _ => merged,
         };
         (merged, anomalies)
     }
@@ -435,6 +461,29 @@ mod tests {
         let (merged, anomalies) = Outcome::Reflected(Q).combine(Outcome::Reflected(Q));
         assert_eq!(merged, Outcome::Reflected(Q));
         assert_eq!(anomalies, Anomalies::default());
+    }
+
+    #[test]
+    fn combine_counts_a_packet_the_relay_shares_under_the_protocol() {
+        use MessageType::{MdnsQuery as Q, MdnsResponse as R, UdpDatagram as U};
+        // A relay and a protocol handler on one ingress see the same packet: the protocol's type
+        // wins in either order and at either disposition, and it is no mismatch.
+        for (mine, theirs) in [
+            (Outcome::Reflected(Q), Outcome::Reflected(U)),
+            (Outcome::Reflected(U), Outcome::Reflected(Q)),
+        ] {
+            let (merged, anomalies) = mine.combine(theirs);
+            assert_eq!(merged, Outcome::Reflected(Q));
+            assert!(!anomalies.type_mismatch);
+        }
+        // The relay forwards a response the protocol's leg skips: reflected, as a response.
+        let (merged, anomalies) = Outcome::Skipped(R).combine(Outcome::Reflected(U));
+        assert_eq!(merged, Outcome::Reflected(R));
+        assert!(!anomalies.type_mismatch);
+        // Two relays agree with each other.
+        let (merged, anomalies) = Outcome::Reflected(U).combine(Outcome::Reflected(U));
+        assert_eq!(merged, Outcome::Reflected(U));
+        assert!(!anomalies.type_mismatch);
     }
 
     #[test]

--- a/src/dispatch/datagram.rs
+++ b/src/dispatch/datagram.rs
@@ -23,9 +23,20 @@ pub(super) enum DatagramError {
     NoSourceMac,
     #[error("destination is unicast; only broadcast/multicast is injected")]
     UnicastDestination,
+    #[error("source and destination are of different address families")]
+    SourceFamilyMismatch,
     /// The frame builder rejected the datagram (buffer too small, or payload too large).
     #[error(transparent)]
     Frame(#[from] FrameError),
+}
+
+/// The IP source of an injected datagram.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DatagramSource {
+    /// The egress's own address of the destination's family, at `port`.
+    Egress { port: u16 },
+    /// A captured sender's own address and port, kept on the re-emit.
+    Captured(SocketAddr),
 }
 
 /// The Ethernet destination MAC for an injected datagram to `dst`: the all-ones broadcast
@@ -47,11 +58,11 @@ pub(super) fn ethernet_dst(
 }
 
 /// Assemble a UDP datagram for an egress with addresses `addrs` and link framing `link` into
-/// `scratch`, returning its byte length. The L2 source is the egress's own IP and MAC; the L2
-/// destination is the caller-supplied `dst_mac` (so this serves unicast, multicast, and broadcast
-/// alike). BSD `DLT_NULL` (loopback/tunnel) carries no L2 addresses, so it ignores `dst_mac` and
-/// needs no source MAC.
-// A frame builder takes the full wire spec (egress addrs + link, dst addr + MAC, port, ttl,
+/// `scratch`, returning its byte length. The IP source is `source`, the L2 source the egress's own
+/// MAC; the L2 destination is the caller-supplied `dst_mac` (so this serves unicast, multicast, and
+/// broadcast alike). BSD `DLT_NULL` (loopback/tunnel) carries no L2 addresses, so it ignores
+/// `dst_mac` and needs no source MAC.
+// A frame builder takes the full wire spec (egress addrs + link, dst addr + MAC, source, ttl,
 // payload, buffer); bundling any of these would obscure more than the arg count costs.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_udp(
@@ -59,15 +70,22 @@ pub(super) fn build_udp(
     link: LinkType,
     dst: SocketAddr,
     dst_mac: MacAddr,
-    src_port: u16,
+    source: DatagramSource,
     ttl: u8,
     payload: &[u8],
     scratch: &mut [u8],
 ) -> Result<usize, DatagramError> {
     match dst {
         SocketAddr::V4(dst) => {
-            let src =
-                SocketAddrV4::new(addrs.v4().ok_or(DatagramError::NoSourceAddress)?, src_port);
+            let src = match source {
+                DatagramSource::Egress { port } => {
+                    SocketAddrV4::new(addrs.v4().ok_or(DatagramError::NoSourceAddress)?, port)
+                }
+                DatagramSource::Captured(SocketAddr::V4(src)) => src,
+                DatagramSource::Captured(SocketAddr::V6(_)) => {
+                    return Err(DatagramError::SourceFamilyMismatch);
+                }
+            };
             match link {
                 LinkType::Ethernet => Ok(frame::ethernet_ipv4_udp(
                     dst_mac,
@@ -83,12 +101,20 @@ pub(super) fn build_udp(
             }
         }
         SocketAddr::V6(dst) => {
-            // Source the datagram from an address matching the destination's scope, so a site-local
-            // group (`ff05::c`) isn't sourced from a link-local address.
-            let src_ip = addrs
-                .v6(Ipv6Scope::of(*dst.ip()))
-                .ok_or(DatagramError::NoSourceAddress)?;
-            let src = SocketAddrV6::new(src_ip, src_port, 0, 0);
+            let src = match source {
+                // Source the datagram from an address matching the destination's scope, so a
+                // site-local group (`ff05::c`) isn't sourced from a link-local address.
+                DatagramSource::Egress { port } => {
+                    let src_ip = addrs
+                        .v6(Ipv6Scope::of(*dst.ip()))
+                        .ok_or(DatagramError::NoSourceAddress)?;
+                    SocketAddrV6::new(src_ip, port, 0, 0)
+                }
+                DatagramSource::Captured(SocketAddr::V6(src)) => src,
+                DatagramSource::Captured(SocketAddr::V4(_)) => {
+                    return Err(DatagramError::SourceFamilyMismatch);
+                }
+            };
             match link {
                 LinkType::Ethernet => Ok(frame::ethernet_ipv6_udp(
                     dst_mac,
@@ -133,7 +159,7 @@ mod tests {
             LinkType::Ethernet,
             dst,
             MacAddr::multicast_for(dst.ip()),
-            4000,
+            DatagramSource::Egress { port: 4000 },
             2,
             b"ssdp",
             &mut scratch,
@@ -151,6 +177,44 @@ mod tests {
             "ff05::c sourced from the routable address"
         );
         assert!(n > 38);
+    }
+
+    #[test]
+    fn build_udp_keeps_a_captured_source_verbatim() {
+        // A relay re-emit carries the sender's own ip:port, not the egress's; the frame's source
+        // sits at bytes [26..30] (14 Ethernet + offset 12) and its port at [34..36].
+        let addrs = full_addrs();
+        let dst = SocketAddr::from((Ipv4Addr::BROADCAST, 9003));
+        let captured: SocketAddr = "192.0.2.7:40001".parse().unwrap();
+        let mut scratch = [0u8; 2048];
+        let n = build_udp(
+            &addrs,
+            LinkType::Ethernet,
+            dst,
+            MacAddr::broadcast(),
+            DatagramSource::Captured(captured),
+            32,
+            b"sood",
+            &mut scratch,
+        )
+        .unwrap();
+        assert_eq!(&scratch[26..30], &[192, 0, 2, 7]);
+        assert_eq!(&scratch[34..36], &40001u16.to_be_bytes());
+        assert!(n > 36);
+        // A source of the other family cannot be framed.
+        assert_eq!(
+            build_udp(
+                &addrs,
+                LinkType::Ethernet,
+                dst,
+                MacAddr::broadcast(),
+                DatagramSource::Captured("[fe80::7]:40001".parse().unwrap()),
+                32,
+                b"sood",
+                &mut scratch,
+            ),
+            Err(DatagramError::SourceFamilyMismatch)
+        );
     }
 
     #[test]
@@ -201,7 +265,7 @@ mod tests {
             LinkType::Ethernet,
             dst,
             MacAddr::broadcast(),
-            4000,
+            DatagramSource::Egress { port: 4000 },
             64,
             b"wol",
             &mut scratch,
@@ -224,7 +288,7 @@ mod tests {
             LinkType::Ethernet,
             dst,
             MacAddr::multicast_for(IpAddr::V6(group)),
-            4000,
+            DatagramSource::Egress { port: 4000 },
             64,
             b"wol",
             &mut scratch,
@@ -248,7 +312,7 @@ mod tests {
             LinkType::Ethernet,
             dst,
             searcher_mac,
-            4000,
+            DatagramSource::Egress { port: 4000 },
             64,
             b"ok",
             &mut scratch,
@@ -277,7 +341,7 @@ mod tests {
                 LinkType::Ethernet,
                 dst,
                 MacAddr::broadcast(),
-                4000,
+                DatagramSource::Egress { port: 4000 },
                 64,
                 b"x",
                 &mut scratch
@@ -302,7 +366,7 @@ mod tests {
                 LinkType::Ethernet,
                 dst,
                 MacAddr::broadcast(),
-                4000,
+                DatagramSource::Egress { port: 4000 },
                 64,
                 b"x",
                 &mut scratch
@@ -323,7 +387,7 @@ mod tests {
                 LinkType::Ethernet,
                 dst,
                 MacAddr::broadcast(),
-                4000,
+                DatagramSource::Egress { port: 4000 },
                 64,
                 b"x",
                 &mut tiny
@@ -351,7 +415,7 @@ mod tests {
             LinkType::DltNull,
             dst,
             MacAddr::broadcast(),
-            4000,
+            DatagramSource::Egress { port: 4000 },
             64,
             b"wol",
             &mut scratch,

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -55,6 +55,8 @@ pub(super) struct InterfaceTable {
     /// One entry per interface, indexed by [`InterfaceKey`].
     entries: Vec<InterfaceEntry>,
     captures: Vec<CaptureEntry>,
+    /// Whether an added interface gets a joiner that joins.
+    join_groups: bool,
 }
 
 impl InterfaceTable {
@@ -62,6 +64,15 @@ impl InterfaceTable {
         Self {
             entries: Vec::new(),
             captures: Vec::new(),
+            join_groups: true,
+        }
+    }
+
+    /// A table whose interfaces join no multicast group: `--no-join`.
+    pub(super) fn without_group_joins() -> Self {
+        Self {
+            join_groups: false,
+            ..Self::new()
         }
     }
 
@@ -69,7 +80,11 @@ impl InterfaceTable {
     fn add_interface(&mut self, interface: Interface) -> InterfaceKey {
         let key =
             InterfaceKey(u32::try_from(self.entries.len()).expect("interface count fits a u32"));
-        let joiner = MulticastJoiner::new();
+        let joiner = if self.join_groups {
+            MulticastJoiner::new()
+        } else {
+            MulticastJoiner::inert()
+        };
         self.entries.push(InterfaceEntry { interface, joiner });
         key
     }

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -46,6 +46,8 @@ pub(crate) struct MulticastJoiner {
     v4: Option<OwnedFd>,
     v6: Option<OwnedFd>,
     desired: Vec<Desired>,
+    /// Cleared for an inert joiner, whose joins succeed without a membership.
+    joins: bool,
 }
 
 impl MulticastJoiner {
@@ -54,6 +56,16 @@ impl MulticastJoiner {
             v4: None,
             v6: None,
             desired: Vec::new(),
+            joins: true,
+        }
+    }
+
+    /// A joiner that joins nothing: `--no-join`. Its joins are successful no-ops and its
+    /// rejoins have nothing to replay.
+    pub(crate) fn inert() -> Self {
+        Self {
+            joins: false,
+            ..Self::new()
         }
     }
 
@@ -82,6 +94,9 @@ impl MulticastJoiner {
     /// retries it on the next address-up event. Any other error is marked reported before it
     /// returns -- the caller's log is the report, and the replay repeats it at debug only.
     pub(crate) fn join(&mut self, group: IpAddr, ifindex: NonZeroU32) -> io::Result<()> {
+        if !self.joins {
+            return Ok(());
+        }
         let index = self.record(group);
         let result = self.apply(group, ifindex);
         if let Err(e) = &result
@@ -224,6 +239,17 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use super::*;
+
+    #[test]
+    fn an_inert_joiner_joins_nothing_and_opens_no_socket() {
+        let mut joiner = MulticastJoiner::inert();
+        let ifindex = NonZeroU32::new(1).unwrap();
+        joiner
+            .join(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251)), ifindex)
+            .unwrap();
+        assert!(joiner.test_socketless());
+        assert_eq!(joiner.rejoin(ifindex), RejoinCounts::default());
+    }
 
     #[test]
     fn the_membership_cap_errnos_are_capped_joins() {

--- a/src/dispatch/multicast.rs
+++ b/src/dispatch/multicast.rs
@@ -205,6 +205,12 @@ pub(crate) fn join_unsupported(err: &io::Error) -> bool {
     )
 }
 
+/// Whether a group-join failure means the socket holds as many memberships as the system allows:
+/// `ENOBUFS` on Linux (`net.ipv4.igmp_max_memberships`), `ETOOMANYREFS` on the BSDs.
+pub(crate) fn join_capped(e: &io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(libc::ENOBUFS | libc::ETOOMANYREFS))
+}
+
 /// Whether a group-join failure is deferrable: `EADDRNOTAVAIL` means the interface has no address of
 /// the group's family yet, so the group joins on the address event that supplies one. Every other
 /// error is replayed just the same, but has no trigger anyone can name, so it reports as a failure
@@ -218,6 +224,15 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use super::*;
+
+    #[test]
+    fn the_membership_cap_errnos_are_capped_joins() {
+        let of = io::Error::from_raw_os_error;
+        assert!(join_capped(&of(libc::ENOBUFS)));
+        assert!(join_capped(&of(libc::ETOOMANYREFS)));
+        assert!(!join_capped(&of(libc::EINVAL)));
+        assert!(!join_capped(&of(libc::EADDRNOTAVAIL)));
+    }
 
     #[test]
     fn only_eaddrnotavail_is_a_deferrable_join() {

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -23,7 +23,7 @@ use crate::{
     sys::sockaddr_for,
 };
 
-use super::datagram::{build_udp, ethernet_dst};
+use super::datagram::{DatagramSource, build_udp, ethernet_dst};
 use super::interface_table::InterfaceTable;
 use super::multicast::MulticastJoiner;
 
@@ -491,7 +491,9 @@ fn inject(
         injector.link_type(),
         dst,
         ethernet_dst(dst.ip(), None).expect("broadcast/multicast destination"),
-        INJECT_SRC_PORT,
+        DatagramSource::Egress {
+            port: INJECT_SRC_PORT,
+        },
         64,
         payload,
         &mut scratch,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,8 +160,8 @@ fn build_reflector(
     interfaces: &InterfaceMap,
     dispatcher: &mut PacketDispatcher,
 ) -> Result<()> {
-    use crate::reflector::{mdns, ssdp, wol, wsd};
-    for build in [wol::build, mdns::build, ssdp::build, wsd::build] {
+    use crate::reflector::{mdns, ssdp, udp, wol, wsd};
+    for build in [wol::build, mdns::build, ssdp::build, wsd::build, udp::build] {
         build(reflector, interfaces, dispatcher)
             .map_err(|e| Error::reflector(reflector.name.as_str(), e))?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub fn run(args: &[OsString]) -> Result<()> {
             Ok(())
         }
         Invocation::CheckConfig(path) => check_config(path),
-        Invocation::Run(path) => reflect(path),
+        Invocation::Run { path, join_groups } => reflect(path, join_groups),
     }
 }
 
@@ -74,12 +74,12 @@ fn check_config(path: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-/// Run netflector to completion.
+/// Run netflector to completion. With `join_groups` off, no multicast group is joined.
 ///
 /// # Errors
 /// Returns [`Error`] if configuration loading or validation fails, or if the
 /// reactor cannot be created or its event loop fails.
-fn reflect(path: Option<&Path>) -> Result<()> {
+fn reflect(path: Option<&Path>, join_groups: bool) -> Result<()> {
     let toml_text = path.map(config::read_config_file).transpose()?;
     // sys::process_env, not std::env::vars: vars() segfaults in statically
     // linked FreeBSD binaries (see process_env).
@@ -111,7 +111,15 @@ fn reflect(path: Option<&Path>) -> Result<()> {
     );
 
     // Build the data path: one capture per interface, then the reflectors that bridge them.
-    let mut dispatcher = PacketDispatcher::new();
+    let mut dispatcher = if join_groups {
+        PacketDispatcher::new()
+    } else {
+        log::warn!(
+            "--no-join: multicast groups are not joined; group traffic reaches the captures \
+             only where the link delivers it without a membership"
+        );
+        PacketDispatcher::without_group_joins()
+    };
     let interfaces = open_captures(&config, &mut dispatcher)?;
     for reflector in &config.reflectors {
         log_mtu_info(reflector, &interfaces, &dispatcher);

--- a/src/net/mac.rs
+++ b/src/net/mac.rs
@@ -111,7 +111,7 @@ impl<'de> Deserialize<'de> for MacAddr {
 
 /// A non-empty, duplicate-free set of MAC addresses: a device allow-filter.
 ///
-/// The set is always non-empty (mirroring [`WolPorts`](crate::config::WolPorts));
+/// The set is always non-empty (mirroring [`PortList`](crate::config::PortList));
 /// "match any device" is expressed by an absent (`None`) filter at the use site,
 /// not by an empty set.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -32,6 +32,20 @@ pub(crate) struct Packet<'a> {
     pub(crate) payload: &'a [u8],
 }
 
+impl Packet<'_> {
+    /// Whether the datagram is an IPv4 broadcast. On a link with MACs the frame says: it went to
+    /// the all-ones MAC, which carries a directed broadcast of any subnet on the link as well as the
+    /// limited one. A link without MACs (`DLT_NULL`, a tunnel or a loopback) leaves the address:
+    /// the limited broadcast, or `directed_broadcast`, the link's own subnet's.
+    pub(crate) fn is_broadcast(&self, directed_broadcast: Option<Ipv4Addr>) -> bool {
+        match (self.dest.ip(), self.dst_mac) {
+            (IpAddr::V4(v4), Some(mac)) => !v4.is_multicast() && mac == MacAddr::broadcast(),
+            (IpAddr::V4(v4), None) => v4.is_broadcast() || Some(v4) == directed_broadcast,
+            (IpAddr::V6(_), _) => false,
+        }
+    }
+}
+
 /// Why a captured frame could not be parsed into a [`Packet`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub(crate) enum ParseError {

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -5,6 +5,7 @@
 pub(crate) mod dial;
 pub(crate) mod mdns;
 pub(crate) mod ssdp;
+pub(crate) mod udp;
 pub(crate) mod wol;
 pub(crate) mod wsd;
 

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -21,7 +21,7 @@ use std::net::{IpAddr, SocketAddr};
 use thiserror::Error;
 
 use crate::config::AddressFamily;
-use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_deferrable};
+use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_capped, join_deferrable};
 use crate::interface::InterfaceAddresses;
 use crate::linear_map::LinearMap;
 use crate::logging::WARN_WINDOW;
@@ -139,6 +139,15 @@ pub(crate) enum BuildError {
     /// nothing, silently discarding every device-side packet.
     #[error("macs can never match on interface \"{0}\": its link carries no MAC addresses")]
     MacsUnmatchable(String),
+    /// A group the reflector captures could not be joined, for a reason no later event clears,
+    /// so its traffic would never arrive. A startup failure rather than a running daemon that
+    /// reflects nothing for it.
+    #[error("cannot join {group} on interface \"{interface}\": {reason}")]
+    GroupJoin {
+        group: IpAddr,
+        interface: String,
+        reason: String,
+    },
 }
 
 /// Refuse a `macs` filter on a target whose link framing carries no MAC addresses:
@@ -218,30 +227,43 @@ fn require_bidirectional_families(
     Ok(())
 }
 
-/// Join `group` on `capture` for `protocol`'s `side` leg (`"source"`/`"target"`), logging the outcome.
-/// A [deferrable](join_deferrable) failure logs at debug (it retries on the next address change); any
-/// other failure is a warning, matching its re-join sibling — a dead reflector must not hide behind
-/// a debug line.
-fn join_group_logged(
+/// Join `group` on `capture`, the capture of `interface`, for `protocol`. A
+/// [deferrable](join_deferrable) failure logs at debug (it retries on the next address change);
+/// any other fails the build.
+///
+/// # Errors
+/// [`BuildError::GroupJoin`], naming the system's membership cap when that is the cause.
+fn require_group_join(
     dispatcher: &mut PacketDispatcher,
     capture: CaptureKey,
     group: IpAddr,
     protocol: &str,
-    side: &str,
-) {
+    interface: &str,
+) -> Result<(), BuildError> {
     match dispatcher.join_group(capture, group) {
-        Ok(()) => log::debug!("{protocol}: joined {group} on {side}"),
+        Ok(()) => log::debug!("{protocol}: joined {group} on {interface}"),
         Err(e) if join_deferrable(&e) => {
             log::debug!(
-                "{protocol}: join {group} on {side} deferred (no address of its family yet): {e}"
+                "{protocol}: join {group} on {interface} deferred (no address of its family yet): {e}"
             );
         }
         Err(e) => {
-            log::warn!(
-                "{protocol}: join {group} on {side} failed; its traffic is not reflected: {e}"
-            );
+            let reason = if join_capped(&e) {
+                format!(
+                    "{e}; the interface holds as many memberships as the system allows \
+                     (net.ipv4.igmp_max_memberships on Linux)"
+                )
+            } else {
+                e.to_string()
+            };
+            return Err(BuildError::GroupJoin {
+                group,
+                interface: interface.to_owned(),
+                reason,
+            });
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -291,6 +313,32 @@ mod tests {
             result,
             Err(BuildError::MacsUnmatchable(LOOPBACK_IFACE.to_owned()))
         );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_join_failure_no_event_clears_fails_the_build() {
+        let Some(cap) = open_loopback_or_skip() else {
+            return;
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let capture = dispatcher
+            .add_capture(cap)
+            .expect("add the loopback capture");
+        // A unicast address is no group: the join is refused outright, whatever the platform.
+        let not_a_group = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let result = require_group_join(
+            &mut dispatcher,
+            capture,
+            not_a_group,
+            "test",
+            LOOPBACK_IFACE,
+        );
+        assert!(matches!(
+            result,
+            Err(BuildError::GroupJoin { group, ref interface, .. })
+                if group == not_a_group && interface == LOOPBACK_IFACE
+        ));
     }
 
     #[test]

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -20,8 +20,8 @@ use crate::net::mdns::{
 };
 
 use super::{
-    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
-    require_bidirectional_families, require_macs_matchable,
+    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, require_bidirectional_families,
+    require_group_join, require_macs_matchable,
 };
 
 /// mDNS's classifier kind *is* its message type: `Query`/`Response` map straight across.
@@ -95,8 +95,11 @@ pub(crate) fn build(
     // on the next address change, so a deferred join logs rather than fails the build.
     let groups = used_groups(reflector.address_family);
     for group in &groups {
-        for (capture, side) in [(source, "source"), (target, "target")] {
-            join_group_logged(dispatcher, capture, group.ip(), "mDNS", side);
+        for (capture, interface) in [
+            (source, &reflector.source_if),
+            (target, &reflector.target_if),
+        ] {
+            require_group_join(dispatcher, capture, group.ip(), "mDNS", interface.as_str())?;
         }
     }
     // One handler per direction spans every group; its filter matches the group set at the mDNS port.

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -14,7 +14,8 @@ use std::net::{IpAddr, SocketAddr};
 use std::time::{Duration, Instant};
 
 use crate::dispatch::{
-    CaptureKey, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler, RegistrationKey,
+    CaptureKey, DatagramSource, Filter, MessageType, Outcome, PacketDispatcher, PacketHandler,
+    RegistrationKey,
 };
 use crate::interface::{InterfaceAddresses, Ipv6Scope};
 use crate::linear_map::LinearMap;
@@ -109,7 +110,9 @@ impl PacketHandler for ResponseReflector {
             self.egress,
             self.searcher,
             self.searcher_mac,
-            packet.source.port(),
+            DatagramSource::Egress {
+                port: packet.source.port(),
+            },
             self.ttl,
             payload,
         ) {
@@ -347,7 +350,7 @@ impl PacketHandler for SearchReflector {
             return match dispatcher.send_udp_group(
                 self.target,
                 packet.dest,
-                port,
+                DatagramSource::Egress { port },
                 self.ttl,
                 packet.payload,
             ) {
@@ -382,7 +385,13 @@ impl PacketHandler for SearchReflector {
             Err(outcome) => return outcome, // make_session logged the cause
         };
         let port = session.reservation.port();
-        match dispatcher.send_udp_group(self.target, packet.dest, port, self.ttl, packet.payload) {
+        match dispatcher.send_udp_group(
+            self.target,
+            packet.dest,
+            DatagramSource::Egress { port },
+            self.ttl,
+            packet.payload,
+        ) {
             Ok(()) => {
                 self.sessions.insert(key, session);
                 log::debug!(

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -4,14 +4,14 @@
 //! Wake-on-LAN are the same operation: classify the payload and, if it's a message for this leg,
 //! re-emit it on the egress interface, verbatim or through an optional [`ReplyRewrite`] (SSDP's
 //! advertisement direction rewrites the DIAL `LOCATION`). What differs per protocol enters as
-//! parameters: the [`Classify`] gate and the [`Emit`] policy (which source port and TTL the re-emit
+//! parameters: the [`Classify`] gate and the [`Emit`] policy (which source and TTL the re-emit
 //! carries). Where it goes follows from the captured destination alone ([`link_destination`]). The
 //! search directions are stateful (per-searcher sessions), so they use the shared `SearchReflector`
 //! instead.
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use crate::dispatch::{CaptureKey, Outcome, PacketDispatcher, PacketHandler};
+use crate::dispatch::{CaptureKey, DatagramSource, Outcome, PacketDispatcher, PacketHandler};
 use crate::interface::InterfaceAddresses;
 use crate::logging::log_rate;
 use crate::net::packet::Packet;
@@ -31,7 +31,28 @@ impl<F: Fn(&[u8]) -> Verdict> Classify for F {
     }
 }
 
-/// The UDP source port a re-emit carries.
+/// The IP source a re-emit carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Source {
+    /// The egress's own address, at the given port.
+    Egress(SourcePort),
+    /// The captured sender's own address and port, kept on the re-emit: the transparent relay,
+    /// whose peers take the sender from the datagram's source.
+    Captured,
+}
+
+impl Source {
+    fn resolve(self, packet: &Packet) -> DatagramSource {
+        match self {
+            Self::Egress(port) => DatagramSource::Egress {
+                port: port.resolve(packet),
+            },
+            Self::Captured => DatagramSource::Captured(packet.source),
+        }
+    }
+}
+
+/// The UDP source port an egress-sourced re-emit carries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourcePort {
     /// A protocol's well-known port.
@@ -66,27 +87,35 @@ impl Ttl {
     }
 }
 
-/// How a re-emit is stamped: the source port and TTL it carries. The address is always the
-/// egress's own; the destination follows from the captured one ([`link_destination`]).
+/// How a re-emit is stamped: the source and TTL it carries. The destination follows from the
+/// captured one ([`link_destination`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Emit {
-    pub(crate) source_port: SourcePort,
+    pub(crate) source: Source,
     pub(crate) ttl: Ttl,
 }
 
 impl Emit {
-    /// From `port` at `ttl`: the multicast-discovery protocols.
+    /// From the egress's address at `port`, at `ttl`: the multicast-discovery protocols.
     pub(crate) const fn fixed(port: u16, ttl: u8) -> Self {
         Self {
-            source_port: SourcePort::Fixed(port),
+            source: Source::Egress(SourcePort::Fixed(port)),
             ttl: Ttl::Fixed(ttl),
         }
     }
 
-    /// From the captured source port at the captured TTL: Wake-on-LAN.
+    /// From the egress's address at the captured source port, at the captured TTL: Wake-on-LAN.
+    pub(crate) const fn captured_from_egress() -> Self {
+        Self {
+            source: Source::Egress(SourcePort::Captured),
+            ttl: Ttl::Captured,
+        }
+    }
+
+    /// From the captured sender's own ip:port, at the captured TTL: the transparent UDP relay.
     pub(crate) const fn captured() -> Self {
         Self {
-            source_port: SourcePort::Captured,
+            source: Source::Captured,
             ttl: Ttl::Captured,
         }
     }
@@ -207,7 +236,7 @@ impl<C: Classify> PacketHandler for SimpleReflector<C> {
         match dispatcher.send_udp_group(
             self.egress,
             dest,
-            self.emit.source_port.resolve(packet),
+            self.emit.source.resolve(packet),
             self.emit.ttl.resolve(packet),
             payload,
         ) {

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -24,7 +24,7 @@ use crate::reactor::Reactor;
 use super::dial::{ProxyPlacement, rewrite_location};
 use super::{
     BuildError, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector,
-    Verdict, join_group_logged, require_bidirectional_families, require_macs_matchable,
+    Verdict, require_bidirectional_families, require_group_join, require_macs_matchable,
 };
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
@@ -178,8 +178,20 @@ pub(crate) fn build(
     // with no address yet is recorded and re-attempted on the next address change.
     let groups = used_groups(reflector.address_family);
     for group in &groups {
-        join_group_logged(dispatcher, target, group.ip(), "SSDP", "target");
-        join_group_logged(dispatcher, source, group.ip(), "SSDP", "source");
+        require_group_join(
+            dispatcher,
+            target,
+            group.ip(),
+            "SSDP",
+            reflector.target_if.as_str(),
+        )?;
+        require_group_join(
+            dispatcher,
+            source,
+            group.ip(),
+            "SSDP",
+            reflector.source_if.as_str(),
+        )?;
     }
     // One handler per direction spans every group; its filter matches the group set at the SSDP port.
     let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();

--- a/src/reflector/udp.rs
+++ b/src/reflector/udp.rs
@@ -7,8 +7,8 @@ use crate::config::Reflector;
 use crate::dispatch::{Filter, MessageType, PacketDispatcher, PortSet};
 
 use super::{
-    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
-    missing_required_family,
+    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, missing_required_family,
+    require_group_join,
 };
 
 /// Every captured datagram is a message for the leg.
@@ -21,8 +21,9 @@ fn relay(_payload: &[u8]) -> Verdict {
 /// groups and one for the broadcasts, each spanning every port.
 ///
 /// # Errors
-/// [`BuildError::UnknownInterface`] if no capture was opened for the source/target, or
-/// [`BuildError::RequiredFamilyUnavailable`] if the target can't currently send a required family.
+/// [`BuildError::UnknownInterface`] if no capture was opened for the source/target,
+/// [`BuildError::RequiredFamilyUnavailable`] if the target can't currently send a required family,
+/// or [`BuildError::GroupJoin`] if a group can't be joined on the source.
 pub(crate) fn build(
     reflector: &Reflector,
     interfaces: &InterfaceMap,
@@ -44,13 +45,13 @@ pub(crate) fn build(
 
     let groups = udp.groups.as_deref().unwrap_or(&[]);
     for group in groups {
-        join_group_logged(
+        require_group_join(
             dispatcher,
             ingress,
             *group,
             "UDP relay",
             reflector.source_if.as_str(),
-        );
+        )?;
     }
 
     // A filter matches every field it sets, so the groups and the broadcasts need one each.

--- a/src/reflector/udp.rs
+++ b/src/reflector/udp.rs
@@ -1,0 +1,96 @@
+//! The transparent UDP relay: datagrams to the entry's ports, sent to a listed multicast group or,
+//! when enabled, a broadcast, are re-emitted on the egress as sent, source ip:port and TTL included
+//! ([`Emit::captured`]). It knows no protocol; the filter alone decides what crosses, so the
+//! shared [`SimpleReflector`] runs with an admit-all classifier.
+
+use crate::config::Reflector;
+use crate::dispatch::{Filter, MessageType, PacketDispatcher, PortSet};
+
+use super::{
+    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, join_group_logged,
+    missing_required_family,
+};
+
+/// Every captured datagram is a message for the leg.
+fn relay(_payload: &[u8]) -> Verdict {
+    Verdict::Reflect(MessageType::UdpDatagram)
+}
+
+/// Build the UDP relay for `reflector` and register it on `dispatcher`. No-op when `udp_ports`
+/// isn't set. Joins the listed groups on the source interface and registers one handler for the
+/// groups and one for the broadcasts, each spanning every port.
+///
+/// # Errors
+/// [`BuildError::UnknownInterface`] if no capture was opened for the source/target, or
+/// [`BuildError::RequiredFamilyUnavailable`] if the target can't currently send a required family.
+pub(crate) fn build(
+    reflector: &Reflector,
+    interfaces: &InterfaceMap,
+    dispatcher: &mut PacketDispatcher,
+) -> Result<(), BuildError> {
+    let Some(udp) = &reflector.udp else {
+        return Ok(());
+    };
+    let ingress = interfaces.require(reflector.source_if.as_str())?;
+    let egress = interfaces.require(reflector.target_if.as_str())?;
+
+    let addrs = dispatcher.egress_addrs(egress).copied().unwrap_or_default();
+    if let Some(family) = missing_required_family(reflector.address_family, &addrs) {
+        return Err(BuildError::RequiredFamilyUnavailable {
+            interface: reflector.target_if.as_str().to_owned(),
+            family,
+        });
+    }
+
+    let groups = udp.groups.as_deref().unwrap_or(&[]);
+    for group in groups {
+        join_group_logged(
+            dispatcher,
+            ingress,
+            *group,
+            "UDP relay",
+            reflector.source_if.as_str(),
+        );
+    }
+
+    // A filter matches every field it sets, so the groups and the broadcasts need one each.
+    let ports: PortSet = udp.ports.iter().map(|port| port.get()).collect();
+    let mut filters = Vec::with_capacity(2);
+    if !groups.is_empty() {
+        filters.push(Filter {
+            dst_ip: Some(groups.iter().copied().collect()),
+            dst_port: Some(ports.clone()),
+            ..Filter::default()
+        });
+    }
+    if udp.broadcast {
+        filters.push(Filter {
+            broadcast: true,
+            dst_port: Some(ports),
+            ..Filter::default()
+        });
+    }
+    for filter in filters {
+        dispatcher.register(
+            ingress,
+            filter,
+            Box::new(SimpleReflector::new(
+                egress,
+                "UDP relay",
+                "datagram",
+                relay,
+                Emit::captured(),
+            )),
+        );
+    }
+    log::info!(
+        "UDP relay \"{}\": {} -> {} on {} port(s) to {} group(s){}",
+        reflector.name.as_str(),
+        reflector.source_if.as_str(),
+        reflector.target_if.as_str(),
+        udp.ports.len(),
+        groups.len(),
+        if udp.broadcast { " and broadcasts" } else { "" }
+    );
+    Ok(())
+}

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -6,7 +6,7 @@
 //! [`WakeClassifier`] validates the payload and applies the optional device allow-set and the
 //! family policy; the shared [`SimpleReflector`] re-emits on the target interface link-wide (a v4
 //! limited broadcast or v6 all-nodes multicast), sourced from that interface's own address at the
-//! captured source port and TTL ([`Emit::captured`]).
+//! captured source port and TTL ([`Emit::captured_from_egress`]).
 
 use std::net::SocketAddr;
 
@@ -128,7 +128,7 @@ pub(crate) fn build(
                 target_macs: reflector.macs.clone(),
                 family: reflector.address_family,
             },
-            Emit::captured(),
+            Emit::captured_from_egress(),
         )),
     );
     log::info!(

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -16,7 +16,7 @@ use crate::net::wsd::{
 
 use super::{
     BuildError, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector,
-    Verdict, join_group_logged, require_bidirectional_families, require_macs_matchable,
+    Verdict, require_bidirectional_families, require_group_join, require_macs_matchable,
 };
 
 /// WSD's classifier kind maps to its group message types. The `ProbeMatches`/`ResolveMatches` unicast
@@ -98,8 +98,20 @@ pub(crate) fn build(
     // no address yet is recorded and re-attempted on the next address change.
     let groups = used_groups(reflector.address_family);
     for group in &groups {
-        join_group_logged(dispatcher, target, group.ip(), "WSD", "target");
-        join_group_logged(dispatcher, source, group.ip(), "WSD", "source");
+        require_group_join(
+            dispatcher,
+            target,
+            group.ip(),
+            "WSD",
+            reflector.target_if.as_str(),
+        )?;
+        require_group_join(
+            dispatcher,
+            source,
+            group.ip(),
+            "WSD",
+            reflector.source_if.as_str(),
+        )?;
     }
     // One handler per direction spans every group; its filter matches the group set at the WSD port.
     let group_ips: IpSet = groups.iter().map(SocketAddr::ip).collect();


### PR DESCRIPTION
An entry with `udp_ports` relays every datagram on those ports, sent to a group in `udp_groups` or, with `udp_broadcast`, to a broadcast, from `source_if` to `target_if` unchanged: payload, TTL and the sender's own ip:port. Roon's SOOD discovery is the recipe in the README.

- config: the three fields (`WolPorts` becomes `PortList`), duplicate detection over flows (leg, port, group or broadcast) so a relay may not overlap a protocol on the same leg while discovery protocols sharing a port still coexist; the relay ignores `macs`, and an entry with only the relay may not set it.
- reflector: the relay on the stateless engine with an admit-all classifier; the send path takes a `DatagramSource`; a `broadcast` filter; counters row `UDP relay`.
- dispatch: broadcasts are matched by the frame's all-ones MAC, so every subnet's directed broadcast qualifies; a link without MACs keeps the address rule.
- reflector: a group join that no address event clears fails startup, the membership cap included.
- dispatch: a packet the relay shares with a discovery protocol on one ingress counts under the protocol.
- `--no-join`, for the emulated e2e lanes: qemu-user has no `MCAST_JOIN_GROUP`.
- version 0.16.0.

Testing: `cargo test --lib`, clippy and doc on macOS and Linux; Docker e2e with nine new relay cases (`config-relay.toml`) and the existing WoL, mDNS, SSDP, WSD and DIAL cases; the preserved source is checked on the group cases only, since the Docker host masquerades bridged broadcasts.
