### PR TITLE
capture: raw IP links on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,9 @@ devices:
   allow-set (exposing just those devices); the source→target direction is never MAC-filtered. For SSDP
   and WSD the same filter scopes the proxied unicast replies: only the allow-set's responses are
   carried back to a searcher. Because the filter reads the frame's L2 source, these protocols refuse
-  `macs` at startup when the target link carries no MAC addresses (a BSD `DLT_NULL` link such as a
-  loopback or an L3 tunnel) - it could never match. WoL is unaffected: it matches the MAC inside the
-  magic packet's payload.
+  `macs` at startup when the target link carries no MAC addresses (a loopback, or an L3 tunnel such
+  as WireGuard) - it could never match. WoL is unaffected: it matches the MAC inside the magic
+  packet's payload.
 - **The UDP relay** ignores the allow-set. An entry with only the relay enabled may not set `macs`.
 
 Omit `macs` for a network-level entry: WoL proxies every valid magic packet, and mDNS/SSDP/WSD relay
@@ -417,9 +417,11 @@ itself link-local. The DIAL proxy itself refuses to proxy a device whose `LOCATI
 `Application-URL` names a never-a-device address. Suppressed messages count as `dropped` and log at
 debug level.
 
-netflector reads untagged Ethernet frames carrying IPv4 or IPv6 UDP. VLAN-tagged frames and IPv6
-extension headers are not parsed, so configure the VLAN as its own interface (`vlan10`, `em0.10`) and
-name that as the entry's `source_if` / `target_if` rather than the trunk.
+netflector reads untagged Ethernet frames carrying IPv4 or IPv6 UDP, and the bare IP packets of a
+link that has no Ethernet header: a loopback, or a WireGuard or tun tunnel (Linux 5.8 or later).
+Other link types are refused at startup. VLAN-tagged frames and IPv6 extension headers are not
+parsed, so configure the VLAN as its own interface (`vlan10`, `em0.10`) and name that as the entry's
+`source_if` / `target_if` rather than the trunk.
 
 For SSDP, multicast reflection delivers **passive** discovery: devices' periodic `NOTIFY ssdp:alive`
 advertisements reach the source segment so clients see them. **Active** discovery works end to end as

--- a/docker_test.sh
+++ b/docker_test.sh
@@ -20,6 +20,8 @@
 #               veths the fixture creates later. Do NOT reach for `systempaths=unconfined` to
 #               make /proc/sys writable instead: that also unmasks /proc/sysrq-trigger (a write
 #               there panics the HOST) and /proc/kcore (the live kernel memory image).
+#   --device    /dev/net/tun, so the raw IP link test can attach a tun device (a Linux host
+#               without the node wants `modprobe tun`)
 # rust:slim also ships no `ip`, and without it the veth fixture skips every pair test instead of
 # failing, so the image adds iproute2. The layer is cached, so later runs pay nothing for it.
 set -euo pipefail
@@ -42,6 +44,7 @@ exec docker run --rm \
     --cap-add=NET_ADMIN \
     --cap-add=NET_RAW \
     --sysctl net.ipv4.conf.all.accept_local=1 \
+    --device /dev/net/tun \
     -v "$PWD":/netflector \
     -v netflector-linux-target:/linux-target \
     -v netflector-cargo-registry:/usr/local/cargo/registry \

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -14,20 +14,18 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use libc::{c_int, c_void};
 
 use super::Read;
-use super::filter::{BpfInsn, DROP_OUTGOING_PROLOGUE, ETHERNET_UDP_FILTER};
+use super::filter::{BpfInsn, DROP_OUTGOING_PROLOGUE, ETHERNET_UDP_FILTER, RAW_IP_UDP_FILTER};
 use crate::interface::if_index;
 use crate::logging::{WARN_WINDOW, log_rate};
 use crate::net::LinkType;
 use crate::sys::{IoStatus, socklen_of};
-
-/// The fallback filter length: the egress-drop prologue plus the UDP classifier.
-const DROP_OUTGOING_FILTER_LEN: usize = DROP_OUTGOING_PROLOGUE.len() + ETHERNET_UDP_FILTER.len();
 
 /// A raw-capture handle on one interface. The socket's bind is the only holder of the
 /// interface's kernel index: sends rely on it, so nothing here goes stale if the index changes.
 pub(crate) struct Capture {
     fd: OwnedFd,
     buf: Box<[u8]>,
+    link_type: LinkType,
     name: String,
     /// Frames dropped for exceeding the receive buffer since the last
     /// [`take_oversized`](Self::take_oversized) drain.
@@ -38,11 +36,10 @@ impl Capture {
     /// Open an `AF_PACKET` capture bound to `if_name`.
     ///
     /// # Errors
-    /// Returns an error if the interface is unknown, the socket can't be created,
-    /// the filter can't be attached, or the bind fails.
+    /// Returns an error if the interface is unknown or of a hardware type that is neither
+    /// Ethernet nor raw IP, the socket can't be created, the filter can't be attached, or the
+    /// bind fails.
     pub(crate) fn open(if_name: &str) -> io::Result<Self> {
-        let ifindex = resolve_ifindex(if_name)?;
-
         // Protocol 0: capture nothing until the filter + loop-prevention are in place.
         // SAFETY: a `socket` call with a valid domain/type/protocol returns a fresh fd or -1.
         let fd = crate::sys::owned_fd_from(unsafe {
@@ -52,49 +49,30 @@ impl Capture {
                 0,
             )
         })?;
-
-        // Loop prevention: stop the kernel from handing us our own injected frames. A link that
-        // returns them as received frames (a hairpin bridge port) gets past this; the dispatcher's
-        // echo drop catches those. PACKET_IGNORE_OUTGOING (Linux 4.20+) drops them at the socket;
-        // if the kernel lacks it (or user-mode QEMU rejects it), prepend an in-filter drop instead.
-        match set_ignore_outgoing(&fd) {
-            Ok(()) => attach_filter(&fd, &ETHERNET_UDP_FILTER)?,
-            Err(e) => {
-                log::info!(
-                    "PACKET_IGNORE_OUTGOING unavailable ({e}); dropping our own frames in the \
-                     BPF filter"
-                );
-                attach_filter(&fd, &drop_outgoing_filter())?;
-            }
-        }
-
-        // Bind with ETH_P_ALL to start capturing. The filter is already installed, so
-        // there is no unfiltered-capture window.
-        bind_interface(&fd, link_addr(ifindex))?;
-
+        let link_type = attach(&fd, if_name)?;
         log::debug!(
-            "opened AF_PACKET capture on {if_name} (fd {}, ifindex {ifindex})",
+            "opened AF_PACKET capture on {if_name} (fd {}, {link_type:?})",
             fd.as_raw_fd()
         );
         Ok(Self {
             fd,
             buf: vec![0u8; crate::net::MAX_FRAME_LEN].into_boxed_slice(),
+            link_type,
             name: if_name.into(),
             oversized: 0,
         })
     }
 
-    /// Re-bind the socket to the interface currently named at open, re-hooking delivery to its
-    /// (possibly recreated) kernel object. The fd, filter, and loop prevention all persist
-    /// across a `bind(2)`, so the filter-before-bind init invariant holds with no unfiltered
-    /// window, and the reactor's watch stays valid.
+    /// Re-attach the socket to the interface currently named at open, re-hooking delivery to
+    /// its (possibly recreated) kernel object. Same fd, so the reactor's watch stays valid;
+    /// [`attach`] re-reads the framing and re-installs the filter ahead of the bind, so the
+    /// init invariant holds with no unfiltered window.
     ///
     /// # Errors
-    /// [`io::ErrorKind::NotFound`] while no interface bears the name; otherwise the `bind`
+    /// [`io::ErrorKind::NotFound`] while no interface bears the name; otherwise the attach
     /// failure.
     pub(crate) fn rebind(&mut self) -> io::Result<()> {
-        let ifindex = resolve_ifindex(&self.name)?;
-        bind_interface(&self.fd, link_addr(ifindex))?;
+        self.link_type = attach(&self.fd, &self.name)?;
         // The kernel parked ENETDOWN on the socket when the old interface died; consume it so
         // the first post-rebind recv surfaces frames, not the stale failure.
         match crate::sys::so_error(self.fd.as_raw_fd()) {
@@ -112,8 +90,9 @@ impl Capture {
             ),
         }
         log::debug!(
-            "re-bound AF_PACKET capture to {} (ifindex {ifindex})",
-            self.name
+            "re-bound AF_PACKET capture to {} ({:?})",
+            self.name,
+            self.link_type
         );
         Ok(())
     }
@@ -137,10 +116,9 @@ impl Capture {
         rc == 0 && u32::try_from(addr.sll_ifindex).is_ok_and(|bound| bound == ifindex)
     }
 
-    /// The link framing: always Ethernet on Linux, loopback included.
-    #[allow(clippy::unused_self)] // uniform Capture API; the BPF backend reads self
+    /// The link framing, from the interface's hardware type.
     pub(crate) fn link_type(&self) -> LinkType {
-        LinkType::Ethernet
+        self.link_type
     }
 
     pub(crate) fn if_name(&self) -> &str {
@@ -195,7 +173,8 @@ impl Capture {
     pub(crate) fn send(&self, frame: &[u8]) -> io::Result<()> {
         // SOCK_RAW carries the whole L2 frame and the socket is bound to its interface, so a
         // plain `send` suffices: the kernel takes the egress from the bind, and the
-        // destination MAC is in the frame.
+        // destination MAC is in the frame. A raw IP link has no header to read the protocol
+        // off; since Linux 5.8 the kernel takes it from the IP version instead.
         // SAFETY: `frame` is a valid readable slice of `frame.len()` bytes.
         let sent = unsafe {
             libc::send(
@@ -240,13 +219,78 @@ impl AsRawFd for Capture {
     }
 }
 
-/// [`DROP_OUTGOING_PROLOGUE`] followed by [`ETHERNET_UDP_FILTER`]: the
-/// loop-prevention fallback for kernels without `PACKET_IGNORE_OUTGOING`.
-fn drop_outgoing_filter() -> [BpfInsn; DROP_OUTGOING_FILTER_LEN] {
-    std::array::from_fn(|i| match DROP_OUTGOING_PROLOGUE.get(i) {
-        Some(&prologue_insn) => prologue_insn,
-        None => ETHERNET_UDP_FILTER[i - DROP_OUTGOING_PROLOGUE.len()],
-    })
+/// Attach `fd` to `if_name` and normalize the per-attachment state: read the link framing,
+/// install the matching UDP filter with loop prevention, then bind with `ETH_P_ALL` to start
+/// delivery. Shared by [`Capture::open`] and [`Capture::rebind`]; the filter goes in before the
+/// bind, so no frame is ever delivered unfiltered.
+fn attach(fd: &OwnedFd, if_name: &str) -> io::Result<LinkType> {
+    let ifindex = resolve_ifindex(if_name)?;
+    let link_type = link_type_of(fd, if_name)?;
+    install_filter(fd, link_type)?;
+    bind_interface(fd, link_addr(ifindex))?;
+    Ok(link_type)
+}
+
+/// The link framing of `if_name`, from its hardware type: Ethernet (a loopback is framed the
+/// same), or the bare IP packets of a link with no header (`ARPHRD_NONE`: `WireGuard`, tun).
+/// Anything else is refused rather than read as Ethernet.
+fn link_type_of(fd: &OwnedFd, if_name: &str) -> io::Result<LinkType> {
+    // SAFETY: an all-zero `ifreq` is valid (a zeroed name and union).
+    let mut ifr: libc::ifreq = unsafe { core::mem::zeroed() };
+    let n = if_name.len().min(libc::IFNAMSIZ - 1);
+    // SAFETY: copy `n` name bytes into the zeroed `c_char` buffer (same layout as `u8`);
+    // the trailing zero keeps it NUL-terminated.
+    unsafe {
+        std::ptr::copy_nonoverlapping(if_name.as_ptr(), ifr.ifr_name.as_mut_ptr().cast::<u8>(), n);
+    }
+    let request =
+        libc::Ioctl::try_from(libc::SIOCGIFHWADDR).expect("SIOCGIFHWADDR fits the request type");
+    // SAFETY: the ioctl reads the name and writes the hardware address back into the union; any
+    // socket serves it.
+    if unsafe { libc::ioctl(fd.as_raw_fd(), request, &raw mut ifr) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: a successful ioctl wrote `ifru_hwaddr`, whose family is the hardware type.
+    match unsafe { ifr.ifr_ifru.ifru_hwaddr.sa_family } {
+        libc::ARPHRD_ETHER | libc::ARPHRD_LOOPBACK => Ok(LinkType::Ethernet),
+        libc::ARPHRD_NONE => Ok(LinkType::RawIp),
+        other => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("hardware type {other} is neither Ethernet nor a raw IP link"),
+        )),
+    }
+}
+
+/// Install the UDP classifier for `link_type`, with loop prevention: stop the kernel from handing
+/// us our own injected frames. A link that returns them as received frames (a hairpin bridge
+/// port) gets past this; the dispatcher's echo drop catches those. `PACKET_IGNORE_OUTGOING`
+/// (Linux 4.20+) drops them at the socket; if the kernel lacks it (or user-mode QEMU rejects
+/// it), an in-filter drop precedes the classifier instead.
+fn install_filter(fd: &OwnedFd, link_type: LinkType) -> io::Result<()> {
+    let classifier: &[BpfInsn] = match link_type {
+        LinkType::Ethernet => &ETHERNET_UDP_FILTER,
+        LinkType::RawIp => &RAW_IP_UDP_FILTER,
+    };
+    match set_ignore_outgoing(fd) {
+        Ok(()) => attach_filter(fd, classifier),
+        Err(e) => {
+            log::info!(
+                "PACKET_IGNORE_OUTGOING unavailable ({e}); dropping our own frames in the BPF \
+                 filter"
+            );
+            attach_filter(fd, &drop_outgoing_filter(classifier))
+        }
+    }
+}
+
+/// [`DROP_OUTGOING_PROLOGUE`] followed by `classifier`: the loop-prevention fallback for
+/// kernels without `PACKET_IGNORE_OUTGOING`.
+fn drop_outgoing_filter(classifier: &[BpfInsn]) -> Vec<BpfInsn> {
+    DROP_OUTGOING_PROLOGUE
+        .iter()
+        .chain(classifier)
+        .copied()
+        .collect()
 }
 
 /// Resolve `if_name` to its kernel index as the `c_int` a `sockaddr_ll` carries, with a clear
@@ -335,12 +379,20 @@ fn bind_interface(fd: &OwnedFd, mut addr: libc::sockaddr_ll) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
+    use std::fs::File;
+    use std::io::{Read as _, Write as _};
+    use std::net::{Ipv4Addr, SocketAddrV4, SocketAddrV6, UdpSocket};
+    use std::time::{Duration, Instant};
+
+    use libc::c_short;
 
     use super::*;
     use crate::capture::{loopback_lock, open_or_skip};
     use crate::net::frame;
     use crate::net::mac::MacAddr;
+
+    /// How long a live tun test waits for a packet to cross the device.
+    const WAIT_BUDGET: Duration = Duration::from_secs(2);
 
     /// `BpfInsn` is libc's type, which derives no `PartialEq`/`Debug`; compare as field tuples.
     fn as_tuples(insns: &[BpfInsn]) -> Vec<(u16, u8, u8, u32)> {
@@ -349,15 +401,184 @@ mod tests {
 
     #[test]
     fn drop_outgoing_filter_prepends_the_prologue() {
-        let filter = drop_outgoing_filter();
-        assert_eq!(
-            as_tuples(&filter[..DROP_OUTGOING_PROLOGUE.len()]),
-            as_tuples(&DROP_OUTGOING_PROLOGUE)
-        );
-        assert_eq!(
-            as_tuples(&filter[DROP_OUTGOING_PROLOGUE.len()..]),
-            as_tuples(&ETHERNET_UDP_FILTER)
-        );
+        for classifier in [&ETHERNET_UDP_FILTER[..], &RAW_IP_UDP_FILTER[..]] {
+            let filter = drop_outgoing_filter(classifier);
+            assert_eq!(
+                as_tuples(&filter[..DROP_OUTGOING_PROLOGUE.len()]),
+                as_tuples(&DROP_OUTGOING_PROLOGUE)
+            );
+            assert_eq!(
+                as_tuples(&filter[DROP_OUTGOING_PROLOGUE.len()..]),
+                as_tuples(classifier)
+            );
+        }
+    }
+
+    /// A tun device attached to this process: its kernel side is a raw IP link, `far_end` the
+    /// other side, where a packet written arrives on the link and one sent on the link comes
+    /// out. Gone when the file closes.
+    struct Tun {
+        far_end: File,
+        name: String,
+    }
+
+    impl Tun {
+        /// `None`, with a note, where the test can't run: no root, no `/dev/net/tun`, or a
+        /// kernel (user-mode QEMU) that refuses the attach.
+        fn create() -> Option<Self> {
+            // A `%d` template asks for a kernel-assigned name, written back by the ioctl.
+            const TEMPLATE: &[u8] = b"nftun%d";
+            // SAFETY: geteuid takes no arguments and cannot fail.
+            if unsafe { libc::geteuid() } != 0 {
+                eprintln!("skip tun test: creating a tun device requires root");
+                return None;
+            }
+            let far_end = match File::options().read(true).write(true).open("/dev/net/tun") {
+                Ok(file) => file,
+                Err(e) => {
+                    eprintln!("skip tun test: /dev/net/tun: {e}");
+                    return None;
+                }
+            };
+            // SAFETY: an all-zero `ifreq` is valid (a zeroed name and union).
+            let mut ifr: libc::ifreq = unsafe { core::mem::zeroed() };
+            // SAFETY: the template fits `ifr_name` with the terminator the zeroed `ifr` provides.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    TEMPLATE.as_ptr(),
+                    ifr.ifr_name.as_mut_ptr().cast::<u8>(),
+                    TEMPLATE.len(),
+                );
+            }
+            ifr.ifr_ifru.ifru_flags =
+                c_short::try_from(libc::IFF_TUN | libc::IFF_NO_PI).expect("tun flags fit");
+            // SAFETY: TUNSETIFF reads the flags and name template, and writes the name back.
+            if unsafe { libc::ioctl(far_end.as_raw_fd(), libc::TUNSETIFF, &raw mut ifr) } < 0 {
+                eprintln!("skip tun test: TUNSETIFF: {}", io::Error::last_os_error());
+                return None;
+            }
+            // SAFETY: the kernel wrote a NUL-terminated name into `ifr_name`.
+            let name = unsafe { std::ffi::CStr::from_ptr(ifr.ifr_name.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            let up = std::process::Command::new("ip")
+                .args(["link", "set", "dev", &name, "up"])
+                .status()
+                .is_ok_and(|status| status.success());
+            if !up {
+                eprintln!("skip tun test: cannot bring {name} up (no ip(8)?)");
+                return None;
+            }
+            Some(Self { far_end, name })
+        }
+
+        /// Whether a packet equal to `want` comes out of the far end within [`WAIT_BUDGET`].
+        fn read_until(&self, want: &[u8]) -> io::Result<bool> {
+            let deadline = Instant::now() + WAIT_BUDGET;
+            let mut buf = [0u8; crate::net::MAX_FRAME_LEN];
+            while let Some(left) = deadline.checked_duration_since(Instant::now()) {
+                let mut pfd = libc::pollfd {
+                    fd: self.far_end.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                let timeout = c_int::try_from(left.as_millis()).unwrap_or(c_int::MAX);
+                // SAFETY: one `pollfd`, as declared.
+                match unsafe { libc::poll(&raw mut pfd, 1, timeout) } {
+                    0 => break,
+                    n if n < 0 => return Err(io::Error::last_os_error()),
+                    _ => {}
+                }
+                // One packet per read (`IFF_NO_PI`: no header).
+                let n = (&self.far_end).read(&mut buf)?;
+                if &buf[..n] == want {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+    }
+
+    /// A bare IPv4 UDP datagram and a bare IPv6 one, each carrying `payload`.
+    fn bare_datagrams(payload: &[u8]) -> [Vec<u8>; 2] {
+        let mut buf = [0u8; 128];
+        let v4 = frame::ipv4_udp(
+            SocketAddrV4::new(Ipv4Addr::new(10, 99, 200, 2), 40000),
+            SocketAddrV4::new(Ipv4Addr::new(10, 99, 200, 1), 40001),
+            64,
+            payload,
+            &mut buf,
+        )
+        .expect("build the IPv4 datagram")
+        .len;
+        let v4 = buf[..v4].to_vec();
+        let v6 = frame::ipv6_udp(
+            SocketAddrV6::new("fd00:99::2".parse().unwrap(), 40000, 0, 0),
+            SocketAddrV6::new("fd00:99::1".parse().unwrap(), 40001, 0, 0),
+            64,
+            payload,
+            &mut buf,
+        )
+        .expect("build the IPv6 datagram")
+        .len;
+        [v4, buf[..v6].to_vec()]
+    }
+
+    /// Whether `capture` yields a frame equal to `want` within [`WAIT_BUDGET`].
+    fn captures(capture: &mut Capture, want: &[u8]) -> io::Result<bool> {
+        let deadline = Instant::now() + WAIT_BUDGET;
+        while Instant::now() < deadline {
+            while let Some(read) = capture.next_frame()? {
+                if matches!(read, Read::Frame(frame) if frame == want) {
+                    return Ok(true);
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        Ok(false)
+    }
+
+    // Live raw IP link, receive side: a tun device is `ARPHRD_NONE`, so a packet its far end
+    // writes is captured as the bare IP packet it is, in either family.
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_tun_link_captures_bare_ip_packets() -> io::Result<()> {
+        let Some(mut tun) = Tun::create() else {
+            return Ok(());
+        };
+        let mut capture = Capture::open(&tun.name)?;
+        assert_eq!(capture.link_type(), LinkType::RawIp);
+        for packet in bare_datagrams(b"netflector-tun-in") {
+            tun.far_end.write_all(&packet)?;
+            assert!(
+                captures(&mut capture, &packet)?,
+                "did not capture the IPv{} packet written to {}",
+                packet[0] >> 4,
+                tun.name
+            );
+        }
+        Ok(())
+    }
+
+    // Live raw IP link, send side: a packet sent on the capture comes out of the tun's far end
+    // as the bare IP packet it was built as, in either family.
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_tun_link_sends_bare_ip_packets() -> io::Result<()> {
+        let Some(tun) = Tun::create() else {
+            return Ok(());
+        };
+        let capture = Capture::open(&tun.name)?;
+        for packet in bare_datagrams(b"netflector-tun-out") {
+            capture.send(&packet)?;
+            assert!(
+                tun.read_until(&packet)?,
+                "the IPv{} packet sent on {} did not reach its far end",
+                packet[0] >> 4,
+                tun.name
+            );
+        }
+        Ok(())
     }
 
     // Live capture against the real kernel: send UDP to 127.0.0.1 and capture the

--- a/src/capture/filter.rs
+++ b/src/capture/filter.rs
@@ -67,6 +67,36 @@ pub(crate) const DROP_OUTGOING_PROLOGUE: [BpfInsn; 3] = [
     insn(0x0006, 0, 0, 0x0000_0000), // BPF_RET|BPF_K drop
 ];
 
+/// Accept IPv4 UDP or IPv6 UDP on a raw IP link (a Linux tunnel), drop everything
+/// else in-kernel. There is no link header: the IP version nibble at offset 0 picks
+/// the layout.
+///
+/// ```text
+/// ldb [0]                  version nibble + IHL / traffic class
+/// and 0xf0                 keep the version
+/// jeq 0x40 -> IPv4@6       else fall through
+/// jeq 0x60 -> IPv6 fall    else drop@9
+/// ldb [6]                  IPv6 next-header
+/// jeq 17   -> accept@8     else drop@9
+/// ldb [9]                  IPv4 protocol
+/// jeq 17   -> accept@8     else drop@9
+/// ret 0xffffffff           accept
+/// ret 0                    drop
+/// ```
+#[cfg(target_os = "linux")]
+pub(crate) const RAW_IP_UDP_FILTER: [BpfInsn; 10] = [
+    insn(0x0030, 0, 0, 0x0000_0000), // BPF_LD|BPF_B|BPF_ABS  [0] version nibble + IHL
+    insn(0x0054, 0, 0, 0x0000_00f0), // BPF_ALU|BPF_AND|BPF_K 0xf0 keep the version
+    insn(0x0015, 3, 0, 0x0000_0040), // BPF_JMP|BPF_JEQ|BPF_K 4 IPv4
+    insn(0x0015, 0, 5, 0x0000_0060), // BPF_JMP|BPF_JEQ|BPF_K 6 IPv6
+    insn(0x0030, 0, 0, 0x0000_0006), // BPF_LD|BPF_B|BPF_ABS  [6] IPv6 next-header
+    insn(0x0015, 2, 3, 0x0000_0011), // BPF_JMP|BPF_JEQ|BPF_K 17 UDP
+    insn(0x0030, 0, 0, 0x0000_0009), // BPF_LD|BPF_B|BPF_ABS  [9] IPv4 protocol
+    insn(0x0015, 0, 1, 0x0000_0011), // BPF_JMP|BPF_JEQ|BPF_K 17 UDP
+    insn(0x0006, 0, 0, 0xffff_ffff), // BPF_RET|BPF_K accept
+    insn(0x0006, 0, 0, 0x0000_0000), // BPF_RET|BPF_K drop
+];
+
 /// Convert a host-order address family to the value a `BPF_LD|BPF_W|BPF_ABS` load
 /// compares against. The classic-BPF VM assembles a loaded word big-endian
 /// regardless of host, but a `DLT_NULL` frame stores the family in host order.

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -141,8 +141,8 @@ pub(crate) type IpSet = FilterSet<IpAddr>;
 pub(crate) type PortSet = FilterSet<u16>;
 
 /// An optional-field packet filter: an unset field
