### PR TITLE
Review fixes: read budget, reactor test, duplicate sends

### DIFF
--- a/e2e/config-per-device.toml
+++ b/e2e/config-per-device.toml
@@ -1,0 +1,15 @@
+log_level = "debug"
+
+# Two entries on one pair that differ only in their device: both build an unfiltered query leg, so
+# a query would go out twice without the duplicate-send check.
+[reflectors.tv]
+source_if = "nf_source"
+target_if = "nf_target"
+mdns = true
+macs = ["02:42:ac:11:00:09"]
+
+[reflectors.printer]
+source_if = "nf_source"
+target_if = "nf_target"
+mdns = true
+macs = ["02:42:ac:11:00:0c"]

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -507,6 +507,19 @@ MDNS_CASES = [
         group=MDNS_GROUP_V4,
         direction="forward",
     ),
+    # Two per-device entries on one pair share the query leg; the receiver fails on a second copy.
+    TestCase(
+        name="per_device_entries_relay_a_query_once",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=5.0,
+        send_payload_hex=MDNS_QUERY_HEX,
+        expect_payload_hex=MDNS_QUERY_HEX,
+        group=MDNS_GROUP_V4,
+        direction="forward",
+        config="config-per-device.toml",
+    ),
     TestCase(
         name="reflects_mdns_response",
         send_port=MDNS_PORT,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -17,6 +17,14 @@ pub(crate) use self::af_packet::Capture;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 pub(crate) use self::bpf::Capture;
 
+/// One read of a capture.
+#[derive(Debug)]
+pub(crate) enum Read<'a> {
+    Frame(&'a [u8]),
+    /// A frame too large to forward, dropped and counted.
+    Oversized,
+}
+
 /// Open a capture on `if_name`, returning `Ok(None)` (and noting why) when the host
 /// can't: no BPF access / `CAP_NET_RAW`, or the interface is absent. Other errors
 /// propagate for the caller to `?`.
@@ -38,9 +46,19 @@ pub(crate) fn open_or_skip(if_name: &str, what: &str) -> std::io::Result<Option<
     }
 }
 
+/// The tests that open a capture on the loopback interface hold this for their duration: every
+/// descriptor attached there sees every frame, and the kernel's small double buffer drops what
+/// a concurrent test's traffic leaves no room for.
+#[cfg(test)]
+pub(crate) fn loopback_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::open_or_skip;
+    use super::{Read, open_or_skip};
     use crate::net::LinkType;
 
     // Live capture against a real interface (`NETFLECTOR_TEST_IFACE`). Backend-neutral
@@ -64,7 +82,8 @@ mod tests {
         let mut validated = 0u32;
         while validated < 8 && std::time::Instant::now() < deadline {
             match capture.next_frame()? {
-                Some(frame) => {
+                Some(Read::Oversized) => {}
+                Some(Read::Frame(frame)) => {
                     assert!(frame.len() >= 14, "frame shorter than an Ethernet header");
                     let ethertype = u16::from_be_bytes([frame[12], frame[13]]);
                     assert!(

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -13,6 +13,7 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 
 use libc::{c_int, c_void};
 
+use super::Read;
 use super::filter::{BpfInsn, DROP_OUTGOING_PROLOGUE, ETHERNET_UDP_FILTER};
 use crate::interface::if_index;
 use crate::logging::{WARN_WINDOW, log_rate};
@@ -146,35 +147,32 @@ impl Capture {
         &self.name
     }
 
-    /// The next captured frame, or `Ok(None)` when a read would block. Oversized
-    /// frames (larger than the receive buffer) are dropped and the next is returned.
+    /// The next read: a frame, or an oversized one (larger than the receive buffer) dropped
+    /// and counted; `Ok(None)` when a read would block.
     ///
     /// # Errors
     /// Returns an error if the `recv` fails for any reason other than would-block.
-    pub(crate) fn next_frame(&mut self) -> io::Result<Option<&[u8]>> {
-        let len = loop {
-            let Some(bytes) = self.recv_once()? else {
-                return Ok(None);
-            };
-            // MSG_TRUNC reports the frame's real length even past the buffer, so an
-            // oversized frame is detectable (and dropped) instead of silently cut.
-            if bytes > self.buf.len() {
-                // Rate-limited: this is the per-frame drain loop, and a remote peer can flood
-                // oversized frames.
-                log_rate!(
-                    log::Level::Warn,
-                    WARN_WINDOW,
-                    "{}: dropping oversized frame: {bytes} bytes exceeds the {}-byte receive \
-                     buffer",
-                    self.name,
-                    self.buf.len()
-                );
-                self.oversized += 1;
-                continue;
-            }
-            break bytes;
+    pub(crate) fn next_frame(&mut self) -> io::Result<Option<Read<'_>>> {
+        let Some(bytes) = self.recv_once()? else {
+            return Ok(None);
         };
-        Ok(Some(&self.buf[..len]))
+        // MSG_TRUNC reports the frame's real length even past the buffer, so an
+        // oversized frame is detectable (and dropped) instead of silently cut.
+        if bytes > self.buf.len() {
+            // Rate-limited: this is the per-frame drain loop, and a remote peer can flood
+            // oversized frames.
+            log_rate!(
+                log::Level::Warn,
+                WARN_WINDOW,
+                "{}: dropping oversized frame: {bytes} bytes exceeds the {}-byte receive \
+                 buffer",
+                self.name,
+                self.buf.len()
+            );
+            self.oversized += 1;
+            return Ok(Some(Read::Oversized));
+        }
+        Ok(Some(Read::Frame(&self.buf[..bytes])))
     }
 
     /// Whether frames are buffered locally. Never, for `AF_PACKET`: each `recv` is
@@ -340,7 +338,7 @@ mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
 
     use super::*;
-    use crate::capture::open_or_skip;
+    use crate::capture::{loopback_lock, open_or_skip};
     use crate::net::frame;
     use crate::net::mac::MacAddr;
 
@@ -369,6 +367,7 @@ mod tests {
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn captures_a_known_frame_on_lo() -> io::Result<()> {
         const PROBE: &[u8] = b"netflector-afpacket-capture-probe";
+        let _serial = loopback_lock();
         let Some(mut capture) = open_or_skip("lo", "afpacket_capture")? else {
             return Ok(());
         };
@@ -386,7 +385,10 @@ mod tests {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         let mut decoded = false;
         while !decoded && std::time::Instant::now() < deadline {
-            while let Some(frame) = capture.next_frame()? {
+            while let Some(read) = capture.next_frame()? {
+                let Read::Frame(frame) = read else {
+                    continue;
+                };
                 if frame.len() >= 14 && frame.ends_with(PROBE) {
                     let ethertype = u16::from_be_bytes([frame[12], frame[13]]);
                     assert!(ethertype == 0x0800 || ethertype == 0x86dd);
@@ -402,6 +404,37 @@ mod tests {
         Ok(())
     }
 
+    // A frame past the receive buffer is dropped, but it still costs a read, so the drain
+    // budget counts it: one oversized datagram on lo yields one `Read::Oversized`.
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn an_oversized_frame_costs_a_read() -> io::Result<()> {
+        let _serial = loopback_lock();
+        let Some(mut capture) = open_or_skip("lo", "afpacket_oversized")? else {
+            return Ok(());
+        };
+        let receiver = UdpSocket::bind("127.0.0.1:0")?;
+        let sender = UdpSocket::bind("127.0.0.1:0")?;
+        // lo's MTU carries it whole, so it arrives as one frame past MAX_FRAME_LEN.
+        sender.send_to(
+            &[0u8; 2 * crate::net::MAX_FRAME_LEN],
+            receiver.local_addr()?,
+        )?;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            match capture.next_frame()? {
+                Some(Read::Oversized) => break,
+                Some(Read::Frame(_)) => {} // unrelated loopback traffic
+                None if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                None => panic!("did not capture the oversized datagram on lo"),
+            }
+        }
+        assert!(capture.take_oversized() >= 1);
+        Ok(())
+    }
+
     // Live send: inject a built Ethernet frame on `lo` via send(), then capture it
     // back. lo loops every transmitted frame to its input tap, and we keep the RX
     // copy (PACKET_IGNORE_OUTGOING drops only the TX copy), so this validates that
@@ -412,6 +445,7 @@ mod tests {
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn send_loops_back_on_lo() -> io::Result<()> {
         const PROBE: &[u8] = b"netflector-afpacket-send-probe";
+        let _serial = loopback_lock();
         let Some(mut capture) = open_or_skip("lo", "afpacket_send")? else {
             return Ok(());
         };
@@ -429,7 +463,10 @@ mod tests {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         let mut looped = false;
         while !looped && std::time::Instant::now() < deadline {
-            while let Some(frame) = capture.next_frame()? {
+            while let Some(read) = capture.next_frame()? {
+                let Read::Frame(frame) = read else {
+                    continue;
+                };
                 if frame.ends_with(PROBE) {
                     looped = true;
                     break;

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -455,7 +455,8 @@ mod tests {
         let mac = MacAddr::broadcast();
         let mut buf = [0u8; 256];
         let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, PROBE, &mut buf)
-            .expect("build Ethernet frame");
+            .expect("build Ethernet frame")
+            .len;
 
         // The injected frame loops to the input tap and waits there until drained, so
         // one send then polling captures it.

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -16,6 +16,7 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 use libc::{c_uint, c_ulong, c_void};
 
+use super::Read;
 use super::filter::{BpfInsn, DLT_NULL_UDP_FILTER, ETHERNET_UDP_FILTER};
 use crate::libcex::bpf_wordalign;
 use crate::logging::{WARN_WINDOW, log_rate};
@@ -119,45 +120,45 @@ impl Capture {
         &self.name
     }
 
-    /// The next captured frame, refilling from the kernel when the current batch
-    /// is drained. Returns `Ok(None)` when nothing more is ready (the batch is
-    /// empty and a read would block). Truncated/oversized records are skipped.
+    /// The next read, refilling from the kernel when the current batch is drained: a frame,
+    /// or a truncated/oversized record dropped and counted. Returns `Ok(None)` when nothing
+    /// more is ready (the batch is empty and a read would block).
     ///
     /// # Errors
     /// Returns an error if the read fails, or the kernel batch is malformed (the
     /// rest of that batch is then abandoned).
-    pub(crate) fn next_frame(&mut self) -> io::Result<Option<&[u8]>> {
-        let range = loop {
-            if self.offset >= self.filled && !self.refill()? {
-                return Ok(None);
-            }
-            let start = self.offset;
-            let (record, advance) = match parse_record(&self.buf[start..self.filled]) {
-                Ok(parsed) => parsed,
-                Err(e) => {
-                    self.offset = self.filled; // abandon the malformed batch
-                    return Err(e);
-                }
-            };
-            self.offset = start + advance;
-            match record {
-                Record::Frame(frame) => break (start + frame.start)..(start + frame.end),
-                // Rate-limited: this is the per-frame drain loop, and a remote peer can flood
-                // oversized frames.
-                Record::Oversized { datalen } => {
-                    log_rate!(
-                        log::Level::Warn,
-                        WARN_WINDOW,
-                        "{}: dropping oversized frame: {datalen} bytes exceeds the {}-byte \
-                         forwarding limit",
-                        self.name,
-                        crate::net::MAX_FRAME_LEN
-                    );
-                    self.oversized += 1;
-                }
+    pub(crate) fn next_frame(&mut self) -> io::Result<Option<Read<'_>>> {
+        if self.offset >= self.filled && !self.refill()? {
+            return Ok(None);
+        }
+        let start = self.offset;
+        let (record, advance) = match parse_record(&self.buf[start..self.filled]) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                self.offset = self.filled; // abandon the malformed batch
+                return Err(e);
             }
         };
-        Ok(Some(&self.buf[range]))
+        self.offset = start + advance;
+        match record {
+            Record::Frame(frame) => Ok(Some(Read::Frame(
+                &self.buf[start + frame.start..start + frame.end],
+            ))),
+            // Rate-limited: this is the per-frame drain loop, and a remote peer can flood
+            // oversized frames.
+            Record::Oversized { datalen } => {
+                log_rate!(
+                    log::Level::Warn,
+                    WARN_WINDOW,
+                    "{}: dropping oversized frame: {datalen} bytes exceeds the {}-byte \
+                     forwarding limit",
+                    self.name,
+                    crate::net::MAX_FRAME_LEN
+                );
+                self.oversized += 1;
+                Ok(Some(Read::Oversized))
+            }
+        }
     }
 
     /// Whether the current batch still holds unread records: the cue to keep
@@ -362,7 +363,7 @@ mod tests {
     use std::mem::offset_of;
 
     use super::*;
-    use crate::capture::open_or_skip;
+    use crate::capture::{loopback_lock, open_or_skip};
     use crate::libcex::BPF_ALIGN;
 
     /// Append one synthetic BPF record (header + frame + word-align padding) to
@@ -493,7 +494,10 @@ mod tests {
         sender.send_to(PROBE, target).unwrap();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         while std::time::Instant::now() < deadline {
-            while let Some(frame) = capture.next_frame().unwrap() {
+            while let Some(read) = capture.next_frame().unwrap() {
+                let Read::Frame(frame) = read else {
+                    continue;
+                };
                 if frame.len() > 4
                     && u32::from_ne_bytes(frame[..4].try_into().unwrap()) == family
                     && frame[4] >> 4 == version
@@ -507,6 +511,37 @@ mod tests {
         false
     }
 
+    // A record past the forwarding limit is dropped, but it still costs a read, so the drain
+    // budget counts it: one oversized datagram on lo0 yields one `Read::Oversized`.
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn an_oversized_record_costs_a_read() -> io::Result<()> {
+        let _serial = loopback_lock();
+        let Some(mut capture) = open_or_skip("lo0", "bpf_oversized")? else {
+            return Ok(());
+        };
+        let receiver = std::net::UdpSocket::bind("127.0.0.1:0")?;
+        let sender = std::net::UdpSocket::bind("127.0.0.1:0")?;
+        // lo0's MTU carries it whole, so it arrives as one record past MAX_FRAME_LEN.
+        sender.send_to(
+            &[0u8; 2 * crate::net::MAX_FRAME_LEN],
+            receiver.local_addr()?,
+        )?;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            match capture.next_frame()? {
+                Some(Read::Oversized) => break,
+                Some(Read::Frame(_)) => {} // unrelated loopback traffic
+                None if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                None => panic!("did not capture the oversized datagram on lo0"),
+            }
+        }
+        assert!(capture.take_oversized() >= 1);
+        Ok(())
+    }
+
     // Live loopback capture: `lo0` reports DLT_NULL, so this exercises `link_type()`,
     // both branches of the DLT_NULL filter (the per-OS AF_INET/AF_INET6 constants and
     // their host-order byte-swap, at different header offsets), and the see-sent skip.
@@ -515,6 +550,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn loopback_capture_decodes_known_frames() -> io::Result<()> {
+        let _serial = loopback_lock();
         let Some(mut capture) = open_or_skip("lo0", "loopback_capture")? else {
             return Ok(());
         };
@@ -558,6 +594,7 @@ mod tests {
 
         const PROBE: &[u8] = b"netflector-loopback-send-probe";
 
+        let _serial = loopback_lock();
         let Some(cap) = open_or_skip("lo0", "loopback_send")? else {
             return Ok(());
         };

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -606,7 +606,8 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, dst_port);
         let mut frame = [0u8; 256];
         let n = crate::net::frame::dlt_null_ipv4_udp(src, dst, 64, PROBE, &mut frame)
-            .expect("build DLT_NULL IPv4 frame");
+            .expect("build DLT_NULL IPv4 frame")
+            .len;
         expect_send_delivered(&cap, &receiver, &frame[..n], PROBE);
 
         // IPv6 loopback isn't guaranteed everywhere; cover it only when ::1 is usable.
@@ -616,7 +617,8 @@ mod tests {
             let dst = SocketAddrV6::new(Ipv6Addr::LOCALHOST, dst_port, 0, 0);
             let mut frame = [0u8; 256];
             let n = crate::net::frame::dlt_null_ipv6_udp(src, dst, 64, PROBE, &mut frame)
-                .expect("build DLT_NULL IPv6 frame");
+                .expect("build DLT_NULL IPv6 frame")
+                .len;
             expect_send_delivered(&cap, &receiver, &frame[..n], PROBE);
         } else {
             eprintln!("skip loopback_send IPv6: ::1 unavailable");

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -47,7 +47,7 @@ use crate::reactor::{Arena, ControlEvent, Handler, Key, Reactor, ReadyEvent};
 
 use self::counters::log_counters;
 use self::datagram::{build_udp, ethernet_dst};
-use self::interface_table::InterfaceTable;
+use self::interface_table::{InterfaceTable, SentFrame};
 
 /// The most frames drained per readable event before yielding, so a flooded interface
 /// can't starve the others. `AF_PACKET` stops here and the level-triggered wait
@@ -267,6 +267,12 @@ pub(crate) struct PacketDispatcher {
     /// [`RECONCILE_RETRY`] while an interface is parked absent or a rebuild step failed, `now`
     /// when a capture read error pulls it forward.
     next_reconcile: Instant,
+    /// The number of the packet being routed, from 1: the scope of the duplicate-send check in
+    /// [`send_udp`](Self::send_udp).
+    packet: u64,
+    /// Whether [`route`](Self::route) is running; a send outside it (a timer, a session) is
+    /// never a duplicate of a packet's re-emit.
+    routing: bool,
 }
 
 impl PacketDispatcher {
@@ -293,6 +299,8 @@ impl PacketDispatcher {
             report: None,
             max_seen_ifindex: 0,
             next_reconcile: Instant::now() + RECONCILE_TICK,
+            packet: 0,
+            routing: false,
         }
     }
 
@@ -473,7 +481,7 @@ impl PacketDispatcher {
             log::warn!("egress {egress:?} unavailable (drained or unknown); datagram dropped");
             return Ok(());
         };
-        let n = build_udp(
+        let built = build_udp(
             &addrs,
             link,
             dst,
@@ -484,7 +492,25 @@ impl PacketDispatcher {
             &mut self.scratch,
         )
         .map_err(io::Error::other)?;
-        self.send(egress, &self.scratch[..n])
+        // Two entries whose legs coincide (per-device entries on one pair, whose query legs
+        // carry no MAC filter) both relay a packet; the second's frame equals the first's. Noted
+        // only once sent, so a failed send leaves the second to try.
+        let frame = self.routing.then_some(SentFrame {
+            packet: self.packet,
+            len: built.len,
+            checksum: built.udp_checksum,
+        });
+        if let Some(frame) = frame
+            && self.table.is_last_sent(egress, frame)
+        {
+            log::trace!("egress {egress:?}: an equal frame already went out for this packet");
+            return Ok(());
+        }
+        self.send(egress, &self.scratch[..built.len])?;
+        if let Some(frame) = frame {
+            self.table.set_last_sent(egress, frame);
+        }
+        Ok(())
     }
 
     /// Inject a broadcast/multicast UDP datagram on `egress`, deriving the L2 destination MAC from
@@ -641,6 +667,8 @@ impl PacketDispatcher {
             .table
             .egress_addrs(ingress)
             .and_then(InterfaceAddresses::v4_directed_broadcast);
+        self.packet += 1;
+        self.routing = true;
         let mut final_outcome: Option<Outcome> = None;
         for i in 0..self.route_keys.len() {
             let key = self.route_keys[i];
@@ -681,6 +709,7 @@ impl PacketDispatcher {
                 }
             });
         }
+        self.routing = false;
         // One packet, one count: record the folded outcome on the ingress capture's row. The row
         // always exists: `route` is reached only via the drain, whose take-out guard admits only a
         // real, in-range ingress key.

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -37,7 +37,7 @@ use std::ops::Deref;
 use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
-use crate::capture::Capture;
+use crate::capture::{Capture, Read};
 use crate::interface::{InterfaceAddresses, InterfaceEvent, InterfaceMonitor};
 use crate::linear_map::LinearMap;
 use crate::net::LinkType;
@@ -518,9 +518,10 @@ impl PacketDispatcher {
         .map_err(io::Error::other)
     }
 
-    /// Drain the capture `ingress` addresses and route each parsed packet. Reads up to
-    /// [`MAX_FRAMES_PER_EVENT`] frames, then yields for fairness (the BPF batch
-    /// exception is via `has_buffered`); a read error abandons the batch and logs.
+    /// Drain the capture `ingress` addresses and route each parsed packet. Makes up to
+    /// [`MAX_FRAMES_PER_EVENT`] reads, dropped oversized frames included, then yields for
+    /// fairness (the BPF batch exception is via `has_buffered`); a read error abandons the
+    /// batch and logs.
     fn drain_and_route(&mut self, ingress: CaptureKey, reactor: &mut Reactor) {
         // Take the ingress capture OUT: the parsed Packet then borrows the owned local, not
         // `self`, so `&mut self` is free for routing, and a reflector can send on the OTHER
@@ -544,7 +545,11 @@ impl PacketDispatcher {
                 break;
             }
             let frame = match capture.next_frame() {
-                Ok(Some(frame)) => frame,
+                Ok(Some(Read::Frame(frame))) => frame,
+                Ok(Some(Read::Oversized)) => {
+                    drained += 1;
+                    continue;
+                }
                 Ok(None) => break,
                 Err(e) => {
                     // A dead capture's read error (Linux parks ENETDOWN on the unregistered
@@ -1102,7 +1107,7 @@ fn oversize_context(e: io::Error, if_name: &str, frame_len: usize, mtu: Option<u
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::capture::open_or_skip;
+    use crate::capture::{loopback_lock, open_or_skip};
     use crate::interface::LOOPBACK_IFACE;
     use std::cell::{Cell, RefCell};
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
@@ -1480,6 +1485,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn routes_a_captured_packet_to_a_matching_reflector() -> io::Result<()> {
+        let _serial = loopback_lock();
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_ingress")? else {
             return Ok(());
         };
@@ -1907,6 +1913,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn reentrant_drain_on_the_same_ingress_hits_the_guard() -> io::Result<()> {
+        let _serial = loopback_lock();
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_reentrant")? else {
             return Ok(());
         };
@@ -1979,6 +1986,7 @@ mod tests {
     )]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn reentrant_drain_on_another_ingress_trips_the_assert() -> io::Result<()> {
+        let _serial = loopback_lock();
         let Some(cap_a) = open_or_skip(LOOPBACK_IFACE, "dispatch_cross_a")? else {
             return Ok(());
         };
@@ -2031,6 +2039,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn reactor_drives_the_dispatcher_to_route_a_packet() -> io::Result<()> {
+        let _serial = loopback_lock();
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_reactor_in")? else {
             return Ok(());
         };
@@ -2136,6 +2145,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn ingress_resolves_and_drops_while_taken_out() -> io::Result<()> {
+        let _serial = loopback_lock();
         let Some(ingress_cap) = open_or_skip(LOOPBACK_IFACE, "dispatch_mid_drain")? else {
             return Ok(());
         };

--- a/src/dispatch/datagram.rs
+++ b/src/dispatch/datagram.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::interface::{InterfaceAddresses, Ipv6Scope};
 use crate::net::LinkType;
-use crate::net::frame::{self, FrameError};
+use crate::net::frame::{self, Built, FrameError};
 use crate::net::mac::MacAddr;
 
 /// Why a datagram could not be assembled for an egress: from [`build_udp`] (no source address or
@@ -58,7 +58,7 @@ pub(super) fn ethernet_dst(
 }
 
 /// Assemble a UDP datagram for an egress with addresses `addrs` and link framing `link` into
-/// `scratch`, returning its byte length. The IP source is `source`, the L2 source the egress's own
+/// `scratch`. The IP source is `source`, the L2 source the egress's own
 /// MAC; the L2 destination is the caller-supplied `dst_mac` (so this serves unicast, multicast, and
 /// broadcast alike). BSD `DLT_NULL` (loopback/tunnel) carries no L2 addresses, so it ignores
 /// `dst_mac` and needs no source MAC.
@@ -74,7 +74,7 @@ pub(super) fn build_udp(
     ttl: u8,
     payload: &[u8],
     scratch: &mut [u8],
-) -> Result<usize, DatagramError> {
+) -> Result<Built, DatagramError> {
     match dst {
         SocketAddr::V4(dst) => {
             let src = match source {
@@ -164,7 +164,8 @@ mod tests {
             b"ssdp",
             &mut scratch,
         )
-        .unwrap();
+        .unwrap()
+        .len;
         // The IPv6 source address sits at bytes [22..38] of the frame (14 Ethernet + offset 8 into
         // the v6 header).
         assert_eq!(
@@ -197,7 +198,8 @@ mod tests {
             b"sood",
             &mut scratch,
         )
-        .unwrap();
+        .unwrap()
+        .len;
         assert_eq!(&scratch[26..30], &[192, 0, 2, 7]);
         assert_eq!(&scratch[34..36], &40001u16.to_be_bytes());
         assert!(n > 36);
@@ -270,7 +272,8 @@ mod tests {
             b"wol",
             &mut scratch,
         )
-        .unwrap();
+        .unwrap()
+        .len;
         // L2 header: the supplied destination MAC, the egress's own MAC as source.
         assert_eq!(&scratch[0..6], MacAddr::broadcast().octets().as_slice());
         assert_eq!(&scratch[6..12], addrs.mac().unwrap().octets().as_slice());
@@ -317,7 +320,8 @@ mod tests {
             b"ok",
             &mut scratch,
         )
-        .unwrap();
+        .unwrap()
+        .len;
         // The supplied unicast MAC is the L2 destination; the egress's own MAC is the source.
         assert_eq!(&scratch[0..6], searcher_mac.octets().as_slice());
         assert_eq!(&scratch[6..12], addrs.mac().unwrap().octets().as_slice());

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -38,6 +38,17 @@ struct CaptureEntry {
     capture: Option<Capture>,
     interface: InterfaceKey,
     counters: CaptureCounters,
+    last_sent: SentFrame,
+}
+
+/// The last frame sent on a capture, tagged with the packet whose routing sent it. A packet's
+/// routing sends one frame per egress, so an equal frame for the same packet is a second handler
+/// relaying what the first already did. `packet` counts from 1, so the default never matches.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct SentFrame {
+    pub(super) packet: u64,
+    pub(super) len: usize,
+    pub(super) checksum: u16,
 }
 
 /// One interface paired with its multicast joiner. Bundling them keeps the two from desyncing (one
@@ -123,6 +134,20 @@ impl InterfaceTable {
         Ok(self.add_interface(Interface::open(name)?))
     }
 
+    /// Whether `frame` is the last one sent on `egress`. An unknown key never sent anything.
+    pub(super) fn is_last_sent(&self, egress: CaptureKey, frame: SentFrame) -> bool {
+        self.captures
+            .get(egress.0 as usize)
+            .is_some_and(|entry| entry.last_sent == frame)
+    }
+
+    /// Set `frame` as the last one sent on `egress`, once its send succeeded.
+    pub(super) fn set_last_sent(&mut self, egress: CaptureKey, frame: SentFrame) {
+        if let Some(entry) = self.captures.get_mut(egress.0 as usize) {
+            entry.last_sent = frame;
+        }
+    }
+
     /// Add a capture bound to `interface`, returning its key. Startup-only.
     pub(super) fn add_capture(&mut self, capture: Capture, interface: InterfaceKey) -> CaptureKey {
         let key = CaptureKey(u32::try_from(self.captures.len()).expect("capture count fits a u32"));
@@ -130,6 +155,7 @@ impl InterfaceTable {
             capture: Some(capture),
             interface,
             counters: CaptureCounters::default(),
+            last_sent: SentFrame::default(),
         });
         key
     }
@@ -509,6 +535,7 @@ mod tests {
                 capture: None,
                 interface: InterfaceKey(0),
                 counters: CaptureCounters::default(),
+                last_sent: SentFrame::default(),
             });
             key
         }
@@ -546,6 +573,35 @@ mod tests {
     // refresh_by_ifindex re-resolves only the interface(s) with the matching kernel index, reporting
     // the changed fields (`None` for an unwatched index). Resolution is unprivileged (no capture
     // needed), so this exercises the monitor's refresh path without CAP_NET_RAW.
+    #[test]
+    fn is_last_sent_matches_only_the_set_frame_for_the_same_packet() {
+        let mut table = InterfaceTable::new();
+        let egress = table.add_test_capture();
+        let other = table.add_test_capture();
+        let frame = SentFrame {
+            packet: 1,
+            len: 60,
+            checksum: 0x1234,
+        };
+        // Nothing set yet: a failed send leaves it that way, so a retry goes out.
+        assert!(!table.is_last_sent(egress, frame));
+        table.set_last_sent(egress, frame);
+        assert!(table.is_last_sent(egress, frame));
+        // Another egress, another length or checksum, or the next packet: not the same frame.
+        assert!(!table.is_last_sent(other, frame));
+        assert!(!table.is_last_sent(egress, SentFrame { len: 61, ..frame }));
+        assert!(!table.is_last_sent(
+            egress,
+            SentFrame {
+                checksum: 0x1235,
+                ..frame
+            }
+        ));
+        assert!(!table.is_last_sent(egress, SentFrame { packet: 2, ..frame }));
+        assert!(!table.is_last_sent(CaptureKey::from_u64(999), frame));
+        table.set_last_sent(CaptureKey::from_u64(999), frame); // an unknown key is a no-op
+    }
+
     #[test]
     #[cfg_attr(miri, ignore = "resolves a real interface")]
     fn refresh_by_ifindex_targets_the_matching_interface() -> io::Result<()> {

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 use std::sync::{Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
-use crate::capture::Capture;
+use crate::capture::{Capture, Read};
 use crate::interface::{Interface, InterfaceAddresses, Ipv6Scope, if_index};
 use crate::net::packet::Packet;
 use crate::sys::socklen_of;
@@ -459,7 +459,8 @@ fn capture_injected(peer: &mut Capture, dest: IpAddr) -> io::Result<Option<Captu
     let deadline = Instant::now() + WAIT_BUDGET;
     while Instant::now() < deadline {
         match peer.next_frame()? {
-            Some(frame) => {
+            Some(Read::Oversized) => {}
+            Some(Read::Frame(frame)) => {
                 let Ok(packet) = Packet::parse(link, frame) else {
                     continue; // unrelated non-UDP or malformed traffic
                 };

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -499,7 +499,8 @@ fn inject(
         payload,
         &mut scratch,
     )
-    .expect("build the injected frame");
+    .expect("build the injected frame")
+    .len;
     injector.send(&scratch[..n])
 }
 

--- a/src/net/frame.rs
+++ b/src/net/frame.rs
@@ -34,9 +34,16 @@ pub(crate) enum FrameError {
     PayloadTooLarge { payload: usize },
 }
 
-/// Ethernet frame carrying an IPv4 UDP datagram into `out`, returning the frame
-/// length: dst/src MAC header and ethertype, then the IPv4 + UDP datagram with
-/// checksums filled.
+/// What a builder wrote: the frame's length in the output buffer, and the UDP checksum it
+/// carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Built {
+    pub(crate) len: usize,
+    pub(crate) udp_checksum: u16,
+}
+
+/// Ethernet frame carrying an IPv4 UDP datagram into `out`: dst/src MAC header and
+/// ethertype, then the IPv4 + UDP datagram with checksums filled.
 ///
 /// # Errors
 /// [`FrameError::PayloadTooLarge`] if the datagram overflows the 16-bit length
@@ -49,17 +56,19 @@ pub(crate) fn ethernet_ipv4_udp(
     ttl: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<usize, FrameError> {
+) -> Result<Built, FrameError> {
     let (header, body) = split_l2(out, ETHERNET_HEADER_SIZE)?;
     let datagram = ipv4_udp(src, dst, ttl, payload, body)
         .map_err(|e| with_l2_header(e, ETHERNET_HEADER_SIZE))?;
     write_ethernet_header(header, dst_mac, src_mac, IPV4_ETHERTYPE);
-    Ok(ETHERNET_HEADER_SIZE + datagram)
+    Ok(Built {
+        len: ETHERNET_HEADER_SIZE + datagram.len,
+        ..datagram
+    })
 }
 
-/// Ethernet frame carrying an IPv6 UDP datagram into `out`, returning the frame
-/// length: dst/src MAC header and ethertype, then the IPv6 + UDP datagram with
-/// the UDP checksum filled.
+/// Ethernet frame carrying an IPv6 UDP datagram into `out`: dst/src MAC header and
+/// ethertype, then the IPv6 + UDP datagram with the UDP checksum filled.
 ///
 /// # Errors
 /// [`FrameError::PayloadTooLarge`] if the datagram overflows the 16-bit length
@@ -72,12 +81,15 @@ pub(crate) fn ethernet_ipv6_udp(
     hop_limit: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<usize, FrameError> {
+) -> Result<Built, FrameError> {
     let (header, body) = split_l2(out, ETHERNET_HEADER_SIZE)?;
     let datagram = ipv6_udp(src, dst, hop_limit, payload, body)
         .map_err(|e| with_l2_header(e, ETHERNET_HEADER_SIZE))?;
     write_ethernet_header(header, dst_mac, src_mac, IPV6_ETHERTYPE);
-    Ok(ETHERNET_HEADER_SIZE + datagram)
+    Ok(Built {
+        len: ETHERNET_HEADER_SIZE + datagram.len,
+        ..datagram
+    })
 }
 
 /// `DLT_NULL` frame carrying an IPv4 UDP datagram into `out` (BSD `lo0`
@@ -94,12 +106,15 @@ pub(crate) fn dlt_null_ipv4_udp(
     ttl: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<usize, FrameError> {
+) -> Result<Built, FrameError> {
     let (header, body) = split_l2(out, DLT_NULL_HEADER_SIZE)?;
     let datagram = ipv4_udp(src, dst, ttl, payload, body)
         .map_err(|e| with_l2_header(e, DLT_NULL_HEADER_SIZE))?;
     write_dlt_null_header(header, libc::AF_INET);
-    Ok(DLT_NULL_HEADER_SIZE + datagram)
+    Ok(Built {
+        len: DLT_NULL_HEADER_SIZE + datagram.len,
+        ..datagram
+    })
 }
 
 /// `DLT_NULL` frame carrying an IPv6 UDP datagram into `out` (BSD `lo0`
@@ -116,23 +131,26 @@ pub(crate) fn dlt_null_ipv6_udp(
     hop_limit: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<usize, FrameError> {
+) -> Result<Built, FrameError> {
     let (header, body) = split_l2(out, DLT_NULL_HEADER_SIZE)?;
     let datagram = ipv6_udp(src, dst, hop_limit, payload, body)
         .map_err(|e| with_l2_header(e, DLT_NULL_HEADER_SIZE))?;
     write_dlt_null_header(header, libc::AF_INET6);
-    Ok(DLT_NULL_HEADER_SIZE + datagram)
+    Ok(Built {
+        len: DLT_NULL_HEADER_SIZE + datagram.len,
+        ..datagram
+    })
 }
 
 /// Write an IPv4 + UDP datagram (headers and `payload`, with the IPv4-header and
-/// UDP checksums filled) into `out`, returning the number of bytes written.
+/// UDP checksums filled) into `out`.
 fn ipv4_udp(
     src: SocketAddrV4,
     dst: SocketAddrV4,
     ttl: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<usize, FrameError> {
+) -> Result<Built, FrameError> {
     let udp_length = datagram_length(payload)?;
     let frame_size = IPV4_HEADER_SIZE + usize::from(udp_length);
     // The IPv4 total-length field is also 16-bit and spans header + datagram.
@@ -159,19 +177,21 @@ fn ipv4_udp(
     let udp_checksum = checksum::udp_v4(*src.ip(), *dst.ip(), &out[udp..]);
     out[udp + 6..udp + 8].copy_from_slice(&udp_checksum.to_be_bytes());
 
-    Ok(frame_size)
+    Ok(Built {
+        len: frame_size,
+        udp_checksum,
+    })
 }
 
 /// Write an IPv6 + UDP datagram (headers and `payload`, with the UDP checksum
-/// filled) into `out`, returning the number of bytes written. The IPv6 header
-/// carries no checksum of its own.
+/// filled) into `out`. The IPv6 header carries no checksum of its own.
 fn ipv6_udp(
     src: SocketAddrV6,
     dst: SocketAddrV6,
     hop_limit: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<usize, FrameError> {
+) -> Result<Built, FrameError> {
     let udp_length = datagram_length(payload)?;
     let frame_size = IPV6_HEADER_SIZE + usize::from(udp_length);
     let out = checked_out(out, frame_size)?;
@@ -191,7 +211,10 @@ fn ipv6_udp(
     let udp_checksum = checksum::udp_v6(*src.ip(), *dst.ip(), &out[udp..]);
     out[udp + 6..udp + 8].copy_from_slice(&udp_checksum.to_be_bytes());
 
-    Ok(frame_size)
+    Ok(Built {
+        len: frame_size,
+        udp_checksum,
+    })
 }
 
 /// The UDP datagram length (header + `payload`) as a `u16`, or
@@ -270,7 +293,7 @@ mod tests {
         let payload = [0xde, 0xad, 0xbe, 0xef];
         let mut buf = [0xAAu8; 64]; // sentinel: every frame byte must be overwritten
 
-        let n = ipv4_udp(src, dst, 1, &payload, &mut buf).unwrap();
+        let n = ipv4_udp(src, dst, 1, &payload, &mut buf).unwrap().len;
         assert_eq!(n, IPV4_HEADER_SIZE + UDP_HEADER_SIZE + payload.len());
         let frame = &buf[..n];
         let udp = IPV4_HEADER_SIZE;
@@ -317,7 +340,7 @@ mod tests {
         let payload = [0xaa, 0xbb, 0xcc];
         let mut buf = [0xAAu8; 80]; // sentinel: every frame byte must be overwritten
 
-        let n = ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap();
+        let n = ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap().len;
         assert_eq!(n, IPV6_HEADER_SIZE + UDP_HEADER_SIZE + payload.len());
         let frame = &buf[..n];
         let udp = IPV6_HEADER_SIZE;
@@ -414,7 +437,9 @@ mod tests {
         let payload = [0xde, 0xad];
         let mut buf = [0xAAu8; 64];
 
-        let n = ethernet_ipv4_udp(dst_mac, src_mac, src, dst, 1, &payload, &mut buf).unwrap();
+        let built = ethernet_ipv4_udp(dst_mac, src_mac, src, dst, 1, &payload, &mut buf).unwrap();
+        assert_eq!(built.udp_checksum, u16::from_be_bytes([buf[40], buf[41]]));
+        let n = built.len;
         assert_eq!(
             n,
             ETHERNET_HEADER_SIZE + IPV4_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -427,7 +452,7 @@ mod tests {
 
         // Past the Ethernet header is exactly the standalone IPv4 datagram.
         let mut datagram = [0u8; 64];
-        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap();
+        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap().len;
         assert_eq!(&frame[ETHERNET_HEADER_SIZE..], &datagram[..dn]);
     }
 
@@ -440,7 +465,9 @@ mod tests {
         let payload = [0xaa, 0xbb, 0xcc];
         let mut buf = [0xAAu8; 80];
 
-        let n = ethernet_ipv6_udp(dst_mac, src_mac, src, dst, 255, &payload, &mut buf).unwrap();
+        let built = ethernet_ipv6_udp(dst_mac, src_mac, src, dst, 255, &payload, &mut buf).unwrap();
+        assert_eq!(built.udp_checksum, u16::from_be_bytes([buf[60], buf[61]]));
+        let n = built.len;
         assert_eq!(
             n,
             ETHERNET_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -452,7 +479,9 @@ mod tests {
         assert_eq!(u16::from_be_bytes([frame[12], frame[13]]), IPV6_ETHERTYPE);
 
         let mut datagram = [0u8; 80];
-        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram).unwrap();
+        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram)
+            .unwrap()
+            .len;
         assert_eq!(&frame[ETHERNET_HEADER_SIZE..], &datagram[..dn]);
     }
 
@@ -493,7 +522,7 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 2);
         let mut buf = [0u8; IPV4_HEADER_SIZE + UDP_HEADER_SIZE]; // exactly the empty-payload frame
         assert_eq!(
-            ipv4_udp(src, dst, 1, &[], &mut buf),
+            ipv4_udp(src, dst, 1, &[], &mut buf).map(|built| built.len),
             Ok(IPV4_HEADER_SIZE + UDP_HEADER_SIZE)
         );
     }
@@ -506,7 +535,9 @@ mod tests {
         let payload = [0xde, 0xad];
         let mut buf = [0xAAu8; 64];
 
-        let n = dlt_null_ipv4_udp(src, dst, 1, &payload, &mut buf).unwrap();
+        let n = dlt_null_ipv4_udp(src, dst, 1, &payload, &mut buf)
+            .unwrap()
+            .len;
         assert_eq!(
             n,
             DLT_NULL_HEADER_SIZE + IPV4_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -520,7 +551,7 @@ mod tests {
         );
         // Past the link header is exactly the standalone IPv4 datagram.
         let mut datagram = [0u8; 64];
-        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap();
+        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap().len;
         assert_eq!(&frame[DLT_NULL_HEADER_SIZE..], &datagram[..dn]);
     }
 
@@ -532,7 +563,9 @@ mod tests {
         let payload = [0xaa, 0xbb, 0xcc];
         let mut buf = [0xAAu8; 80];
 
-        let n = dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap();
+        let n = dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf)
+            .unwrap()
+            .len;
         assert_eq!(
             n,
             DLT_NULL_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -544,7 +577,9 @@ mod tests {
             libc::AF_INET6.cast_unsigned()
         );
         let mut datagram = [0u8; 80];
-        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram).unwrap();
+        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram)
+            .unwrap()
+            .len;
         assert_eq!(&frame[DLT_NULL_HEADER_SIZE..], &datagram[..dn]);
     }
 }

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -255,8 +255,9 @@ mod tests {
         // Distinct dst/src MACs so a swapped read would fail.
         let dst_mac = MacAddr::from([0x02, 0, 0, 0, 0, 0xaa]);
         let src_mac = MacAddr::from([0x02, 0, 0, 0, 0, 0xbb]);
-        let n =
-            frame::ethernet_ipv4_udp(dst_mac, src_mac, src, dst, 64, &payload, &mut buf).unwrap();
+        let n = frame::ethernet_ipv4_udp(dst_mac, src_mac, src, dst, 64, &payload, &mut buf)
+            .unwrap()
+            .len;
 
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V4(src));
@@ -275,8 +276,9 @@ mod tests {
         let mut buf = [0u8; 80];
         let dst_mac = MacAddr::from([0x33, 0x33, 0, 0, 0, 0xfb]);
         let src_mac = MacAddr::from([0x02, 0, 0, 0, 0, 0xbb]);
-        let n =
-            frame::ethernet_ipv6_udp(dst_mac, src_mac, src, dst, 255, &payload, &mut buf).unwrap();
+        let n = frame::ethernet_ipv6_udp(dst_mac, src_mac, src, dst, 255, &payload, &mut buf)
+            .unwrap()
+            .len;
 
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V6(src));
@@ -294,7 +296,9 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5354);
         let payload = [0x01, 0x02];
         let mut buf = [0u8; 64];
-        let n = frame::dlt_null_ipv4_udp(src, dst, 64, &payload, &mut buf).unwrap();
+        let n = frame::dlt_null_ipv4_udp(src, dst, 64, &payload, &mut buf)
+            .unwrap()
+            .len;
 
         let packet = Packet::parse(LinkType::DltNull, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V4(src));
@@ -313,7 +317,9 @@ mod tests {
         let dst = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5354, 0, 0);
         let payload = [0x09];
         let mut buf = [0u8; 80];
-        let n = frame::dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap();
+        let n = frame::dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf)
+            .unwrap()
+            .len;
 
         let packet = Packet::parse(LinkType::DltNull, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V6(src));
@@ -331,7 +337,9 @@ mod tests {
         let payload = [0x11, 0x22, 0x33];
         let mut buf = [0u8; 64]; // zero-filled tail stands in for padding
         let mac = MacAddr::broadcast();
-        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &payload, &mut buf).unwrap();
+        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &payload, &mut buf)
+            .unwrap()
+            .len;
 
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n + 10]).unwrap();
         assert_eq!(packet.payload, &payload);
@@ -367,7 +375,9 @@ mod tests {
         let src = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1234);
         let dst = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 5678);
         let mac = MacAddr::broadcast();
-        frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[0xab; 4], buf).unwrap()
+        frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[0xab; 4], buf)
+            .unwrap()
+            .len
     }
 
     #[test]
@@ -474,7 +484,9 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 2);
         let mac = MacAddr::broadcast();
         let mut buf = [0u8; 64];
-        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[], &mut buf).unwrap();
+        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[], &mut buf)
+            .unwrap()
+            .len;
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n]).unwrap();
         assert!(packet.payload.is_empty());
     }
@@ -485,7 +497,9 @@ mod tests {
         let src = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 1234, 0, 0);
         let dst = SocketAddrV6::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb), 5678, 0, 0);
         let mac = MacAddr::broadcast();
-        frame::ethernet_ipv6_udp(mac, mac, src, dst, 64, &[0xab; 4], buf).unwrap()
+        frame::ethernet_ipv6_udp(mac, mac, src, dst, 64, &[0xab; 4], buf)
+            .unwrap()
+            .len
     }
 
     #[test]

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -1077,13 +1077,9 @@ mod tests {
         let mut reactor = Reactor::new().unwrap();
         let (a, _pa) = pair();
         let hk = reactor.register(TestHandler::read(a, |_, _| {}));
-        // A closed (but non-negative) fd fails the kernel add; nothing allocates an fd between the
-        // close and the watch, so the number isn't reused.
-        let closed = {
-            let (c, _pc) = pair();
-            c.as_raw_fd()
-        };
-        assert!(reactor.watch(hk, closed, 0).is_err());
+        // The largest descriptor number is never open, so the kernel add fails with EBADF; a
+        // closed one would not do, as another test thread can reuse its number before the watch.
+        assert!(reactor.watch(hk, RawFd::MAX, 0).is_err());
         // The handler is intact and can still watch a good fd afterward.
         assert!(reactor.is_registered(hk));
         let (b, _pb) = pair();

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -271,7 +271,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use super::*;
-    use crate::capture::Capture;
+    use crate::capture::{Capture, loopback_lock};
     use crate::interface::LOOPBACK_IFACE;
     use crate::net::mac::MacAddr;
 
@@ -290,6 +290,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn macs_matchability_follows_the_target_link_framing() {
+        let _serial = loopback_lock();
         let Some(cap) = open_loopback_or_skip() else {
             return;
         };
@@ -318,6 +319,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn a_join_failure_no_event_clears_fails_the_build() {
+        let _serial = loopback_lock();
         let Some(cap) = open_loopback_or_skip() else {
             return;
         };

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -476,7 +476,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
-    use crate::capture::Capture;
+    use crate::capture::{Capture, loopback_lock};
     use crate::reflector::NoRewrite;
 
     const TEST_TTL: u8 = 2;
@@ -919,6 +919,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn suppression_drops_an_untouched_reply() {
+        let _serial = loopback_lock();
         // The Dropped outcome proves the early return: a completed loopback send would be Reflected.
         let Some((mut reflector, mut dispatcher, mut reactor)) =
             reply_over_loopback(Box::new(NoRewrite), |_| true)
@@ -942,6 +943,7 @@ mod tests {
             SUPPRESS_CONSULTED.store(true, Ordering::Relaxed);
             true
         }
+        let _serial = loopback_lock();
         let Some((mut reflector, mut dispatcher, mut reactor)) =
             reply_over_loopback(Box::new(ReplaceRewrite), tracking_suppress)
         else {
@@ -972,6 +974,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn a_failed_reflect_rolls_back_the_session_registration() {
+        let _serial = loopback_lock();
         // make_session makes the response registration before reflecting; if the reflect then fails, that
         // registration must be rolled back, not leaked. A real loopback target lets make_session succeed;
         // an oversized payload then makes build_udp reject the reflect deterministically.

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -288,7 +288,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
-    use crate::capture::Capture;
+    use crate::capture::{Capture, loopback_lock};
     use crate::dispatch::MessageType;
 
     /// Open a loopback capture, or `None` (skip) without `CAP_NET_RAW`. A real capture gives the
@@ -420,6 +420,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn a_suppressed_payload_is_dropped_before_the_send() {
+        let _serial = loopback_lock();
         // The Dropped outcome proves the early return: a completed loopback send would be Reflected.
         let Some((mut reflector, mut dispatcher, mut reactor)) =
             reflector_over_loopback(Box::new(NoRewrite), |_| true)
@@ -459,6 +460,7 @@ mod tests {
             SUPPRESS_CONSULTED.store(true, Ordering::Relaxed);
             true
         }
+        let _serial = loopback_lock();
         let Some((mut reflector, mut dispatcher, mut reactor)) =
             reflector_over_loopback(Box::new(ReplaceRewrite), tracking_suppress)
         else {


### PR DESCRIPTION
Three review findings on 0.16.0.

- capture: an oversized frame now costs a read like any other, so a flood of them on one interface yields after the 64-read budget instead of holding the event loop. `next_frame` returns `Read::Oversized` for it; the counter and the log line are unchanged.
- reactor: the failed-watch test uses `RawFd::MAX` instead of a closed descriptor, whose number a parallel test could reuse before the watch.
- dispatch: per-device entries with disjoint MAC lists on one pair each relayed a query, since only the response legs filter on MACs. The send path remembers, per egress, the length and UDP checksum of the last frame sent for the packet being routed, and drops an equal one. The frame builders return the checksum they wrote. Searches still go out once per entry from their own reserved ports, so each entry's session forwards its own devices' replies.

Testing: `cargo test --lib`, clippy and doc on macOS and Linux, including a loopback test per capture backend for the oversized read; Docker e2e with the new `per_device_entries_relay_a_query_once` case on `config-per-device.toml`, which fails on main with the receiver reporting the query reflected twice and passes here, plus the mDNS query and SSDP round-trip cases.