-/// matches anything. A `src_mac`/`dst_mac` filter never matches a `DLT_NULL` packet,
-/// which has no L2 addresses. `dst_ip`/`dst_port` match membership in their [`FilterSet`].
+/// matches anything. A `src_mac`/`dst_mac` filter never matches a packet from a link without
+/// L2 addresses (`DLT_NULL`, raw IP). `dst_ip`/`dst_port` match membership in their [`FilterSet`].
 #[derive(Clone, Default)]
 pub(crate) struct Filter {
     pub(crate) src_ip: Option<IpAddr>,

--- a/src/dispatch/datagram.rs
+++ b/src/dispatch/datagram.rs
@@ -60,8 +60,8 @@ pub(super) fn ethernet_dst(
 /// Assemble a UDP datagram for an egress with addresses `addrs` and link framing `link` into
 /// `scratch`. The IP source is `source`, the L2 source the egress's own
 /// MAC; the L2 destination is the caller-supplied `dst_mac` (so this serves unicast, multicast, and
-/// broadcast alike). BSD `DLT_NULL` (loopback/tunnel) carries no L2 addresses, so it ignores
-/// `dst_mac` and needs no source MAC.
+/// broadcast alike). A link without L2 addresses (BSD `DLT_NULL`, a Linux raw IP tunnel)
+/// ignores `dst_mac` and needs no source MAC.
 // A frame builder takes the full wire spec (egress addrs + link, dst addr + MAC, source, ttl,
 // payload, buffer); bundling any of these would obscure more than the arg count costs.
 #[allow(clippy::too_many_arguments)]
@@ -98,6 +98,8 @@ pub(super) fn build_udp(
                 )?),
                 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
                 LinkType::DltNull => Ok(frame::dlt_null_ipv4_udp(src, dst, ttl, payload, scratch)?),
+                #[cfg(target_os = "linux")]
+                LinkType::RawIp => Ok(frame::ipv4_udp(src, dst, ttl, payload, scratch)?),
             }
         }
         SocketAddr::V6(dst) => {
@@ -127,6 +129,8 @@ pub(super) fn build_udp(
                 )?),
                 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
                 LinkType::DltNull => Ok(frame::dlt_null_ipv6_udp(src, dst, ttl, payload, scratch)?),
+                #[cfg(target_os = "linux")]
+                LinkType::RawIp => Ok(frame::ipv6_udp(src, dst, ttl, payload, scratch)?),
             }
         }
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -20,14 +20,17 @@ pub(crate) mod wsd;
 
 /// Link-layer framing of a captured or injected frame. The capture layer reports
 /// it per interface; [`frame`] adds the matching link header and [`packet`] strips
-/// it before parsing L3. Either a 14-byte Ethernet header, or on BSD `DLT_NULL`'s
-/// 4-byte host-order address family (loopback/tunnel interfaces). Linux frames every
-/// interface as Ethernet, loopback included.
+/// it before parsing L3. A 14-byte Ethernet header; on BSD `DLT_NULL`'s 4-byte
+/// host-order address family (loopback/tunnel interfaces); on Linux no header at all,
+/// the bare IP packet a tunnel (`WireGuard`, tun) carries. Linux frames loopback as
+/// Ethernet.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum LinkType {
     Ethernet,
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     DltNull,
+    #[cfg(target_os = "linux")]
+    RawIp,
 }
 
 /// IANA protocol number for UDP.

--- a/src/net/frame.rs
+++ b/src/net/frame.rs
@@ -4,7 +4,8 @@
 //! data-path allocation) and return the byte count, filling checksums via
 //! [`super::checksum`]. Ethernet builders prefix destination/source MACs and an
 //! ethertype. The BSD `DLT_NULL` builders (macOS/FreeBSD) prefix a 4-byte
-//! host-order address family instead, matching the capture-side framing.
+//! host-order address family instead, matching the capture-side framing. A Linux raw
+//! IP link (`WireGuard`, tun) takes the bare datagram that [`ipv4_udp`] / [`ipv6_udp`] write.
 
 use std::net::{SocketAddrV4, SocketAddrV6};
 
@@ -144,7 +145,11 @@ pub(crate) fn dlt_null_ipv6_udp(
 
 /// Write an IPv4 + UDP datagram (headers and `payload`, with the IPv4-header and
 /// UDP checksums filled) into `out`.
-fn ipv4_udp(
+///
+/// # Errors
+/// [`FrameError::PayloadTooLarge`] if the datagram overflows the 16-bit length
+/// fields, or [`FrameError::BufferTooSmall`] if `out` cannot hold it.
+pub(crate) fn ipv4_udp(
     src: SocketAddrV4,
     dst: SocketAddrV4,
     ttl: u8,
@@ -185,7 +190,11 @@ fn ipv4_udp(
 
 /// Write an IPv6 + UDP datagram (headers and `payload`, with the UDP checksum
 /// filled) into `out`. The IPv6 header carries no checksum of its own.
-fn ipv6_udp(
+///
+/// # Errors
+/// [`FrameError::PayloadTooLarge`] if the datagram overflows the 16-bit length
+/// fields, or [`FrameError::BufferTooSmall`] if `out` cannot hold it.
+pub(crate) fn ipv6_udp(
     src: SocketAddrV6,
     dst: SocketAddrV6,
     hop_limit: u8,

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -26,7 +26,7 @@ pub(crate) struct Packet<'a> {
     pub(crate) dest: SocketAddr,
     /// IPv4 TTL or IPv6 hop limit, as captured.
     pub(crate) ttl: u8,
-    /// Ethernet destination/source MAC, or `None` on `DLT_NULL` (loopback/tunnel, no L2).
+    /// Ethernet destination/source MAC, or `None` on a link without them (`DLT_NULL`, raw IP).
     pub(crate) dst_mac: Option<MacAddr>,
     pub(crate) src_mac: Option<MacAddr>,
     pub(crate) payload: &'a [u8],
@@ -85,7 +85,7 @@ impl<'a> Packet<'a> {
     }
 }
 
-/// A frame's link header: its L2 addresses (absent on `DLT_NULL`) and the L3 bytes
+/// A frame's link header: its L2 addresses (absent on a MAC-less link) and the L3 bytes
 /// that follow.
 #[derive(Clone, Copy)]
 struct LinkHeader<'a> {
@@ -116,6 +116,12 @@ fn parse_link_header(link_type: LinkType, frame: &[u8]) -> Result<LinkHeader<'_>
             l3: frame
                 .get(DLT_NULL_HEADER_SIZE..)
                 .ok_or(ParseError::Truncated)?,
+        }),
+        #[cfg(target_os = "linux")]
+        LinkType::RawIp => Ok(LinkHeader {
+            dst_mac: None,
+            src_mac: None,
+            l3: frame,
         }),
     }
 }
@@ -322,6 +328,49 @@ mod tests {
             .len;
 
         let packet = Packet::parse(LinkType::DltNull, &buf[..n]).unwrap();
+        assert_eq!(packet.source, SocketAddr::V6(src));
+        assert_eq!(packet.dest, SocketAddr::V6(dst));
+        assert_eq!(packet.ttl, 255);
+        assert_eq!(packet.payload, &payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn round_trips_raw_ip_ipv4() {
+        let src = SocketAddrV4::new(Ipv4Addr::new(10, 10, 10, 2), 5353);
+        let dst = SocketAddrV4::new(Ipv4Addr::new(10, 10, 10, 1), 5354);
+        let payload = [0x01, 0x02];
+        let mut buf = [0u8; 64];
+        let n = frame::ipv4_udp(src, dst, 64, &payload, &mut buf)
+            .unwrap()
+            .len;
+
+        let packet = Packet::parse(LinkType::RawIp, &buf[..n]).unwrap();
+        assert_eq!(packet.source, SocketAddr::V4(src));
+        assert_eq!(packet.dest, SocketAddr::V4(dst));
+        assert_eq!(packet.ttl, 64);
+        // No link header, so no MACs to report.
+        assert_eq!(packet.dst_mac, None);
+        assert_eq!(packet.src_mac, None);
+        assert_eq!(packet.payload, &payload);
+        assert_eq!(
+            Packet::parse(LinkType::RawIp, &[]),
+            Err(ParseError::Truncated)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn round_trips_raw_ip_ipv6() {
+        let src = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5353, 0, 0);
+        let dst = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5354, 0, 0);
+        let payload = [0x09];
+        let mut buf = [0u8; 80];
+        let n = frame::ipv6_udp(src, dst, 255, &payload, &mut buf)
+            .unwrap()
+            .len;
+
+        let packet = Packet::parse(LinkType::RawIp, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V6(src));
         assert_eq!(packet.dest, SocketAddr::V6(dst));
         assert_eq!(packet.ttl, 255);


### PR DESCRIPTION
A packet socket on a WireGuard or tun device hands over bare IP packets: no link header, no MACs. The AF_PACKET backend framed every interface as Ethernet, so on such a link the kernel filter dropped nearly everything, what got through failed to parse, and an injected frame went out with an Ethernet header the tunnel could not read. FreeBSD was already fine through `DLT_NULL`.

The hardware type (`SIOCGIFHWADDR`) now picks the framing at open and rebind: Ethernet and loopback as Ethernet, `ARPHRD_NONE` as raw IP with its own kernel filter, parser arm and builders, anything else refused at startup. Sends stay a plain `send`: since Linux 5.8 the kernel derives a header-less link's protocol from the IP version (`ip_tunnel_header_ops` on wireguard and tun), so raw IP links need that kernel or later. `sendto` with the protocol in the address was tried and dropped: it only buys 5.6 and 5.7, at the cost of a cached ifindex.

Testing: parser round trips for both families, filter composition, and two root-gated live tests that attach a tun device and push an IPv4 and an IPv6 datagram through it in each direction, byte for byte. Sabotaging the raw-IP classifier fails the receive test. `docker_test.sh` now passes `/dev/net/tun` into the container so they run there; the emulated CI lanes skip them without root. Suite green on macOS and Linux, clippy clean on both FreeBSD targets.
