### PR TITLE
dispatch: deliver group sends to an entry's peers as unicast

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ counters_interval_secs = 0         # optional; seconds between per-interface pac
 [reflectors.tv]
 source_if = "en0"                # required; interface to listen on (must differ from target_if)
 target_if = "lo0"                # required; interface to emit reflected traffic on
+target_peers = ["10.10.10.2"]    # optional; the hosts behind target_if when a group sent there reaches nobody (see Peers)
+# source_peers = ["10.0.0.2"]    # optional; the same for source_if; not with mdns, whose answers go there
 macs      = ["B0:37:95:C5:60:BE"] # optional; device(s) to scope to (see below). Omit for a whole network.
 wol       = true                 # optional; enable Wake-on-LAN reflection (default false)
 mdns      = true                 # optional; enable mDNS reflection (default false)
@@ -267,7 +269,8 @@ udp_broadcast = true             # optional; also relay broadcasts on those port
 
 An entry must enable at least one protocol or set `udp_ports`, and expands into one reflector per
 enabled protocol, all sharing the entry's interfaces, MAC selection, and `address_family`. The same shape serves one or a few
-specific devices (set `macs`) or a whole network (omit it). No IP addresses ever appear in the config.
+specific devices (set `macs`) or a whole network (omit it). Apart from peers, no IP addresses appear
+in the config.
 `dial` is not a separate reflector; it augments the entry's SSDP reflector with the DIAL application
 proxy (so it requires `ssdp`; see [DIAL](#dial)).
 
@@ -286,13 +289,13 @@ then optional; with none, the environment is the whole configuration. Variables 
 
 - `<TAG>` ties one entry's parameters together: any alphanumeric string (`1`, `2`, `TV`, …). It also
   becomes the entry's name (and thus its log label) unless a `NAME` parameter overrides it.
-- `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`, `MACS`,
-  `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`, `ADDRESS_FAMILY`, `BIDIRECTIONAL`, `UDP_PORTS`,
-  `UDP_GROUPS`, `UDP_BROADCAST`), case-insensitive.
+- `<PARAM>` is `NAME` or any field from the entry table above (`SOURCE_IF`, `TARGET_IF`,
+  `SOURCE_PEERS`, `TARGET_PEERS`, `MACS`, `WOL`, `MDNS`, `SSDP`, `WSD`, `DIAL`, `WOL_PORTS`,
+  `ADDRESS_FAMILY`, `BIDIRECTIONAL`, `UDP_PORTS`, `UDP_GROUPS`, `UDP_BROADCAST`), case-insensitive.
 
 The globals are `NETFLECTOR_LOG_LEVEL`, `NETFLECTOR_DEBUG_MEMORY_INTERVAL_SECS`, and
 `NETFLECTOR_COUNTERS_INTERVAL_SECS`, so `LOG`, `DEBUG`, and `COUNTERS` are reserved tags. Booleans are
-`true`/`false` or `1`/`0`; `WOL_PORTS`, `UDP_PORTS`, `UDP_GROUPS`
+`true`/`false` or `1`/`0`; `WOL_PORTS`, `UDP_PORTS`, `UDP_GROUPS`, `SOURCE_PEERS`, `TARGET_PEERS`
 and `MACS` are comma-separated (`7,9` / `B0:...,C4:...`). The `[reflectors.tv]` entry above looks like
 this in the environment:
 
@@ -490,6 +493,30 @@ UDP 9003, from servers and endpoints alike:
 [reflectors.roon]
 source_if = "lan"
 target_if = "iot"
+udp_ports = [9003]
+udp_groups = ["239.255.90.90"]
+udp_broadcast = true
+bidirectional = true
+```
+
+### Peers
+
+A WireGuard tunnel delivers a datagram only to the peer whose allowed addresses cover its
+destination, so one sent to a group or a broadcast reaches nobody and comes back as an ICMP
+unreachable. List the hosts behind such an interface in `source_peers` or `target_peers`, and every
+group or broadcast the entry would send there goes to each of them as a unicast copy instead, same
+port, same source, for every protocol the entry enables. A tunnel that carries multicast, such as
+GRE, needs no peers. Peers work on any link; on Ethernet each copy travels in a broadcast frame,
+since netflector resolves no MAC addresses. The exception is mDNS answers: a client takes a
+unicast answer only to a question it asked with the unicast-response bit, so an entry with `mdns`
+may list `target_peers` for its queries but no peers on the side its answers go to. Roon for road
+warriors, with the server on the LAN and the phones behind the tunnel:
+
+```toml
+[reflectors.roon-remote]
+source_if = "lan"
+target_if = "wg0"
+target_peers = ["10.10.10.2", "10.10.10.3"]
 udp_ports = [9003]
 udp_groups = ["239.255.90.90"]
 udp_broadcast = true

--- a/e2e/config-peers-both.toml
+++ b/e2e/config-peers-both.toml
@@ -1,0 +1,32 @@
+log_level = "debug"
+
+# config-peers-target.toml and config-peers-source.toml at once: each segment's probe is that
+# segment's peer, so every group or broadcast re-emit, either way, reaches it as a unicast copy.
+
+[reflectors.wol]
+source_if = "nf_source"
+target_if = "nf_target"
+source_peers = ["192.0.2.20", "fd00:e2e0:1::20"]
+target_peers = ["198.51.100.20", "fd00:e2e0:2::20"]
+wol = true
+wol_ports = [9011]
+bidirectional = true
+
+[reflectors.discovery]
+source_if = "nf_source"
+target_if = "nf_target"
+source_peers = ["192.0.2.20", "fd00:e2e0:1::20"]
+target_peers = ["198.51.100.20", "fd00:e2e0:2::20"]
+# No mdns: its answers go to the source, and an mDNS entry may not list peers there.
+ssdp = true
+wsd = true
+
+[reflectors.relay]
+source_if = "nf_source"
+target_if = "nf_target"
+source_peers = ["192.0.2.20", "fd00:e2e0:1::20"]
+target_peers = ["198.51.100.20", "fd00:e2e0:2::20"]
+udp_ports = [9003]
+udp_groups = ["239.255.90.90", "ff02::5a5a"]
+udp_broadcast = true
+bidirectional = true

--- a/e2e/config-peers-source.toml
+++ b/e2e/config-peers-source.toml
@@ -1,0 +1,30 @@
+log_level = "debug"
+
+# The mirror of config-peers-target.toml: the source segment's probe is the only peer, so a
+# group or broadcast re-emit on the source reaches it as a unicast copy while the target keeps
+# its group and broadcast.
+
+[reflectors.wol]
+source_if = "nf_source"
+target_if = "nf_target"
+source_peers = ["192.0.2.20", "fd00:e2e0:1::20"]
+wol = true
+wol_ports = [9011]
+bidirectional = true
+
+[reflectors.discovery]
+source_if = "nf_source"
+target_if = "nf_target"
+source_peers = ["192.0.2.20", "fd00:e2e0:1::20"]
+# No mdns: its answers go to the source, and an mDNS entry may not list peers there.
+ssdp = true
+wsd = true
+
+[reflectors.relay]
+source_if = "nf_source"
+target_if = "nf_target"
+source_peers = ["192.0.2.20", "fd00:e2e0:1::20"]
+udp_ports = [9003]
+udp_groups = ["239.255.90.90", "ff02::5a5a"]
+udp_broadcast = true
+bidirectional = true

--- a/e2e/config-peers-target.toml
+++ b/e2e/config-peers-target.toml
@@ -1,0 +1,31 @@
+log_level = "debug"
+
+# Every protocol with the target segment's probe listed as that segment's only peer, so a group or
+# broadcast re-emit on the target reaches it as a unicast copy while the source keeps its group
+# and broadcast. The host number is the harness's plan: the probe on a segment is .20 / ::20 on
+# both fabrics.
+
+[reflectors.wol]
+source_if = "nf_source"
+target_if = "nf_target"
+target_peers = ["198.51.100.20", "fd00:e2e0:2::20"]
+wol = true
+wol_ports = [9011]
+bidirectional = true
+
+[reflectors.discovery]
+source_if = "nf_source"
+target_if = "nf_target"
+target_peers = ["198.51.100.20", "fd00:e2e0:2::20"]
+mdns = true
+ssdp = true
+wsd = true
+
+[reflectors.relay]
+source_if = "nf_source"
+target_if = "nf_target"
+target_peers = ["198.51.100.20", "fd00:e2e0:2::20"]
+udp_ports = [9003]
+udp_groups = ["239.255.90.90", "ff02::5a5a"]
+udp_broadcast = true
+bidirectional = true

--- a/e2e/probe.py
+++ b/e2e/probe.py
@@ -163,7 +163,7 @@ def receive(args: argparse.Namespace) -> int:
     deadline = time.monotonic() + args.timeout
 
     family = socket.AF_INET6 if args.family == 6 else socket.AF_INET
-    bind_address = "::" if family == socket.AF_INET6 else "0.0.0.0"
+    bind_address = args.bind_address or ("::" if family == socket.AF_INET6 else "0.0.0.0")
 
     try:
         return _receive(args, expected, deadline, family, bind_address)
@@ -182,7 +182,7 @@ def _receive(args, expected, deadline, family, bind_address) -> int:
             # Multicast is only delivered to sockets that joined the group on the receiving
             # interface; broadcast/all-nodes (the WoL IPv4 path) needs no join.
             join_group(sock, family, args.join_group, args.interface)
-        print(f"receiver ready: UDP socket bound on port {args.port}", flush=True)
+        print(f"receiver ready: UDP socket bound on {bind_address} port {args.port}", flush=True)
 
         # An expect-none receiver outlives its own deadline: the harness stops it once the sender
         # has finished, so the window provably spans the send instead of racing it.
@@ -205,6 +205,10 @@ def _receive(args, expected, deadline, family, bind_address) -> int:
             if args.expect_none:
                 print("expected no packets, but one was received", file=sys.stderr, flush=True)
                 return 1
+
+            if payload in args.ignore_payload_hex:
+                print("ignored", flush=True)
+                continue
 
             if payload == expected:
                 if not source_as_expected(args, peer):
@@ -275,7 +279,7 @@ def respond(args: argparse.Namespace) -> int:
     # straight back to its sender. The sender is netflector's reserved port on the target segment,
     # which proxies the reply back to the searcher on the source segment.
     family = socket.AF_INET6 if args.family == 6 else socket.AF_INET
-    bind_address = "::" if family == socket.AF_INET6 else "0.0.0.0"
+    bind_address = args.bind_address or ("::" if family == socket.AF_INET6 else "0.0.0.0")
 
     with socket.socket(family, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -283,7 +287,7 @@ def respond(args: argparse.Namespace) -> int:
         if args.join_group is not None:
             join_group(sock, family, args.join_group, args.interface)
         # Readiness marker so run.py can sequence the searcher after the responder is listening.
-        print(f"responder ready: UDP socket bound on port {args.port}", flush=True)
+        print(f"responder ready: UDP socket bound on {bind_address} port {args.port}", flush=True)
 
         sock.settimeout(args.timeout)
         try:
@@ -760,6 +764,10 @@ def main() -> int:
     receive_parser.add_argument("--family", default=4, type=int, choices=(4, 6), help="IP version to bind")
     receive_parser.add_argument("--join-group", help="multicast group to join on --interface")
     receive_parser.add_argument("--interface", help="interface to join the multicast group on")
+    receive_parser.add_argument("--bind-address",
+                                help="bind to this address instead of the wildcard: only a datagram sent to it arrives")
+    receive_parser.add_argument("--ignore-payload-hex", type=parse_payload_hex, action="append", default=[],
+                                help="a UDP payload to skip rather than fail on; may be passed more than once")
 
     expectation = receive_parser.add_mutually_exclusive_group(required=True)
     expectation.add_argument("--expect-mac", help="MAC address whose magic packet must be received")
@@ -777,6 +785,8 @@ def main() -> int:
     respond_parser.add_argument("--family", default=4, type=int, choices=(4, 6), help="IP version to bind")
     respond_parser.add_argument("--join-group", help="multicast group to join on --interface")
     respond_parser.add_argument("--interface", help="interface to join the multicast group on")
+    respond_parser.add_argument("--bind-address",
+                                help="bind to this address instead of the wildcard: only a datagram sent to it arrives")
     respond_parser.add_argument("--reply-hex", required=True, type=parse_payload_hex, help="UDP payload to unicast back")
     respond_parser.set_defaults(func=respond)
 

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -389,6 +389,11 @@ class TestCase:
     # Send from a fixed port and require the reflected packet to come from that port and from
     # the sender's own segment: the UDP relay keeps the source as sent.
     expect_source_preserved: bool = False
+    # The receiver binds to its own address, so only a unicast copy sent to it arrives: the
+    # config names the probe as a peer of its segment.
+    expect_unicast: bool = False
+    # The port to send from; an mDNS response must come from 5353 to count as one.
+    send_source_port: int | None = None
 
     @property
     def send_address(self) -> str:
@@ -522,6 +527,7 @@ MDNS_CASES = [
     ),
     TestCase(
         name="reflects_mdns_response",
+        send_source_port=MDNS_PORT,
         send_port=MDNS_PORT,
         receive_port=MDNS_PORT,
         expect_mac=None,
@@ -545,6 +551,7 @@ MDNS_CASES = [
     ),
     TestCase(
         name="reflects_mdns_response_ipv6",
+        send_source_port=MDNS_PORT,
         send_port=MDNS_PORT,
         receive_port=MDNS_PORT,
         expect_mac=None,
@@ -558,6 +565,7 @@ MDNS_CASES = [
     # A routable address beside the link-local one rescues the response from suppression.
     TestCase(
         name="reflects_mdns_response_with_mixed_addresses",
+        send_source_port=MDNS_PORT,
         send_port=MDNS_PORT,
         receive_port=MDNS_PORT,
         expect_mac=None,
@@ -568,8 +576,20 @@ MDNS_CASES = [
         direction="reverse",
     ),
     # Every address is link-local, so the response is suppressed rather than relayed.
+    # A response from any port but 5353 is not one (RFC 6762 §6), so it stays where it was sent.
+    TestCase(
+        name="ignores_mdns_response_from_another_port",
+        send_port=MDNS_PORT,
+        receive_port=MDNS_PORT,
+        expect_mac=None,
+        timeout_seconds=1.5,
+        send_payload_hex=MDNS_RESPONSE_HEX,
+        group=MDNS_GROUP_V4,
+        direction="reverse",
+    ),
     TestCase(
         name="ignores_mdns_link_local_only_response",
+        send_source_port=MDNS_PORT,
         send_port=MDNS_PORT,
         receive_port=MDNS_PORT,
         expect_mac=None,
@@ -594,6 +614,7 @@ MDNS_CASES = [
     ),
     TestCase(
         name="bidirectional_reflects_mdns_response_from_source",
+        send_source_port=MDNS_PORT,
         send_port=MDNS_PORT,
         receive_port=MDNS_PORT,
         expect_mac=None,
@@ -618,6 +639,7 @@ MDNS_CASES = [
     # A response sent source->target hits the source's query-only handler and is dropped.
     TestCase(
         name="ignores_mdns_response_in_query_direction",
+        send_source_port=MDNS_PORT,
         send_port=MDNS_PORT,
         receive_port=MDNS_PORT,
         expect_mac=None,
@@ -1101,6 +1123,79 @@ RELAY_CASES = [
 ]
 
 
+# The probe on a segment named as that segment's peer, on the target only, the source only, or
+# both (config-peers-*.toml). On a side with peers the re-emit that would go to the group or
+# broadcast arrives as a unicast copy, which only a socket bound to the probe's own address can
+# prove; on a side without, it still goes to the group or broadcast. Every protocol, both legs,
+# every config: the forward leg sends on the target, the reverse one (a response, an
+# announcement, or a bidirectional entry's second leg) on the source.
+PEERS_CONFIGS = {
+    "target": ("config-peers-target.toml", {"target"}),
+    "source": ("config-peers-source.toml", {"source"}),
+    "both": ("config-peers-both.toml", {"source", "target"}),
+}
+
+# (protocol, forward leg, reverse leg): a leg is (message name, its TestCase fields).
+PEERS_LEGS = [
+    ("wol",
+     ("wake", dict(send_port=ANY_MAC_PORT, receive_port=ANY_MAC_PORT, expect_mac=WRONG_MAC, send_mac=WRONG_MAC)),
+     ("wake", dict(send_port=ANY_MAC_PORT, receive_port=ANY_MAC_PORT, expect_mac=WRONG_MAC, send_mac=WRONG_MAC))),
+    ("mdns",
+     ("query", dict(send_port=MDNS_PORT, receive_port=MDNS_PORT, expect_mac=None, group=MDNS_GROUP_V4,
+                    send_payload_hex=MDNS_QUERY_HEX, expect_payload_hex=MDNS_QUERY_HEX)),
+     ("response", dict(send_port=MDNS_PORT, receive_port=MDNS_PORT, expect_mac=None, group=MDNS_GROUP_V4,
+                       send_payload_hex=MDNS_RESPONSE_HEX, expect_payload_hex=MDNS_RESPONSE_HEX,
+                       send_source_port=MDNS_PORT))),
+    ("ssdp",
+     ("msearch", dict(send_port=SSDP_PORT, receive_port=SSDP_PORT, expect_mac=None, group=SSDP_GROUP_V4,
+                      send_payload_hex=SSDP_MSEARCH_HEX, expect_payload_hex=SSDP_MSEARCH_HEX)),
+     ("notify", dict(send_port=SSDP_PORT, receive_port=SSDP_PORT, expect_mac=None, group=SSDP_GROUP_V4,
+                     send_payload_hex=SSDP_NOTIFY_HEX, expect_payload_hex=SSDP_NOTIFY_HEX))),
+    ("wsd",
+     ("probe", dict(send_port=WSD_PORT, receive_port=WSD_PORT, expect_mac=None, group=WSD_GROUP_V4,
+                    send_payload_hex=WSD_PROBE_HEX, expect_payload_hex=WSD_PROBE_HEX)),
+     ("hello", dict(send_port=WSD_PORT, receive_port=WSD_PORT, expect_mac=None, group=WSD_GROUP_V4,
+                    send_payload_hex=WSD_HELLO_HEX, expect_payload_hex=WSD_HELLO_HEX))),
+    # The relay's unicast copies keep the sender's source; the receiver does not check it, since
+    # the copy travels in a broadcast frame and the docker host masquerades it like a broadcast
+    # (see the relay broadcast cases). The native fabrics deliver it as sent.
+    ("relay",
+     ("datagram", dict(send_port=RELAY_PORT, receive_port=RELAY_PORT, expect_mac=None, group=RELAY_GROUP_V4,
+                       send_payload_hex=SOOD_QUERY_HEX, expect_payload_hex=SOOD_QUERY_HEX)),
+     ("datagram", dict(send_port=RELAY_PORT, receive_port=RELAY_PORT, expect_mac=None, group=RELAY_GROUP_V4,
+                       send_payload_hex=SOOD_QUERY_HEX, expect_payload_hex=SOOD_QUERY_HEX))),
+]
+
+
+def _peers_cases() -> list[TestCase]:
+    cases = []
+    for label, (config, sides) in PEERS_CONFIGS.items():
+        for protocol, forward, reverse in PEERS_LEGS:
+            # An mDNS entry may not list source peers (its answers go there), so the configs with
+            # source peers leave mDNS out.
+            if protocol == "mdns" and "source" in sides:
+                continue
+            for direction, (message, fields), side in (("forward", forward, "target"), ("reverse", reverse, "source")):
+                unicast = side in sides
+                reach = "peers" if unicast else ("broadcast" if protocol == "wol" else "group")
+                cases.append(TestCase(
+                    name=f"{protocol}_{message}_to_{side}_{reach}_with_{label}_peers",
+                    timeout_seconds=5.0, config=config, direction=direction, expect_unicast=unicast,
+                    **fields,
+                ))
+    return cases
+
+
+PEERS_CASES = [
+    *_peers_cases(),
+    # A copy to a routable IPv6 peer, for a query sent to the link-local group.
+    TestCase(name="mdns_query_to_target_peers_ipv6_with_target_peers", send_port=MDNS_PORT,
+        receive_port=MDNS_PORT, expect_mac=None, timeout_seconds=5.0, send_payload_hex=MDNS_QUERY_HEX,
+        expect_payload_hex=MDNS_QUERY_HEX, group=MDNS_GROUP_V6, family=6,
+        config="config-peers-target.toml", expect_unicast=True),
+]
+
+
 @dataclasses.dataclass(frozen=True)
 class RoundTripCase:
     name: str
@@ -1120,6 +1215,9 @@ class RoundTripCase:
     # "forward" searches from the source segment with the responder on the target; "reverse" swaps
     # them, the leg a bidirectional entry adds.
     direction: str = "forward"
+    # The responder binds to its own address, so only a unicast copy of the search arrives: the
+    # config names it as a peer of its segment.
+    responder_unicast: bool = False
 
 
 ROUNDTRIP_CASES = [
@@ -1147,6 +1245,46 @@ ROUNDTRIP_CASES = [
     RoundTripCase(name="wsd_resolve_roundtrip", family=4, group=WSD_GROUP_V4, port=WSD_PORT,
         probe_hex=WSD_RESOLVE_HEX, reply_hex=WSD_RESOLVEMATCHES_HEX, config="config-wsd.toml",
         evict_log="evicted WSD session"),
+    # Searches with peers: on a target with peers the copy reaches the responder at its own
+    # address and its reply finds the session; on one without, the search still goes to the
+    # group. The IPv6 case sends to the link-local group while the peer is a routable address,
+    # so the session must listen on netflector's routable address, not its link-local one.
+    *(
+        RoundTripCase(name=f"ssdp_msearch_roundtrip_to_target_{'peers' if 'target' in sides else 'group'}_with_{label}_peers",
+            family=4, group=SSDP_GROUP_V4, config=config, responder_unicast="target" in sides)
+        for label, (config, sides) in PEERS_CONFIGS.items()
+    ),
+    *(
+        RoundTripCase(name=f"wsd_probe_roundtrip_to_target_{'peers' if 'target' in sides else 'group'}_with_{label}_peers",
+            family=4, group=WSD_GROUP_V4, port=WSD_PORT, probe_hex=WSD_PROBE_HEX,
+            reply_hex=WSD_PROBEMATCHES_HEX, config=config, evict_log="evicted WSD session",
+            responder_unicast="target" in sides)
+        for label, (config, sides) in PEERS_CONFIGS.items()
+    ),
+    RoundTripCase(name="ssdp_msearch_roundtrip_to_target_peers_ipv6_with_target_peers", family=6,
+        group=SSDP_GROUP_V6, config="config-peers-target.toml", responder_unicast=True),
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class AnswerCase:
+    # A query relayed to a peer as unicast is answered by unicast to netflector, and the answer
+    # must come out on the source segment's group. A sender on the source queries the group; a
+    # responder on the target, bound to its own address, answers whatever reaches it; a receiver
+    # on the source, joined to the group, must see the answer once.
+    name: str
+    group: str
+    port: int
+    query_hex: str
+    answer_hex: str
+    family: int = 4
+    timeout_seconds: float = 5.0
+    config: str = "config-peers-target.toml"
+
+
+ANSWER_CASES = [
+    AnswerCase(name="mdns_answer_from_target_peer_reaches_source_group_with_target_peers",
+        group=MDNS_GROUP_V4, port=MDNS_PORT, query_hex=MDNS_QUERY_HEX, answer_hex=MDNS_RESPONSE_HEX),
 ]
 
 
@@ -1173,6 +1311,7 @@ class SearchRecreateCase:
     direction: str = "forward"
     timeout_seconds: float = 8.0
     decoy: bool = False  # plant a decoy on the freed index so the recreation lands on a different one
+    responder_unicast: bool = False  # as RoundTripCase's; the responder is shared
 
 
 SEARCH_RECREATE_CASES = [
@@ -1350,10 +1489,10 @@ RECREATE_CASES = [
 
 ALL_CASES: list[
     TestCase | RoundTripCase | SearchRecreateCase | DialCase | DialAddressChangeCase
-    | AddressChangeCase | RecreateCase | DialRecreateCase
+    | AddressChangeCase | RecreateCase | DialRecreateCase | AnswerCase
 ] = [
-    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *WSD_CASES, *RELAY_CASES, *ROUNDTRIP_CASES,
-    *SEARCH_RECREATE_CASES,
+    *TEST_CASES, *MDNS_CASES, *SSDP_CASES, *WSD_CASES, *RELAY_CASES, *PEERS_CASES, *ROUNDTRIP_CASES,
+    *ANSWER_CASES, *SEARCH_RECREATE_CASES,
     *DIAL_CASES, *DIAL_ADDRESS_CHANGE_CASES, *ADDRESS_CHANGE_CASES, *RECREATE_CASES,
     *DIAL_RECREATE_CASES]
 
@@ -1444,6 +1583,10 @@ SEGMENTS = ("source", "target")
 # docker rejects a static address on an IPAM-auto subnet).
 SEGMENT_V4_SUBNET = {"source": "192.0.2", "target": "198.51.100"}
 SEGMENT_V6_PREFIX = {"source": "fd00:e2e0:1", "target": "fd00:e2e0:2"}
+# The host number of a segment's probe: what the native fabrics assign, and what docker pins when
+# a case names the probe as a peer in its config (config-peers-*.toml). Past what docker's IPAM
+# hands out on its own.
+HELPER_HOST = 20
 
 
 class Backend:
@@ -1497,8 +1640,15 @@ class Backend:
     def start_netflector(self, config_path: Path) -> None:
         raise NotImplementedError
 
+    def helper_address(self, segment: str, family: int) -> str:
+        # The probe's own address on `segment`, from the plan both fabrics follow.
+        if family == 6:
+            return f"{SEGMENT_V6_PREFIX[segment]}::{HELPER_HOST}"
+        return f"{SEGMENT_V4_SUBNET[segment]}.{HELPER_HOST}"
+
     def start_probe(
-        self, role: str, segment: str, ifname: str, probe_args: list[str], *, detach: bool = True
+        self, role: str, segment: str, ifname: str, probe_args: list[str], *,
+        detach: bool = True, pin_address: bool = False,
     ) -> None:
         # Run probe.py with `probe_args` single-homed on `segment`. detach=False blocks until
         # exit and raises on a non-zero code.
@@ -1718,20 +1868,24 @@ class DockerBackend(Backend):
             print("no bridge port reachable for hairpin; the daemon's default stands", flush=True)
 
     def start_probe(
-        self, role: str, segment: str, ifname: str, probe_args: list[str], *, detach: bool = True
+        self, role: str, segment: str, ifname: str, probe_args: list[str], *,
+        detach: bool = True, pin_address: bool = False,
     ) -> None:
         container = f"{self.prefix}-{role}"
         self.roles[role] = container
         command = ["run"]
         if detach:
             command.append("-d")
+        # Pin the helper's interface name so the probe can scope multicast egress / group
+        # joins to it deterministically (see start_netflector for the rationale).
+        network = f"name={self.networks[segment]},driver-opt=com.docker.network.endpoint.ifname={ifname}"
+        if pin_address:
+            network += f",ip={self.helper_address(segment, 4)},ip6={self.helper_address(segment, 6)}"
         command += [
             "--name",
             container,
-            # Pin the helper's interface name so the probe can scope multicast egress / group
-            # joins to it deterministically (see start_netflector for the rationale).
             "--network",
-            f"name={self.networks[segment]},driver-opt=com.docker.network.endpoint.ifname={ifname}",
+            network,
             "--mount",
             f"type=bind,source={E2E_DIR},target=/e2e,readonly",
             self.args.helper_image,
@@ -1868,7 +2022,6 @@ class DockerBackend(Backend):
 # and a segment's helper host 2, replacing Docker's IPAM discovery with a fixed plan (the kernel adds
 # fe80:: itself).
 NATIVE_NETFLECTOR_HOST = 1
-NATIVE_HELPER_HOST = 2
 
 
 class NativeBackend(Backend):
@@ -1954,9 +2107,11 @@ class NativeBackend(Backend):
         self._spawn("netflector", self._netflector_command(config_path))
 
     def start_probe(
-        self, role: str, segment: str, ifname: str, probe_args: list[str], *, detach: bool = True
+        self, role: str, segment: str, ifname: str, probe_args: list[str], *,
+        detach: bool = True, pin_address: bool = False,
     ) -> None:
         del ifname  # the far end is always probe0; the caller got that from helper_ifname()
+        del pin_address  # the fabric gives every probe the planned address
         command = [*self._probe_exec(segment), sys.executable, str(E2E_DIR / "probe.py"), *probe_args]
         self._spawn(role, command)
         if not detach:
@@ -2020,7 +2175,7 @@ class NativeBackend(Backend):
 
     def probe_ip(self, role: str, segment: str) -> str:
         del role  # one helper per segment; the plan gives them all the same host number
-        return f"{SEGMENT_V4_SUBNET[segment]}.{NATIVE_HELPER_HOST}"
+        return f"{SEGMENT_V4_SUBNET[segment]}.{HELPER_HOST}"
 
     def print_diagnostics(self) -> None:
         for logfile in sorted(self.logdir.iterdir()):
@@ -2085,8 +2240,8 @@ class NativeLinuxBackend(NativeBackend):
         dut, far = self.ns["dut"], self.ns[segment]
         self._ip(["-n", dut, "addr", "add", f"{v4}.{NATIVE_NETFLECTOR_HOST}/24", "dev", dut_ifname])
         self._ip(["-n", dut, "addr", "add", f"{v6}::{NATIVE_NETFLECTOR_HOST}/64", "dev", dut_ifname])
-        self._ip(["-n", far, "addr", "add", f"{v4}.{NATIVE_HELPER_HOST}/24", "dev", RECEIVER_IFNAME])
-        self._ip(["-n", far, "addr", "add", f"{v6}::{NATIVE_HELPER_HOST}/64", "dev", RECEIVER_IFNAME])
+        self._ip(["-n", far, "addr", "add", f"{v4}.{HELPER_HOST}/24", "dev", RECEIVER_IFNAME])
+        self._ip(["-n", far, "addr", "add", f"{v6}::{HELPER_HOST}/64", "dev", RECEIVER_IFNAME])
         self._ip(["-n", dut, "link", "set", dut_ifname, "up"])
         self._ip(["-n", far, "link", "set", RECEIVER_IFNAME, "up"])
         # The probe's 255.255.255.255 sends are routed, not interface-pinned; single-homed
@@ -2231,8 +2386,8 @@ class NativeFreeBSDBackend(NativeBackend):
         run_command([*jexec_dut, "ifconfig", dut_ifname, "inet", f"{v4}.{NATIVE_NETFLECTOR_HOST}/24"])
         run_command([*jexec_dut, "ifconfig", dut_ifname, "inet6", f"{v6}::{NATIVE_NETFLECTOR_HOST}/64"])
         run_command([*jexec_dut, "ifconfig", dut_ifname, "up"])
-        run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet", f"{v4}.{NATIVE_HELPER_HOST}/24"])
-        run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet6", f"{v6}::{NATIVE_HELPER_HOST}/64"])
+        run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet", f"{v4}.{HELPER_HOST}/24"])
+        run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "inet6", f"{v6}::{HELPER_HOST}/64"])
         run_command([*jexec_far, "ifconfig", RECEIVER_IFNAME, "up"])
         # The probe's 255.255.255.255 sends are routed, not interface-pinned; single-homed
         # plus this default route pins them to the segment.
@@ -2459,7 +2614,10 @@ class CaseRunner:
             probe_args.append("--expect-none")
 
         probe_args.extend(["--family", str(case.family)])
-        if case.group is not None:
+        if case.expect_unicast:
+            address = self.backend.helper_address(self.receiver_segment, case.family)
+            probe_args.extend(["--bind-address", address])
+        elif case.group is not None:
             probe_args.extend(["--join-group", case.group, "--interface", ifname])
         if case.expect_routable_source:
             probe_args.append("--expect-source-not-link-local")
@@ -2468,7 +2626,9 @@ class CaseRunner:
             subnet = f"{SEGMENT_V4_SUBNET[self.sender_segment]}.0/24"
             probe_args.extend(["--expect-source-net", subnet, "--expect-source-port", str(RELAY_SOURCE_PORT)])
 
-        self.backend.start_probe("receiver", self.receiver_segment, ifname, probe_args)
+        self.backend.start_probe(
+            "receiver", self.receiver_segment, ifname, probe_args, pin_address=case.expect_unicast
+        )
         self.wait_for_receiver()
 
     def wait_for_receiver(self) -> None:
@@ -2484,7 +2644,8 @@ class CaseRunner:
             raise RuntimeError(f"case {case.name} has no send payload")
 
         ifname = self.backend.helper_ifname(self.sender_ifname)
-        source_args = ["--source-port", str(RELAY_SOURCE_PORT)] if case.expect_source_preserved else []
+        source_port = RELAY_SOURCE_PORT if case.expect_source_preserved else case.send_source_port
+        source_args = ["--source-port", str(source_port)] if source_port is not None else []
         self.backend.start_probe(
             "sender",
             self.sender_segment,
@@ -2587,12 +2748,15 @@ class RoundTripRunner(CaseRunner):
 
     def start_responder(self) -> None:
         ifname = self.backend.helper_ifname(RECEIVER_IFNAME)
+        if self.rt.responder_unicast:
+            listen = ["--bind-address", self.backend.helper_address(self.responder_seg, self.rt.family)]
+        else:
+            listen = ["--join-group", self.rt.group, "--interface", ifname]
         self.backend.start_probe("responder", self.responder_seg, ifname, [
             "respond",
             "--port", str(self.rt.port), "--timeout", str(self.rt.timeout_seconds),
-            "--family", str(self.rt.family), "--join-group", self.rt.group,
-            "--interface", ifname, "--reply-hex", self.rt.reply_hex,
-        ])
+            "--family", str(self.rt.family), *listen, "--reply-hex", self.rt.reply_hex,
+        ], pin_address=self.rt.responder_unicast)
         self.wait_for_log("responder", "responder ready", "responder")
 
     def run_searcher(self) -> None:
@@ -2631,6 +2795,43 @@ class RoundTripRunner(CaseRunner):
         self.wait_for_log("netflector", self.rt.evict_log, "session eviction")
         print(f"{self.rt.name}: session evicted after expiry", flush=True)
         print(f"PASS {self.rt.name}", flush=True)
+        if self.args.show_netflector_logs:
+            time.sleep(0.5)
+            self.print_netflector_logs()
+
+
+class AnswerRunner(CaseRunner):
+    # See AnswerCase. The receiver sits on the sender's segment, unlike a TestCase's, and skips
+    # the sender's own query, which the group hands it too.
+    def __init__(self, args: argparse.Namespace, case: AnswerCase) -> None:
+        shim = TestCase(name=case.name, send_port=case.port, receive_port=case.port,
+            expect_mac=None, timeout_seconds=case.timeout_seconds, family=case.family,
+            group=case.group, send_payload_hex=case.query_hex, config=case.config)
+        super().__init__(args, shim)
+        self.answer = case
+
+    def run(self) -> None:
+        print(f"\n=== {self.answer.name} ===", flush=True)
+        self.backend.setup_segments()
+        self.start_netflector()
+        ifname = self.backend.helper_ifname(RECEIVER_IFNAME)
+        # Pinned: with peers on the source too, the answer comes to it as a unicast copy.
+        self.backend.start_probe("receiver", self.sender_segment, ifname, [
+            "receive", "--port", str(self.answer.port), "--timeout", str(self.answer.timeout_seconds),
+            "--family", str(self.answer.family), "--join-group", self.answer.group, "--interface", ifname,
+            "--expect-payload-hex", self.answer.answer_hex, "--ignore-payload-hex", self.answer.query_hex,
+        ], pin_address=True)
+        self.wait_for_receiver()
+        self.backend.start_probe("responder", self.receiver_segment, ifname, [
+            "respond", "--port", str(self.answer.port), "--timeout", str(self.answer.timeout_seconds),
+            "--family", str(self.answer.family),
+            "--bind-address", self.backend.helper_address(self.receiver_segment, self.answer.family),
+            "--reply-hex", self.answer.answer_hex,
+        ], pin_address=True)
+        self.wait_for_log("responder", "responder ready", "responder")
+        self.run_sender()
+        self.wait_for_result()
+        print(f"PASS {self.answer.name}", flush=True)
         if self.args.show_netflector_logs:
             time.sleep(0.5)
             self.print_netflector_logs()
@@ -3037,6 +3238,7 @@ class AddressChangeRunner(CaseRunner):
             timeout_seconds=timeout,
             send_mac=(CONFIGURED_MAC if is_wol else None),
             send_payload_hex=payload,
+            send_source_port=(MDNS_PORT if reverse else None),
             family=phase.family,
             direction=direction,
             group=group,
@@ -3240,7 +3442,9 @@ class RecreateRunner(AddressChangeRunner):
 
 def make_runner(args: argparse.Namespace,
         case: TestCase | RoundTripCase | SearchRecreateCase | DialCase | DialAddressChangeCase
-        | AddressChangeCase | RecreateCase | DialRecreateCase) -> CaseRunner:
+        | AddressChangeCase | RecreateCase | DialRecreateCase | AnswerCase) -> CaseRunner:
+    if isinstance(case, AnswerCase):
+        return AnswerRunner(args, case)
     if isinstance(case, SearchRecreateCase):
         return SearchRecreateRunner(args, case)
     if isinstance(case, RoundTripCase):
@@ -3265,7 +3469,7 @@ def build_netflector_image(image: str, target: str | None = None) -> None:
 
 def select_cases(case_names: list[str]) -> list[
         TestCase | RoundTripCase | SearchRecreateCase | DialCase | DialAddressChangeCase
-        | AddressChangeCase | RecreateCase | DialRecreateCase]:
+        | AddressChangeCase | RecreateCase | DialRecreateCase | AnswerCase]:
     if not case_names:
         return ALL_CASES
 

--- a/man/netflector.toml.5
+++ b/man/netflector.toml.5
@@ -62,6 +62,30 @@ Required; must differ from
 .It Ic target_if
 The interface the devices are on.
 Required.
+.It Ic source_peers , target_peers
+The hosts behind
+.Ic source_if
+or
+.Ic target_if
+when a group or broadcast datagram sent there reaches nobody, as on a
+.Xr wg 4
+tunnel.
+Such a datagram goes to each listed host as a unicast copy instead, same port
+and source, for every protocol the entry enables.
+A tunnel that carries multicast, such as
+.Xr gre 4 ,
+needs none.
+On Ethernet each copy travels in a broadcast frame, since the daemon resolves
+no MAC addresses.
+An entry with
+.Ic mdns
+may list
+.Ic target_peers
+for its queries but no peers on the side its answers go to: a client takes a
+unicast answer only to a question it asked with the unicast-response bit.
+A list of unicast addresses of the families the entry's
+.Ic address_family
+uses.
 .It Ic macs
 Optional list of MAC addresses limiting the entry to specific devices on
 .Ic target_if :
@@ -195,9 +219,9 @@ parameter overrides it.
 .It Aq Ar PARAM
 .Ic NAME ,
 or any entry field:
-.Ic SOURCE_IF , TARGET_IF , MACS , WOL , MDNS , SSDP , WSD , DIAL ,
-.Ic WOL_PORTS , ADDRESS_FAMILY , BIDIRECTIONAL , UDP_PORTS , UDP_GROUPS ,
-.Ic UDP_BROADCAST .
+.Ic SOURCE_IF , TARGET_IF , SOURCE_PEERS , TARGET_PEERS , MACS , WOL , MDNS ,
+.Ic SSDP , WSD , DIAL , WOL_PORTS , ADDRESS_FAMILY , BIDIRECTIONAL , UDP_PORTS ,
+.Ic UDP_GROUPS , UDP_BROADCAST .
 Case-insensitive.
 .El
 .Pp
@@ -305,6 +329,18 @@ endpoints:
 [reflectors.roon]
 source_if     = "lan"
 target_if     = "iot"
+udp_ports     = [9003]
+udp_groups    = ["239.255.90.90"]
+udp_broadcast = true
+bidirectional = true
+.Ed
+.Pp
+The same for phones behind a WireGuard tunnel, which has no broadcast domain:
+.Bd -literal -offset indent
+[reflectors.roon-remote]
+source_if     = "lan"
+target_if     = "wg0"
+target_peers  = ["10.10.10.2", "10.10.10.3"]
 udp_ports     = [9003]
 udp_groups    = ["239.255.90.90"]
 udp_broadcast = true

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -56,6 +56,116 @@ pub(crate) fn loopback_lock() -> std::sync::MutexGuard<'static, ()> {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
+/// A tun device attached to this process: its kernel side is a raw IP link, `far_end` the other
+/// side, where a packet written arrives on the link and one sent on the link comes out. Gone
+/// when the file closes. For the raw IP link tests.
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) struct Tun {
+    pub(crate) far_end: std::fs::File,
+    pub(crate) name: String,
+}
+
+#[cfg(all(test, target_os = "linux"))]
+impl Tun {
+    /// `None`, with a note, where the test can't run: no root, no `/dev/net/tun`, or a kernel
+    /// (user-mode QEMU) that refuses the attach.
+    pub(crate) fn create() -> Option<Self> {
+        use std::os::fd::AsRawFd;
+
+        // A `%d` template asks for a kernel-assigned name, written back by the ioctl.
+        const TEMPLATE: &[u8] = b"nftun%d";
+        // SAFETY: geteuid takes no arguments and cannot fail.
+        if unsafe { libc::geteuid() } != 0 {
+            eprintln!("skip tun test: creating a tun device requires root");
+            return None;
+        }
+        let far_end = match std::fs::File::options()
+            .read(true)
+            .write(true)
+            .open("/dev/net/tun")
+        {
+            Ok(file) => file,
+            Err(e) => {
+                eprintln!("skip tun test: /dev/net/tun: {e}");
+                return None;
+            }
+        };
+        // SAFETY: an all-zero `ifreq` is valid (a zeroed name and union).
+        let mut ifr: libc::ifreq = unsafe { core::mem::zeroed() };
+        // SAFETY: the template fits `ifr_name` with the terminator the zeroed `ifr` provides.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                TEMPLATE.as_ptr(),
+                ifr.ifr_name.as_mut_ptr().cast::<u8>(),
+                TEMPLATE.len(),
+            );
+        }
+        ifr.ifr_ifru.ifru_flags =
+            libc::c_short::try_from(libc::IFF_TUN | libc::IFF_NO_PI).expect("tun flags fit");
+        // SAFETY: TUNSETIFF reads the flags and name template, and writes the name back.
+        if unsafe { libc::ioctl(far_end.as_raw_fd(), libc::TUNSETIFF, &raw mut ifr) } < 0 {
+            eprintln!(
+                "skip tun test: TUNSETIFF: {}",
+                std::io::Error::last_os_error()
+            );
+            return None;
+        }
+        // SAFETY: the kernel wrote a NUL-terminated name into `ifr_name`.
+        let name = unsafe { std::ffi::CStr::from_ptr(ifr.ifr_name.as_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        let up = std::process::Command::new("ip")
+            .args(["link", "set", "dev", &name, "up"])
+            .status()
+            .is_ok_and(|status| status.success());
+        if !up {
+            eprintln!("skip tun test: cannot bring {name} up (no ip(8)?)");
+            return None;
+        }
+        Some(Self { far_end, name })
+    }
+
+    /// The next packet out of the far end, or `None` once `deadline` passes.
+    pub(crate) fn next_packet(
+        &self,
+        deadline: std::time::Instant,
+    ) -> std::io::Result<Option<Vec<u8>>> {
+        use std::io::Read as _;
+        use std::os::fd::AsRawFd;
+
+        let Some(left) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            return Ok(None);
+        };
+        let mut pfd = libc::pollfd {
+            fd: self.far_end.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let timeout = libc::c_int::try_from(left.as_millis()).unwrap_or(libc::c_int::MAX);
+        // SAFETY: one `pollfd`, as declared.
+        match unsafe { libc::poll(&raw mut pfd, 1, timeout) } {
+            0 => return Ok(None),
+            n if n < 0 => return Err(std::io::Error::last_os_error()),
+            _ => {}
+        }
+        // One packet per read (`IFF_NO_PI`: no header).
+        let mut buf = [0u8; crate::net::MAX_FRAME_LEN];
+        let n = (&self.far_end).read(&mut buf)?;
+        Ok(Some(buf[..n].to_vec()))
+    }
+
+    /// Whether a packet equal to `want` comes out of the far end within two seconds.
+    pub(crate) fn read_until(&self, want: &[u8]) -> std::io::Result<bool> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while let Some(packet) = self.next_packet(deadline)? {
+            if packet == want {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Read, open_or_skip};

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -125,6 +125,19 @@ impl Tun {
         Some(Self { far_end, name })
     }
 
+    /// Give the device an address, `cidr` as `ip address add` takes it. IPv6 skips duplicate
+    /// address detection, so the address is usable at once.
+    pub(crate) fn add_address(&self, cidr: &str) -> bool {
+        let mut args = vec!["address", "add", cidr, "dev", &self.name];
+        if cidr.contains(':') {
+            args.push("nodad");
+        }
+        std::process::Command::new("ip")
+            .args(args)
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
     /// The next packet out of the far end, or `None` once `deadline` passes.
     pub(crate) fn next_packet(
         &self,

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -421,8 +421,7 @@ mod tests {
             payload,
             &mut buf,
         )
-        .expect("build the IPv4 datagram")
-        .len;
+        .expect("build the IPv4 datagram");
         let v4 = buf[..v4].to_vec();
         let v6 = frame::ipv6_udp(
             SocketAddrV6::new("fd00:99::2".parse().unwrap(), 40000, 0, 0),
@@ -431,8 +430,7 @@ mod tests {
             payload,
             &mut buf,
         )
-        .expect("build the IPv6 datagram")
-        .len;
+        .expect("build the IPv6 datagram");
         [v4, buf[..v6].to_vec()]
     }
 
@@ -588,8 +586,7 @@ mod tests {
         let mac = MacAddr::broadcast();
         let mut buf = [0u8; 256];
         let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, PROBE, &mut buf)
-            .expect("build Ethernet frame")
-            .len;
+            .expect("build Ethernet frame");
 
         // The injected frame loops to the input tap and waits there until drained, so
         // one send then polling captures it.

--- a/src/capture/af_packet.rs
+++ b/src/capture/af_packet.rs
@@ -379,15 +379,12 @@ fn bind_interface(fd: &OwnedFd, mut addr: libc::sockaddr_ll) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-    use std::io::{Read as _, Write as _};
+    use std::io::Write as _;
     use std::net::{Ipv4Addr, SocketAddrV4, SocketAddrV6, UdpSocket};
     use std::time::{Duration, Instant};
 
-    use libc::c_short;
-
     use super::*;
-    use crate::capture::{loopback_lock, open_or_skip};
+    use crate::capture::{Tun, loopback_lock, open_or_skip};
     use crate::net::frame;
     use crate::net::mac::MacAddr;
 
@@ -411,91 +408,6 @@ mod tests {
                 as_tuples(&filter[DROP_OUTGOING_PROLOGUE.len()..]),
                 as_tuples(classifier)
             );
-        }
-    }
-
-    /// A tun device attached to this process: its kernel side is a raw IP link, `far_end` the
-    /// other side, where a packet written arrives on the link and one sent on the link comes
-    /// out. Gone when the file closes.
-    struct Tun {
-        far_end: File,
-        name: String,
-    }
-
-    impl Tun {
-        /// `None`, with a note, where the test can't run: no root, no `/dev/net/tun`, or a
-        /// kernel (user-mode QEMU) that refuses the attach.
-        fn create() -> Option<Self> {
-            // A `%d` template asks for a kernel-assigned name, written back by the ioctl.
-            const TEMPLATE: &[u8] = b"nftun%d";
-            // SAFETY: geteuid takes no arguments and cannot fail.
-            if unsafe { libc::geteuid() } != 0 {
-                eprintln!("skip tun test: creating a tun device requires root");
-                return None;
-            }
-            let far_end = match File::options().read(true).write(true).open("/dev/net/tun") {
-                Ok(file) => file,
-                Err(e) => {
-                    eprintln!("skip tun test: /dev/net/tun: {e}");
-                    return None;
-                }
-            };
-            // SAFETY: an all-zero `ifreq` is valid (a zeroed name and union).
-            let mut ifr: libc::ifreq = unsafe { core::mem::zeroed() };
-            // SAFETY: the template fits `ifr_name` with the terminator the zeroed `ifr` provides.
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    TEMPLATE.as_ptr(),
-                    ifr.ifr_name.as_mut_ptr().cast::<u8>(),
-                    TEMPLATE.len(),
-                );
-            }
-            ifr.ifr_ifru.ifru_flags =
-                c_short::try_from(libc::IFF_TUN | libc::IFF_NO_PI).expect("tun flags fit");
-            // SAFETY: TUNSETIFF reads the flags and name template, and writes the name back.
-            if unsafe { libc::ioctl(far_end.as_raw_fd(), libc::TUNSETIFF, &raw mut ifr) } < 0 {
-                eprintln!("skip tun test: TUNSETIFF: {}", io::Error::last_os_error());
-                return None;
-            }
-            // SAFETY: the kernel wrote a NUL-terminated name into `ifr_name`.
-            let name = unsafe { std::ffi::CStr::from_ptr(ifr.ifr_name.as_ptr()) }
-                .to_string_lossy()
-                .into_owned();
-            let up = std::process::Command::new("ip")
-                .args(["link", "set", "dev", &name, "up"])
-                .status()
-                .is_ok_and(|status| status.success());
-            if !up {
-                eprintln!("skip tun test: cannot bring {name} up (no ip(8)?)");
-                return None;
-            }
-            Some(Self { far_end, name })
-        }
-
-        /// Whether a packet equal to `want` comes out of the far end within [`WAIT_BUDGET`].
-        fn read_until(&self, want: &[u8]) -> io::Result<bool> {
-            let deadline = Instant::now() + WAIT_BUDGET;
-            let mut buf = [0u8; crate::net::MAX_FRAME_LEN];
-            while let Some(left) = deadline.checked_duration_since(Instant::now()) {
-                let mut pfd = libc::pollfd {
-                    fd: self.far_end.as_raw_fd(),
-                    events: libc::POLLIN,
-                    revents: 0,
-                };
-                let timeout = c_int::try_from(left.as_millis()).unwrap_or(c_int::MAX);
-                // SAFETY: one `pollfd`, as declared.
-                match unsafe { libc::poll(&raw mut pfd, 1, timeout) } {
-                    0 => break,
-                    n if n < 0 => return Err(io::Error::last_os_error()),
-                    _ => {}
-                }
-                // One packet per read (`IFF_NO_PI`: no header).
-                let n = (&self.far_end).read(&mut buf)?;
-                if &buf[..n] == want {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
         }
     }
 

--- a/src/capture/bpf.rs
+++ b/src/capture/bpf.rs
@@ -606,8 +606,7 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, dst_port);
         let mut frame = [0u8; 256];
         let n = crate::net::frame::dlt_null_ipv4_udp(src, dst, 64, PROBE, &mut frame)
-            .expect("build DLT_NULL IPv4 frame")
-            .len;
+            .expect("build DLT_NULL IPv4 frame");
         expect_send_delivered(&cap, &receiver, &frame[..n], PROBE);
 
         // IPv6 loopback isn't guaranteed everywhere; cover it only when ::1 is usable.
@@ -617,8 +616,7 @@ mod tests {
             let dst = SocketAddrV6::new(Ipv6Addr::LOCALHOST, dst_port, 0, 0);
             let mut frame = [0u8; 256];
             let n = crate::net::frame::dlt_null_ipv6_udp(src, dst, 64, PROBE, &mut frame)
-                .expect("build DLT_NULL IPv6 frame")
-                .len;
+                .expect("build DLT_NULL IPv6 frame");
             expect_send_delivered(&cap, &receiver, &frame[..n], PROBE);
         } else {
             eprintln!("skip loopback_send IPv6: ::1 unavailable");

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,6 +696,22 @@ mod tests {
         from_toml(text).unwrap_err()
     }
 
+    // Every TOML block in the README is a whole configuration the checks accept.
+    #[test]
+    fn the_readme_examples_are_valid_configurations() {
+        let readme = include_str!("../README.md");
+        let blocks: Vec<&str> = readme
+            .split("```toml\n")
+            .skip(1)
+            .map(|rest| rest.split("```").next().unwrap_or(""))
+            .collect();
+        assert!(blocks.len() >= 4, "the README lost its examples");
+        for block in blocks {
+            from_toml(block)
+                .unwrap_or_else(|e| panic!("README example does not load: {e}\n{block}"));
+        }
+    }
+
     #[test]
     fn minimal_reflector_uses_defaults() {
         let cfg = from_toml(

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ mod value;
 
 pub(crate) use self::error::{ConfigError, Protocol};
 pub(crate) use self::value::{
-    AddressFamily, GroupList, InterfaceName, LogLevel, PortList, ReflectorName,
+    AddressFamily, GroupList, InterfaceName, LogLevel, PeerList, PortList, ReflectorName,
 };
 
 use std::net::IpAddr;
@@ -75,7 +75,7 @@ impl Reach {
         match (self, other) {
             (Self::Any(a), Self::Any(b)) => families_overlap(a, b),
             (Self::Any(family), Self::Group(group)) | (Self::Group(group), Self::Any(family)) => {
-                family_uses(family, group)
+                family.uses(group)
             }
             (Self::Any(family), Self::Broadcast) | (Self::Broadcast, Self::Any(family)) => {
                 family.uses_ipv4()
@@ -150,6 +150,10 @@ pub(crate) struct Reflector {
     pub(crate) source_if: InterfaceName,
     /// Interface to emit on (always different from `source_if`).
     pub(crate) target_if: InterfaceName,
+    /// The hosts behind `source_if` / `target_if` when that interface has no broadcast domain:
+    /// a group or broadcast re-emitted there goes to each of them as unicast instead.
+    pub(crate) source_peers: Option<PeerList>,
+    pub(crate) target_peers: Option<PeerList>,
     /// Optional device allow-filter; `None` matches any device, `Some` a non-empty set.
     pub(crate) macs: Option<MacSet>,
     /// IP-version policy for this reflector.
@@ -175,6 +179,8 @@ impl Reflector {
         Reflector {
             source_if: self.target_if.clone(),
             target_if: self.source_if.clone(),
+            source_peers: self.target_peers.clone(),
+            target_peers: self.source_peers.clone(),
             ..self.clone()
         }
     }
@@ -196,7 +202,7 @@ impl Reflector {
         let family = self.address_family;
         let mut flows = Vec::new();
         let mut discovery = |protocol, port, groups: &[IpAddr]| {
-            for group in groups.iter().filter(|group| family_uses(family, **group)) {
+            for group in groups.iter().filter(|group| family.uses(**group)) {
                 let legs = [
                     (&self.source_if, &self.target_if),
                     (&self.target_if, &self.source_if),
@@ -308,25 +314,61 @@ impl Reflector {
     }
 }
 
-/// Whether `family` handles `ip`'s IP version.
-fn family_uses(family: AddressFamily, ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(_) => family.uses_ipv4(),
-        IpAddr::V6(_) => family.uses_ipv6(),
+/// The first listed peer of a family the entry's `address_family` does not use, if any.
+fn peer_of_unused_family(raw: &RawReflector) -> Option<IpAddr> {
+    [&raw.source_peers, &raw.target_peers]
+        .into_iter()
+        .flat_map(|peers| peers.as_deref().unwrap_or(&[]))
+        .find(|peer| !raw.address_family.uses(**peer))
+        .copied()
+}
+
+/// The peers parameter an mDNS entry's answers would go to, if any: `source_peers`, or
+/// `target_peers` once the entry is bidirectional. A client takes a unicast answer only to a
+/// question it asked with the unicast-response bit (RFC 6762 §5.4), so such peers get nothing.
+fn mdns_answers_to_peers(raw: &RawReflector) -> Option<&'static str> {
+    if !raw.mdns {
+        return None;
     }
+    if raw.source_peers.is_some() {
+        Some("source_peers")
+    } else if raw.bidirectional && raw.target_peers.is_some() {
+        Some("target_peers")
+    } else {
+        None
+    }
+}
+
+/// The peers checks: every peer of a family the entry uses, and none where an mDNS answer goes.
+fn check_peers(raw: &RawReflector, name: &ReflectorName) -> Result<(), ConfigError> {
+    if let Some(peer) = peer_of_unused_family(raw) {
+        return Err(ConfigError::PeerFamily {
+            name: name.clone(),
+            peer,
+        });
+    }
+    if let Some(param) = mdns_answers_to_peers(raw) {
+        return Err(ConfigError::MdnsAnswersToPeers {
+            name: name.clone(),
+            param,
+        });
+    }
+    Ok(())
 }
 
 impl TryFrom<(String, RawReflector)> for Reflector {
     type Error = ConfigError;
 
-    fn try_from((key, raw): (String, RawReflector)) -> Result<Self, ConfigError> {
+    fn try_from((key, mut raw): (String, RawReflector)) -> Result<Self, ConfigError> {
         // Env `NAME` override is already validated; the identity key (file table
         // key / env tag) is validated here.
-        let name = match raw.name {
+        let name = match raw.name.take() {
             Some(name) => name,
             None => ReflectorName::from_str(&key)
                 .map_err(|_| ConfigError::EmptyReflectorName { key: key.clone() })?,
         };
+        check_peers(&raw, &name)?;
+
         let source_if = raw.source_if;
         let target_if = raw.target_if;
         if source_if == target_if {
@@ -350,7 +392,7 @@ impl TryFrom<(String, RawReflector)> for Reflector {
                     .as_deref()
                     .unwrap_or(&[])
                     .iter()
-                    .find(|group| !family_uses(raw.address_family, **group));
+                    .find(|group| !raw.address_family.uses(**group));
                 if let Some(group) = foreign {
                     return Err(ConfigError::UdpGroupFamily {
                         name,
@@ -397,6 +439,8 @@ impl TryFrom<(String, RawReflector)> for Reflector {
             name,
             source_if,
             target_if,
+            source_peers: raw.source_peers,
+            target_peers: raw.target_peers,
             macs: raw.macs,
             address_family: raw.address_family,
             wol,
@@ -736,6 +780,68 @@ mod tests {
         );
         assert!(udp.broadcast);
         assert!(cfg.reflectors[0].wol.is_none());
+    }
+
+    #[test]
+    fn peers_parse_and_swap_with_the_direction() {
+        let cfg = from_toml(
+            r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "wg0"
+            udp_ports = [9003]
+            udp_groups = ["239.255.90.90"]
+            target_peers = ["10.10.10.2", "10.10.10.3"]
+            bidirectional = true
+            "#,
+        )
+        .unwrap();
+        let roon = &cfg.reflectors[0];
+        assert!(roon.source_peers.is_none());
+        assert_eq!(roon.target_peers.as_deref().map(<[IpAddr]>::len), Some(2));
+        let reversed = roon.reversed();
+        assert_eq!(reversed.source_peers, roon.target_peers);
+        assert!(reversed.target_peers.is_none());
+    }
+
+    #[test]
+    fn mdns_answers_cannot_go_to_peers() {
+        let entry = |extra: &str| {
+            format!(
+                "[reflectors.a]\nsource_if = \"lan\"\ntarget_if = \"wg0\"\nmdns = true\n{extra}"
+            )
+        };
+        assert!(matches!(
+            err(&entry("source_peers = [\"192.0.2.2\"]\n")),
+            ConfigError::MdnsAnswersToPeers {
+                param: "source_peers",
+                ..
+            }
+        ));
+        assert!(matches!(
+            err(&entry(
+                "target_peers = [\"10.10.10.2\"]\nbidirectional = true\n"
+            )),
+            ConfigError::MdnsAnswersToPeers {
+                param: "target_peers",
+                ..
+            }
+        ));
+        // Queries may go to peers: a device answers a direct unicast query.
+        assert!(from_toml(&entry("target_peers = [\"10.10.10.2\"]\n")).is_ok());
+    }
+
+    #[test]
+    fn peer_must_be_of_a_used_family() {
+        let text = r#"
+            [reflectors.roon]
+            source_if = "lan"
+            target_if = "wg0"
+            address_family = "ipv4"
+            mdns = true
+            target_peers = ["fd00::2"]
+        "#;
+        assert!(matches!(err(text), ConfigError::PeerFamily { .. }));
     }
 
     #[test]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -9,7 +9,9 @@ use std::str::FromStr;
 
 use super::error::{ConfigError, ParseBoolError, ParseValueError, RequiredField};
 use super::raw::{RawConfig, RawReflector};
-use super::value::{AddressFamily, GroupList, InterfaceName, LogLevel, PortList, ReflectorName};
+use super::value::{
+    AddressFamily, GroupList, InterfaceName, LogLevel, PeerList, PortList, ReflectorName,
+};
 use crate::net::mac::MacSet;
 
 /// Accumulates a reflector's fields across its `NETFLECTOR_<tag>_<param>` variables,
@@ -19,6 +21,8 @@ struct PartialReflector {
     name: Option<ReflectorName>,
     source_if: Option<InterfaceName>,
     target_if: Option<InterfaceName>,
+    source_peers: Option<PeerList>,
+    target_peers: Option<PeerList>,
     macs: Option<MacSet>,
     wol: Option<bool>,
     mdns: Option<bool>,
@@ -57,6 +61,8 @@ impl PartialReflector {
             "name" => put(&mut self.name, env_value(value, var)?, param, var),
             "source_if" => put(&mut self.source_if, env_value(value, var)?, param, var),
             "target_if" => put(&mut self.target_if, env_value(value, var)?, param, var),
+            "source_peers" => put(&mut self.source_peers, env_value(value, var)?, param, var),
+            "target_peers" => put(&mut self.target_peers, env_value(value, var)?, param, var),
             "macs" => put(&mut self.macs, env_value(value, var)?, param, var),
             "wol_ports" => put(&mut self.wol_ports, env_value(value, var)?, param, var),
             "address_family" => put(&mut self.address_family, env_value(value, var)?, param, var),
@@ -88,6 +94,8 @@ impl PartialReflector {
                 name: name.to_owned(),
                 field: RequiredField::TargetIf,
             })?,
+            source_peers: self.source_peers,
+            target_peers: self.target_peers,
             macs: self.macs,
             wol: self.wol.unwrap_or(false),
             mdns: self.mdns.unwrap_or(false),
@@ -285,6 +293,20 @@ mod tests {
         let r = &cfg.reflectors[0];
         assert!(r.wol.is_some());
         assert!(!r.mdns);
+    }
+
+    #[test]
+    fn env_peer_lists() {
+        let cfg = from_env(&[
+            ("NETFLECTOR_ROON_SOURCE_IF", "lan"),
+            ("NETFLECTOR_ROON_TARGET_IF", "wg0"),
+            ("NETFLECTOR_ROON_MDNS", "true"),
+            ("NETFLECTOR_ROON_TARGET_PEERS", "10.10.10.2, 10.10.10.3"),
+        ])
+        .unwrap();
+        let peers = cfg.reflectors[0].target_peers.as_deref().unwrap();
+        assert_eq!(peers.len(), 2);
+        assert!(cfg.reflectors[0].source_peers.is_none());
     }
 
     #[test]

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use super::value::{
     GroupListError, InterfaceName, ParseAddressFamilyError, ParseInterfaceNameError,
-    ParseLogLevelError, ParseReflectorNameError, PortListError, ReflectorName,
+    ParseLogLevelError, ParseReflectorNameError, PeerListError, PortListError, ReflectorName,
 };
 use crate::net::mac::MacSetError;
 
@@ -59,6 +59,9 @@ pub(crate) enum ConfigError {
     )]
     UdpGroupFamily { name: ReflectorName, group: IpAddr },
 
+    #[error("reflector \"{name}\" lists peer {peer}, whose family its address_family does not use")]
+    PeerFamily { name: ReflectorName, peer: IpAddr },
+
     #[error("reflector \"{name}\" sets udp_broadcast but its address_family has no IPv4")]
     UdpBroadcastFamily { name: ReflectorName },
 
@@ -81,6 +84,15 @@ pub(crate) enum ConfigError {
 
     #[error("reflector \"{name}\" sets dial but does not enable ssdp")]
     DialWithoutSsdp { name: ReflectorName },
+
+    #[error(
+        "reflector \"{name}\" enables mdns with {param}, but a client takes a unicast mDNS answer \
+         only to a question it asked with the unicast-response bit"
+    )]
+    MdnsAnswersToPeers {
+        name: ReflectorName,
+        param: &'static str,
+    },
 
     #[error(
         "reflector \"{name}\" enables dial but the address family has no IPv4 (DIAL is IPv4-only)"
@@ -211,6 +223,8 @@ pub(crate) enum ParseValueError {
     /// `UDP_GROUPS`.
     #[error(transparent)]
     GroupList(#[from] GroupListError),
+    #[error(transparent)]
+    PeerList(#[from] PeerListError),
     /// `NAME`.
     #[error(transparent)]
     ReflectorName(#[from] ParseReflectorNameError),

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -9,7 +9,9 @@ use std::collections::BTreeMap;
 use serde::Deserialize;
 
 use super::error::ConfigError;
-use super::value::{AddressFamily, GroupList, InterfaceName, LogLevel, PortList, ReflectorName};
+use super::value::{
+    AddressFamily, GroupList, InterfaceName, LogLevel, PeerList, PortList, ReflectorName,
+};
 use crate::net::mac::MacSet;
 
 #[derive(Debug, Default, Deserialize)]
@@ -37,6 +39,8 @@ pub(super) struct RawReflector {
     pub(super) name: Option<ReflectorName>,
     pub(super) source_if: InterfaceName,
     pub(super) target_if: InterfaceName,
+    pub(super) source_peers: Option<PeerList>,
+    pub(super) target_peers: Option<PeerList>,
     pub(super) macs: Option<MacSet>,
     #[serde(default)]
     pub(super) address_family: AddressFamily,

--- a/src/config/value.rs
+++ b/src/config/value.rs
@@ -76,6 +76,14 @@ impl AddressFamily {
         matches!(self, Self::Default | Self::Dual | Self::Ipv6)
     }
 
+    /// Whether the policy handles `ip`'s IP version.
+    pub(crate) fn uses(self, ip: IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(_) => self.uses_ipv4(),
+            IpAddr::V6(_) => self.uses_ipv6(),
+        }
+    }
+
     /// A v4 source must be present at startup, else the reflector fails to build. Same set as
     /// `uses_ipv4`, but distinct in meaning: `Default` requires v4 while treating v6 as
     /// best-effort.
@@ -328,9 +336,113 @@ impl<'de> Deserialize<'de> for GroupList {
     }
 }
 
+/// A non-empty, duplicate-free list of unicast addresses, of either family: the hosts behind an
+/// interface that has no broadcast domain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PeerList(Vec<IpAddr>);
+
+impl Deref for PeerList {
+    type Target = [IpAddr];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum PeerListError {
+    #[error("peer list must not be empty")]
+    Empty,
+    #[error("duplicate peer {0}")]
+    Duplicate(IpAddr),
+    #[error("{0} is not a unicast address")]
+    NotUnicast(IpAddr),
+    /// A comma-separated token was not an IP address.
+    #[error("invalid peer \"{0}\"")]
+    BadAddress(String),
+}
+
+impl TryFrom<Vec<IpAddr>> for PeerList {
+    type Error = PeerListError;
+
+    fn try_from(peers: Vec<IpAddr>) -> Result<Self, Self::Error> {
+        if peers.is_empty() {
+            return Err(PeerListError::Empty);
+        }
+        for (i, peer) in peers.iter().enumerate() {
+            let unicast = match peer {
+                IpAddr::V4(v4) => !v4.is_multicast() && !v4.is_broadcast() && !v4.is_unspecified(),
+                IpAddr::V6(v6) => !v6.is_multicast() && !v6.is_unspecified(),
+            };
+            if !unicast {
+                return Err(PeerListError::NotUnicast(*peer));
+            }
+            if peers[..i].contains(peer) {
+                return Err(PeerListError::Duplicate(*peer));
+            }
+        }
+        Ok(Self(peers))
+    }
+}
+
+impl FromStr for PeerList {
+    type Err = PeerListError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let peers = s
+            .split(',')
+            .map(|token| {
+                let token = token.trim();
+                token
+                    .parse::<IpAddr>()
+                    .map_err(|_| PeerListError::BadAddress(token.to_owned()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        PeerList::try_from(peers)
+    }
+}
+
+impl<'de> Deserialize<'de> for PeerList {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Vec::<IpAddr>::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn peer_list_takes_unicast_addresses_only() {
+        let peers: PeerList = "10.10.10.2, fd00::2".parse().unwrap();
+        assert_eq!(peers.len(), 2);
+        for bad in [
+            "239.255.90.90",
+            "255.255.255.255",
+            "0.0.0.0",
+            "ff02::1",
+            "::",
+        ] {
+            assert!(matches!(
+                bad.parse::<PeerList>(),
+                Err(PeerListError::NotUnicast(_))
+            ));
+        }
+        assert!(matches!(
+            "10.10.10.2,10.10.10.2".parse::<PeerList>(),
+            Err(PeerListError::Duplicate(_))
+        ));
+        assert!(matches!(
+            "".parse::<PeerList>(),
+            Err(PeerListError::BadAddress(_))
+        ));
+        assert!(matches!(
+            PeerList::try_from(Vec::new()),
+            Err(PeerListError::Empty)
+        ));
+    }
 
     #[test]
     fn address_family_uses_and_requires() {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -32,12 +32,13 @@ pub(crate) use self::dial_context::{DialContext, DialProxyKey};
 pub(crate) use self::multicast::{join_capped, join_deferrable};
 
 use std::io;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, SocketAddr};
 use std::ops::Deref;
 use std::os::fd::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
 use crate::capture::{Capture, Read};
+use crate::config::AddressFamily;
 use crate::interface::{InterfaceAddresses, InterfaceEvent, InterfaceMonitor};
 use crate::linear_map::LinearMap;
 use crate::logging::{WARN_WINDOW, log_rate};
@@ -155,18 +156,26 @@ pub(crate) struct Filter {
     pub(crate) dst_mac: Option<MacAddr>,
     /// Require an IPv4 broadcast destination, see [`Packet::is_broadcast`].
     pub(crate) broadcast: bool,
+    /// Widen `dst_ip` to the ingress interface's own addresses of these families: an answer sent
+    /// to this host.
+    pub(crate) dst_own: Option<AddressFamily>,
 }
 
 impl Filter {
-    /// Whether `p` satisfies every set field (an unset field matches anything), given the ingress's
-    /// directed broadcast for the `broadcast` field on a link without MACs.
-    fn matches(&self, p: &Packet, ingress_directed_broadcast: Option<Ipv4Addr>) -> bool {
-        (!self.broadcast || p.is_broadcast(ingress_directed_broadcast))
+    /// Whether `p` satisfies every set field (an unset field matches anything), given the
+    /// ingress's addresses: its directed broadcast for the `broadcast` field on a link without
+    /// MACs, its own addresses for `dst_own`.
+    fn matches(&self, p: &Packet, ingress: Option<&InterfaceAddresses>) -> bool {
+        (!self.broadcast
+            || p.is_broadcast(ingress.and_then(InterfaceAddresses::v4_directed_broadcast)))
             && self.src_ip.is_none_or(|ip| p.source.ip() == ip)
-            && self
-                .dst_ip
-                .as_ref()
-                .is_none_or(|set| set.contains(&p.dest.ip()))
+            && self.dst_ip.as_ref().is_none_or(|set| {
+                set.contains(&p.dest.ip())
+                    || self.dst_own.is_some_and(|family| {
+                        family.uses(p.dest.ip())
+                            && ingress.is_some_and(|addrs| addrs.has(p.dest.ip()))
+                    })
+            })
             && self.src_port.is_none_or(|port| p.source.port() == port)
             && self
                 .dst_port
@@ -739,17 +748,14 @@ impl PacketDispatcher {
                 .iter()
                 .map(|(key, _)| RegistrationKey(key)),
         );
-        let ingress_directed_broadcast = self
-            .table
-            .egress_addrs(ingress)
-            .and_then(InterfaceAddresses::v4_directed_broadcast);
+        let ingress_addrs = self.table.egress_addrs(ingress).copied();
         self.packet += 1;
         self.routing = true;
         let mut final_outcome: Option<Outcome> = None;
         for i in 0..self.route_keys.len() {
             let key = self.route_keys[i];
             let applies = self.registrations.get(key.0).is_some_and(|reg| {
-                reg.ingress == ingress && reg.filter.matches(packet, ingress_directed_broadcast)
+                reg.ingress == ingress && reg.filter.matches(packet, ingress_addrs.as_ref())
             });
             if !applies {
                 continue;
@@ -1378,6 +1384,70 @@ mod tests {
     }
 
     #[test]
+    fn filter_dst_own_widens_dst_ip_to_the_ingress_addresses() {
+        let group: IpAddr = "224.0.0.251".parse().unwrap();
+        let ingress = InterfaceAddresses::new(
+            None,
+            Some(Ipv4Addr::new(10, 0, 0, 1)),
+            Some("fe80::1".parse().unwrap()),
+            Some("fd00::1".parse().unwrap()),
+        );
+        let widened = Filter {
+            dst_ip: Some(group.into()),
+            dst_own: Some(AddressFamily::Dual),
+            ..Filter::default()
+        };
+        assert!(widened.matches(
+            &packet("10.0.0.2:1", "224.0.0.251:9", None, None),
+            Some(&ingress)
+        ));
+        // Every address the ingress owns, in either family.
+        for own in ["10.0.0.1:9", "[fe80::1]:9", "[fd00::1]:9"] {
+            assert!(widened.matches(&packet("10.0.0.2:1", own, None, None), Some(&ingress)));
+        }
+        // Only the families the widening names: an answer of the other family is not taken.
+        let v4_only = Filter {
+            dst_own: Some(AddressFamily::Ipv4),
+            ..widened.clone()
+        };
+        assert!(v4_only.matches(
+            &packet("10.0.0.2:1", "10.0.0.1:9", None, None),
+            Some(&ingress)
+        ));
+        assert!(!v4_only.matches(
+            &packet("[fe80::2]:1", "[fe80::1]:9", None, None),
+            Some(&ingress)
+        ));
+        let v6_only = Filter {
+            dst_own: Some(AddressFamily::Ipv6),
+            ..widened.clone()
+        };
+        assert!(v6_only.matches(
+            &packet("[fe80::2]:1", "[fd00::1]:9", None, None),
+            Some(&ingress)
+        ));
+        assert!(!v6_only.matches(
+            &packet("10.0.0.2:1", "10.0.0.1:9", None, None),
+            Some(&ingress)
+        ));
+        // Another host's address, and an ingress with no known addresses, both miss.
+        assert!(!widened.matches(
+            &packet("10.0.0.2:1", "10.0.0.3:9", None, None),
+            Some(&ingress)
+        ));
+        assert!(!widened.matches(&packet("10.0.0.2:1", "10.0.0.1:9", None, None), None));
+        // Without the widening the group alone matches.
+        let group_only = Filter {
+            dst_ip: Some(group.into()),
+            ..Filter::default()
+        };
+        assert!(!group_only.matches(
+            &packet("10.0.0.2:1", "10.0.0.1:9", None, None),
+            Some(&ingress)
+        ));
+    }
+
+    #[test]
     fn filter_broadcast_takes_the_all_ones_mac_or_the_limited_broadcast() {
         let f = Filter {
             broadcast: true,
@@ -1385,7 +1455,10 @@ mod tests {
         };
         let all_ones = Some(MacAddr::broadcast());
         let unicast = Some(MacAddr::from([0x02, 0, 0, 0, 0, 1]));
-        let own = Some(Ipv4Addr::new(10, 0, 0, 255));
+        // The ingress owns 10.0.0.1/24, so its directed broadcast is 10.0.0.255.
+        let ingress = InterfaceAddresses::new(None, Some(Ipv4Addr::new(10, 0, 0, 1)), None, None)
+            .with_v4_prefix(24);
+        let own = Some(&ingress);
         // On the all-ones MAC every subnet's directed broadcast qualifies, the limited one too.
         assert!(f.matches(&packet("10.0.0.1:1", "10.0.0.255:9", all_ones, None), own));
         assert!(f.matches(&packet("10.0.1.1:1", "10.0.1.255:9", all_ones, None), own));
@@ -1762,6 +1835,86 @@ mod tests {
             .map(|(_, dest, _)| dest.ip())
             .collect();
         assert_eq!(delivered, peers);
+        Ok(())
+    }
+
+    // A query relayed to a peer as unicast is answered by unicast to this host; the mDNS response
+    // leg takes that answer off the tunnel and puts it on the source segment's group.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_unicast_mdns_answer_from_a_peer_goes_to_the_group() -> io::Result<()> {
+        use std::io::Write as _;
+
+        use crate::net::frame;
+        use crate::net::mdns::{MDNS_GROUP_V4, MDNS_PORT};
+        use crate::reflector::{InterfaceMap, mdns};
+
+        let _serial = loopback_lock();
+        let Some(mut tun) = crate::capture::Tun::create() else {
+            return Ok(());
+        };
+        assert!(tun.add_address("10.99.200.1/24"));
+        let mut dispatcher = PacketDispatcher::without_group_joins();
+        let source = dispatcher.add_capture(Capture::open(LOOPBACK_IFACE)?)?;
+        let target = dispatcher.add_capture(Capture::open(&tun.name)?)?;
+        let mut interfaces = InterfaceMap::default();
+        interfaces.insert(LOOPBACK_IFACE.to_owned(), source);
+        interfaces.insert(tun.name.clone(), target);
+        let entry = crate::config::Config::from_sources(
+            Some(&format!(
+                "[reflectors.a]\nsource_if = \"{LOOPBACK_IFACE}\"\ntarget_if = \"{}\"\n\
+                 mdns = true\naddress_family = \"ipv4\"\ntarget_peers = [\"10.99.200.2\"]\n",
+                tun.name
+            )),
+            std::iter::empty(),
+        )
+        .expect("a valid configuration")
+        .reflectors
+        .remove(0);
+        mdns::build(&entry, &interfaces, &mut dispatcher).expect("build the mDNS reflector");
+        let mut observer = Capture::open(LOOPBACK_IFACE)?;
+
+        // A DNS header with QR set: a response with no records.
+        let answer = [0, 0, 0x84, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let mut packet = [0u8; 64];
+        let n = frame::ipv4_udp(
+            SocketAddrV4::new(Ipv4Addr::new(10, 99, 200, 2), MDNS_PORT),
+            SocketAddrV4::new(Ipv4Addr::new(10, 99, 200, 1), MDNS_PORT),
+            255,
+            &answer,
+            &mut packet,
+        )
+        .expect("build the answer");
+        tun.far_end.write_all(&packet[..n])?;
+
+        let mut reactor = Reactor::new()?;
+        let mut relayed = None;
+        pump_until(
+            2,
+            || {
+                while relayed.is_none()
+                    && let Some(read) = observer.next_frame().unwrap()
+                {
+                    if let Read::Frame(frame) = read
+                        && let Ok(parsed) = Packet::parse(LinkType::Ethernet, frame)
+                        && parsed.payload == answer
+                    {
+                        relayed = Some((parsed.source, parsed.dest));
+                    }
+                }
+                relayed.is_some()
+            },
+            || dispatcher.drain_and_route(target, &mut reactor),
+        );
+        assert_eq!(
+            relayed,
+            Some((
+                SocketAddr::from((Ipv4Addr::LOCALHOST, MDNS_PORT)),
+                SocketAddr::from((MDNS_GROUP_V4, MDNS_PORT)),
+            )),
+            "the answer was not relayed to the group on the source side"
+        );
         Ok(())
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -47,7 +47,7 @@ use crate::reactor::{Arena, ControlEvent, Handler, Key, Reactor, ReadyEvent};
 
 use self::counters::log_counters;
 use self::datagram::{build_udp, ethernet_dst};
-use self::interface_table::{InterfaceTable, SentFrame};
+use self::interface_table::InterfaceTable;
 
 /// The most frames drained per readable event before yielding, so a flooded interface
 /// can't starve the others. `AF_PACKET` stops here and the level-triggered wait
@@ -473,51 +473,17 @@ impl PacketDispatcher {
         ttl: u8,
         payload: &[u8],
     ) -> io::Result<()> {
-        // Copy the addresses out (they're `Copy`) so the borrow of the table ends before the
-        // mutable borrow of `self.scratch`.
-        let (Some(addrs), Some(link)) =
-            (self.egress_addrs(egress).copied(), self.link_type(egress))
-        else {
-            log::warn!("egress {egress:?} unavailable (drained or unknown); datagram dropped");
-            return Ok(());
-        };
-        let built = build_udp(
-            &addrs,
-            link,
-            dst,
-            dst_mac,
-            source,
-            ttl,
-            payload,
-            &mut self.scratch,
-        )
-        .map_err(io::Error::other)?;
-        // Two entries whose legs coincide (per-device entries on one pair, whose query legs
-        // carry no MAC filter) both relay a packet; the second's frame equals the first's. Noted
-        // only once sent, so a failed send leaves the second to try.
-        let frame = self.routing.then_some(SentFrame {
-            packet: self.packet,
-            len: built.len,
-            checksum: built.udp_checksum,
-        });
-        if let Some(frame) = frame
-            && self.table.is_last_sent(egress, frame)
-        {
-            log::trace!("egress {egress:?}: an equal frame already went out for this packet");
-            return Ok(());
-        }
-        self.send(egress, &self.scratch[..built.len])?;
-        if let Some(frame) = frame {
-            self.table.set_last_sent(egress, frame);
+        if let Some(len) = self.build_frame(egress, dst, dst_mac, source, ttl, payload)? {
+            self.send_built(egress, len)?;
         }
         Ok(())
     }
 
     /// Inject a broadcast/multicast UDP datagram on `egress`, deriving the L2 destination MAC from
     /// `dst`'s address class (all-ones for the IPv4 limited broadcast, the RFC-derived group MAC
-    /// for multicast). A thin wrapper over [`send_udp`](Self::send_udp). A unicast `dst` has no
-    /// derivable group MAC, so it is a [`DatagramError::UnicastDestination`](datagram::DatagramError::UnicastDestination); use `send_udp` with an
-    /// explicit MAC for unicast.
+    /// for multicast). A unicast `dst` has no derivable group MAC, so it is a
+    /// [`DatagramError::UnicastDestination`](datagram::DatagramError::UnicastDestination); use
+    /// [`send_udp`](Self::send_udp) with an explicit MAC for unicast.
     ///
     /// # Errors
     /// As [`send_udp`](Self::send_udp), plus [`DatagramError::UnicastDestination`](datagram::DatagramError::UnicastDestination) for a unicast `dst`.
@@ -531,6 +497,61 @@ impl PacketDispatcher {
     ) -> io::Result<()> {
         let dst_mac = self.group_mac(egress, dst)?;
         self.send_udp(egress, dst, dst_mac, source, ttl, payload)
+    }
+
+    /// Assemble the datagram for `egress` into the scratch buffer. `None` (logged) when the
+    /// egress is unknown or taken out for its drain.
+    fn build_frame(
+        &mut self,
+        egress: CaptureKey,
+        dst: SocketAddr,
+        dst_mac: MacAddr,
+        source: DatagramSource,
+        ttl: u8,
+        payload: &[u8],
+    ) -> io::Result<Option<usize>> {
+        // Copy the addresses out (they're `Copy`) so the borrow of the table ends before the
+        // mutable borrow of `self.scratch`.
+        let (Some(addrs), Some(link)) =
+            (self.egress_addrs(egress).copied(), self.link_type(egress))
+        else {
+            log::warn!("egress {egress:?} unavailable (drained or unknown); datagram dropped");
+            return Ok(None);
+        };
+        build_udp(
+            &addrs,
+            link,
+            dst,
+            dst_mac,
+            source,
+            ttl,
+            payload,
+            &mut self.scratch,
+        )
+        .map(Some)
+        .map_err(io::Error::other)
+    }
+
+    /// Send the frame in the scratch buffer on `egress`, unless an equal one already went out
+    /// there for the packet being routed: two entries whose legs coincide (per-device entries
+    /// on one pair, whose query legs carry no MAC filter) both relay a packet, and the second's
+    /// frame equals the first's. Noted only once sent, so a failed send leaves the second to
+    /// try. Returns whether the frame went out.
+    fn send_built(&mut self, egress: CaptureKey, len: usize) -> io::Result<bool> {
+        if self.routing
+            && self
+                .table
+                .was_sent(egress, self.packet, &self.scratch[..len])
+        {
+            log::trace!("egress {egress:?}: an equal frame already went out for this packet");
+            return Ok(false);
+        }
+        self.send(egress, &self.scratch[..len])?;
+        if self.routing {
+            self.table
+                .record_sent(egress, self.packet, &self.scratch[..len]);
+        }
+        Ok(true)
     }
 
     /// The L2 destination for a broadcast/multicast `dst` on `egress`: its own directed broadcast

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -40,6 +40,7 @@ use std::time::{Duration, Instant};
 use crate::capture::{Capture, Read};
 use crate::interface::{InterfaceAddresses, InterfaceEvent, InterfaceMonitor};
 use crate::linear_map::LinearMap;
+use crate::logging::{WARN_WINDOW, log_rate};
 use crate::net::LinkType;
 use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
@@ -497,6 +498,60 @@ impl PacketDispatcher {
     ) -> io::Result<()> {
         let dst_mac = self.group_mac(egress, dst)?;
         self.send_udp(egress, dst, dst_mac, source, ttl, payload)
+    }
+
+    /// Deliver a group or broadcast datagram to `peers` instead: one unicast copy per peer of
+    /// `dst`'s family, at `dst`'s port. Each copy is checked against the packet's earlier sends on
+    /// its own, so two entries whose lists share a peer deliver to it once.
+    ///
+    /// # Errors
+    /// As [`send_udp`](Self::send_udp) when no copy went out at all. A peer the link cannot reach
+    /// (a `WireGuard` peer without an endpoint) costs only its own copy, logged.
+    pub(crate) fn send_udp_to_peers(
+        &mut self,
+        egress: CaptureKey,
+        peers: &[IpAddr],
+        dst: SocketAddr,
+        source: DatagramSource,
+        ttl: u8,
+        payload: &[u8],
+    ) -> io::Result<()> {
+        let mut delivered = false;
+        let mut failure = None;
+        for &peer in peers.iter().filter(|peer| peer.is_ipv4() == dst.is_ipv4()) {
+            // Nothing here resolves neighbours: on a link with MACs the copy travels in a
+            // broadcast frame, and only the addressed host keeps it.
+            let to = SocketAddr::new(peer, dst.port());
+            let Some(len) =
+                self.build_frame(egress, to, MacAddr::broadcast(), source, ttl, payload)?
+            else {
+                return Ok(());
+            };
+            match self.send_built(egress, len) {
+                Ok(_) => delivered = true,
+                Err(e) => {
+                    log_rate!(
+                        log::Level::Warn,
+                        WARN_WINDOW,
+                        "{}: cannot send to peer {peer}: {e}",
+                        self.egress_name(egress)
+                    );
+                    failure = Some(e);
+                }
+            }
+        }
+        match failure {
+            Some(e) if !delivered => Err(e),
+            _ => Ok(()),
+        }
+    }
+
+    /// The name of the interface behind `egress`, for a message; `?` for an unknown key.
+    fn egress_name(&self, egress: CaptureKey) -> &str {
+        self.table
+            .interface_of(egress)
+            .and_then(|interface| self.table.interface_name(interface))
+            .unwrap_or("?")
     }
 
     /// Assemble the datagram for `egress` into the scratch buffer. `None` (logged) when the
@@ -1580,6 +1635,246 @@ mod tests {
         assert!(!records.is_empty(), "the reflector never fired");
         assert_eq!(records[0].0, PROBE, "reflector saw the wrong payload");
         assert!(records[0].1, "the keyed egress send failed");
+        Ok(())
+    }
+
+    /// Every `sood` datagram out of the tun's far end within a second: source, destination, TTL.
+    #[cfg(target_os = "linux")]
+    fn sood_deliveries(tun: &crate::capture::Tun) -> io::Result<Vec<(SocketAddr, SocketAddr, u8)>> {
+        let mut delivered = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while let Some(packet) = tun.next_packet(deadline)? {
+            if let Ok(parsed) = Packet::parse(LinkType::RawIp, &packet)
+                && parsed.payload == b"sood"
+            {
+                delivered.push((parsed.source, parsed.dest, parsed.ttl));
+            }
+        }
+        Ok(delivered)
+    }
+
+    // Peers behind a raw IP link: a group send fans out to one unicast copy per peer of the
+    // group's family, at the group's port, and a second relay of the same packet adds nothing.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn group_sends_fan_out_to_the_peers_of_a_raw_ip_link() -> io::Result<()> {
+        let Some(tun) = crate::capture::Tun::create() else {
+            return Ok(());
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let egress = dispatcher.add_capture(Capture::open(&tun.name)?)?;
+        let peers: [IpAddr; 3] = [
+            "10.99.200.2".parse().unwrap(),
+            "10.99.200.3".parse().unwrap(),
+            "fd00:99::2".parse().unwrap(),
+        ];
+
+        let group: SocketAddr = "239.255.90.90:9003".parse().unwrap();
+        let source: SocketAddr = "192.0.2.7:40001".parse().unwrap();
+        // Two handlers relaying one routed packet: the second fan-out duplicates the first.
+        dispatcher.packet = 1;
+        dispatcher.routing = true;
+        for _ in 0..2 {
+            dispatcher.send_udp_to_peers(
+                egress,
+                &peers,
+                group,
+                DatagramSource::Exact(source),
+                32,
+                b"sood",
+            )?;
+        }
+
+        let to = |peer: &str| -> SocketAddr { format!("{peer}:9003").parse().unwrap() };
+        assert_eq!(
+            sood_deliveries(&tun)?,
+            [
+                (source, to("10.99.200.2"), 32),
+                (source, to("10.99.200.3"), 32)
+            ]
+        );
+        Ok(())
+    }
+
+    // Two entries whose peer lists overlap relay one packet: each peer gets it once, whatever
+    // the lists' order or other members.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn overlapping_peer_lists_deliver_to_each_peer_once() -> io::Result<()> {
+        let Some(tun) = crate::capture::Tun::create() else {
+            return Ok(());
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let egress = dispatcher.add_capture(Capture::open(&tun.name)?)?;
+        let peer = |host: u8| IpAddr::V4(Ipv4Addr::new(10, 99, 200, host));
+        let (x, y, z) = (peer(2), peer(3), peer(4));
+        let group: SocketAddr = "239.255.90.90:9003".parse().unwrap();
+        let source: SocketAddr = "192.0.2.7:40001".parse().unwrap();
+        dispatcher.packet = 1;
+        dispatcher.routing = true;
+        for list in [[x, y], [y, z]] {
+            dispatcher.send_udp_to_peers(
+                egress,
+                &list,
+                group,
+                DatagramSource::Exact(source),
+                32,
+                b"sood",
+            )?;
+        }
+
+        let delivered: Vec<IpAddr> = sood_deliveries(&tun)?
+            .into_iter()
+            .map(|(_, dest, _)| dest.ip())
+            .collect();
+        assert_eq!(delivered, [x, y, z]);
+        Ok(())
+    }
+
+    // 10.0.1.2 and 10.1.1.1 sum to the same checksum words, so their frames differ only in the
+    // destination; each peer must still get its copy.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn peers_whose_frames_share_a_checksum_each_get_a_copy() -> io::Result<()> {
+        let Some(tun) = crate::capture::Tun::create() else {
+            return Ok(());
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let egress = dispatcher.add_capture(Capture::open(&tun.name)?)?;
+        let peers: [IpAddr; 2] = ["10.0.1.2".parse().unwrap(), "10.1.1.1".parse().unwrap()];
+        let group: SocketAddr = "239.255.90.90:9003".parse().unwrap();
+        let source: SocketAddr = "192.0.2.7:40001".parse().unwrap();
+        dispatcher.packet = 1;
+        dispatcher.routing = true;
+        dispatcher.send_udp_to_peers(
+            egress,
+            &peers,
+            group,
+            DatagramSource::Exact(source),
+            32,
+            b"sood",
+        )?;
+        let delivered: Vec<IpAddr> = sood_deliveries(&tun)?
+            .into_iter()
+            .map(|(_, dest, _)| dest.ip())
+            .collect();
+        assert_eq!(delivered, peers);
+        Ok(())
+    }
+
+    /// A `WireGuard` interface with two peers, one with an endpoint and one without. FreeBSD
+    /// only: `wg` ships in base there, and the interface is created as root.
+    #[cfg(target_os = "freebsd")]
+    struct WgPeers {
+        name: String,
+        reachable: IpAddr,
+        unreachable: IpAddr,
+    }
+
+    #[cfg(target_os = "freebsd")]
+    impl WgPeers {
+        /// The endpoint the reachable peer's handshake goes to.
+        const ENDPOINT: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 51820);
+
+        /// `None`, with a note, where the test can't run: not root, or the static build, whose
+        /// process spawning crashes (see the pair tests).
+        fn create() -> Option<Self> {
+            if cfg!(target_feature = "crt-static") {
+                eprintln!("skip wg test: process spawning crashes static FreeBSD binaries");
+                return None;
+            }
+            // SAFETY: geteuid takes no arguments and cannot fail.
+            if unsafe { libc::geteuid() } != 0 {
+                eprintln!("skip wg test: interface creation requires root");
+                return None;
+            }
+            let name = sh_output("ifconfig wg create")?;
+            let this = Self {
+                name,
+                reachable: IpAddr::V4(Ipv4Addr::new(10, 99, 77, 2)),
+                unreachable: IpAddr::V4(Ipv4Addr::new(10, 99, 77, 3)),
+            };
+            let key = std::env::temp_dir().join(format!("netflector-{}.key", this.name));
+            let configured = sh(&format!(
+                "umask 077 && wg genkey > {key} && wg set {name} private-key {key} listen-port 0 \
+                 peer $(wg genkey | wg pubkey) allowed-ips {reachable}/32 endpoint {endpoint} \
+                 peer $(wg genkey | wg pubkey) allowed-ips {unreachable}/32 \
+                 && ifconfig {name} inet 10.99.77.1/24 up",
+                key = key.display(),
+                name = this.name,
+                reachable = this.reachable,
+                unreachable = this.unreachable,
+                endpoint = Self::ENDPOINT,
+            ));
+            std::fs::remove_file(&key).ok();
+            assert!(configured, "could not configure {}", this.name);
+            Some(this)
+        }
+    }
+
+    #[cfg(target_os = "freebsd")]
+    impl Drop for WgPeers {
+        fn drop(&mut self) {
+            sh(&format!("ifconfig {} destroy", self.name));
+        }
+    }
+
+    /// Run `command` through the shell, succeeding only on exit 0.
+    #[cfg(target_os = "freebsd")]
+    fn sh(command: &str) -> bool {
+        std::process::Command::new("sh")
+            .args(["-ec", command])
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    /// Run `command` through the shell and return its trimmed stdout, `None` on failure.
+    #[cfg(target_os = "freebsd")]
+    fn sh_output(command: &str) -> Option<String> {
+        let output = std::process::Command::new("sh")
+            .args(["-ec", command])
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    }
+
+    // WireGuard refuses a copy for a peer it has no endpoint for, and on FreeBSD the BPF write
+    // reports that at once. The other peers still get theirs: the send counts as delivered, and
+    // the reachable peer's handshake shows up at its endpoint. Only when every copy fails does
+    // the send fail.
+    #[cfg(target_os = "freebsd")]
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_peer_without_an_endpoint_costs_only_its_own_copy() -> io::Result<()> {
+        let Some(wg) = WgPeers::create() else {
+            return Ok(());
+        };
+        let endpoint = UdpSocket::bind(WgPeers::ENDPOINT)?;
+        endpoint.set_read_timeout(Some(Duration::from_secs(2)))?;
+        let mut dispatcher = PacketDispatcher::new();
+        let egress = dispatcher.add_capture(Capture::open(&wg.name)?)?;
+        let group: SocketAddr = "239.255.90.90:9003".parse().unwrap();
+        let source = DatagramSource::Egress { port: 40000 };
+
+        let peers = [wg.unreachable, wg.reachable];
+        dispatcher.send_udp_to_peers(egress, &peers, group, source, 1, b"sood")?;
+        let mut buf = [0u8; 256];
+        let (n, from) = endpoint.recv_from(&mut buf)?;
+        assert!(n > 0, "the reachable peer's handshake never reached {from}");
+
+        let only_unreachable = [wg.unreachable];
+        let failed =
+            dispatcher.send_udp_to_peers(egress, &only_unreachable, group, source, 1, b"sood");
+        assert_eq!(
+            failed.map_err(|e| e.raw_os_error()),
+            Err(Some(libc::EHOSTUNREACH))
+        );
         Ok(())
     }
 

--- a/src/dispatch/datagram.rs
+++ b/src/dispatch/datagram.rs
@@ -35,8 +35,8 @@ pub(super) enum DatagramError {
 pub(crate) enum DatagramSource {
     /// The egress's own address of the destination's family, at `port`.
     Egress { port: u16 },
-    /// A captured sender's own address and port, kept on the re-emit.
-    Captured(SocketAddr),
+    /// This address and port: a relayed sender's own, or a session's reserved one.
+    Exact(SocketAddr),
 }
 
 /// The Ethernet destination MAC for an injected datagram to `dst`: the all-ones broadcast
@@ -81,8 +81,8 @@ pub(super) fn build_udp(
                 DatagramSource::Egress { port } => {
                     SocketAddrV4::new(addrs.v4().ok_or(DatagramError::NoSourceAddress)?, port)
                 }
-                DatagramSource::Captured(SocketAddr::V4(src)) => src,
-                DatagramSource::Captured(SocketAddr::V6(_)) => {
+                DatagramSource::Exact(SocketAddr::V4(src)) => src,
+                DatagramSource::Exact(SocketAddr::V6(_)) => {
                     return Err(DatagramError::SourceFamilyMismatch);
                 }
             };
@@ -112,8 +112,8 @@ pub(super) fn build_udp(
                         .ok_or(DatagramError::NoSourceAddress)?;
                     SocketAddrV6::new(src_ip, port, 0, 0)
                 }
-                DatagramSource::Captured(SocketAddr::V6(src)) => src,
-                DatagramSource::Captured(SocketAddr::V4(_)) => {
+                DatagramSource::Exact(SocketAddr::V6(src)) => src,
+                DatagramSource::Exact(SocketAddr::V4(_)) => {
                     return Err(DatagramError::SourceFamilyMismatch);
                 }
             };
@@ -196,7 +196,7 @@ mod tests {
             LinkType::Ethernet,
             dst,
             MacAddr::broadcast(),
-            DatagramSource::Captured(captured),
+            DatagramSource::Exact(captured),
             32,
             b"sood",
             &mut scratch,
@@ -212,7 +212,7 @@ mod tests {
                 LinkType::Ethernet,
                 dst,
                 MacAddr::broadcast(),
-                DatagramSource::Captured("[fe80::7]:40001".parse().unwrap()),
+                DatagramSource::Exact("[fe80::7]:40001".parse().unwrap()),
                 32,
                 b"sood",
                 &mut scratch,

--- a/src/dispatch/datagram.rs
+++ b/src/dispatch/datagram.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::interface::{InterfaceAddresses, Ipv6Scope};
 use crate::net::LinkType;
-use crate::net::frame::{self, Built, FrameError};
+use crate::net::frame::{self, FrameError};
 use crate::net::mac::MacAddr;
 
 /// Why a datagram could not be assembled for an egress: from [`build_udp`] (no source address or
@@ -74,7 +74,7 @@ pub(super) fn build_udp(
     ttl: u8,
     payload: &[u8],
     scratch: &mut [u8],
-) -> Result<Built, DatagramError> {
+) -> Result<usize, DatagramError> {
     match dst {
         SocketAddr::V4(dst) => {
             let src = match source {
@@ -168,8 +168,7 @@ mod tests {
             b"ssdp",
             &mut scratch,
         )
-        .unwrap()
-        .len;
+        .unwrap();
         // The IPv6 source address sits at bytes [22..38] of the frame (14 Ethernet + offset 8 into
         // the v6 header).
         assert_eq!(
@@ -202,8 +201,7 @@ mod tests {
             b"sood",
             &mut scratch,
         )
-        .unwrap()
-        .len;
+        .unwrap();
         assert_eq!(&scratch[26..30], &[192, 0, 2, 7]);
         assert_eq!(&scratch[34..36], &40001u16.to_be_bytes());
         assert!(n > 36);
@@ -276,8 +274,7 @@ mod tests {
             b"wol",
             &mut scratch,
         )
-        .unwrap()
-        .len;
+        .unwrap();
         // L2 header: the supplied destination MAC, the egress's own MAC as source.
         assert_eq!(&scratch[0..6], MacAddr::broadcast().octets().as_slice());
         assert_eq!(&scratch[6..12], addrs.mac().unwrap().octets().as_slice());
@@ -324,8 +321,7 @@ mod tests {
             b"ok",
             &mut scratch,
         )
-        .unwrap()
-        .len;
+        .unwrap();
         // The supplied unicast MAC is the L2 destination; the egress's own MAC is the source.
         assert_eq!(&scratch[0..6], searcher_mac.octets().as_slice());
         assert_eq!(&scratch[6..12], addrs.mac().unwrap().octets().as_slice());

--- a/src/dispatch/interface_table.rs
+++ b/src/dispatch/interface_table.rs
@@ -1,6 +1,7 @@
 //! The dispatcher's interface table: every interface with its multicast joiner, and every capture
 //! linked to its interface, all addressed by `Copy` index keys.
 
+use std::hash::{DefaultHasher, Hasher};
 use std::io;
 use std::net::IpAddr;
 use std::num::NonZeroU32;
@@ -38,17 +39,11 @@ struct CaptureEntry {
     capture: Option<Capture>,
     interface: InterfaceKey,
     counters: CaptureCounters,
-    last_sent: SentFrame,
-}
-
-/// The last frame sent on a capture, tagged with the packet whose routing sent it. A packet's
-/// routing sends one frame per egress, so an equal frame for the same packet is a second handler
-/// relaying what the first already did. `packet` counts from 1, so the default never matches.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(super) struct SentFrame {
-    pub(super) packet: u64,
-    pub(super) len: usize,
-    pub(super) checksum: u16,
+    /// The packet whose routing last sent here (they count from 1), and a hash of each frame it
+    /// sent: an equal frame for the same packet is a second handler relaying what the first
+    /// already did. The list grows once, to the largest fan-out on the capture.
+    sent_packet: u64,
+    sent: Vec<u64>,
 }
 
 /// One interface paired with its multicast joiner. Bundling them keeps the two from desyncing (one
@@ -134,17 +129,22 @@ impl InterfaceTable {
         Ok(self.add_interface(Interface::open(name)?))
     }
 
-    /// Whether `frame` is the last one sent on `egress`. An unknown key never sent anything.
-    pub(super) fn is_last_sent(&self, egress: CaptureKey, frame: SentFrame) -> bool {
+    /// Whether `frame` already went out on `egress` for `packet`. An unknown key sent nothing.
+    pub(super) fn was_sent(&self, egress: CaptureKey, packet: u64, frame: &[u8]) -> bool {
         self.captures
             .get(egress.0 as usize)
-            .is_some_and(|entry| entry.last_sent == frame)
+            .is_some_and(|entry| entry.sent_packet == packet && entry.sent.contains(&hash(frame)))
     }
 
-    /// Set `frame` as the last one sent on `egress`, once its send succeeded.
-    pub(super) fn set_last_sent(&mut self, egress: CaptureKey, frame: SentFrame) {
+    /// Record `frame` as sent on `egress` for `packet`, once its send succeeded. A new packet's
+    /// first frame drops the previous packet's.
+    pub(super) fn record_sent(&mut self, egress: CaptureKey, packet: u64, frame: &[u8]) {
         if let Some(entry) = self.captures.get_mut(egress.0 as usize) {
-            entry.last_sent = frame;
+            if entry.sent_packet != packet {
+                entry.sent_packet = packet;
+                entry.sent.clear();
+            }
+            entry.sent.push(hash(frame));
         }
     }
 
@@ -155,7 +155,8 @@ impl InterfaceTable {
             capture: Some(capture),
             interface,
             counters: CaptureCounters::default(),
-            last_sent: SentFrame::default(),
+            sent_packet: 0,
+            sent: Vec::new(),
         });
         key
     }
@@ -499,6 +500,13 @@ impl InterfaceTable {
     }
 }
 
+/// The hash a sent frame is remembered by.
+fn hash(frame: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    hasher.write(frame);
+    hasher.finish()
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -535,7 +543,8 @@ mod tests {
                 capture: None,
                 interface: InterfaceKey(0),
                 counters: CaptureCounters::default(),
-                last_sent: SentFrame::default(),
+                sent_packet: 0,
+                sent: Vec::new(),
             });
             key
         }
@@ -574,32 +583,26 @@ mod tests {
     // the changed fields (`None` for an unwatched index). Resolution is unprivileged (no capture
     // needed), so this exercises the monitor's refresh path without CAP_NET_RAW.
     #[test]
-    fn is_last_sent_matches_only_the_set_frame_for_the_same_packet() {
+    fn was_sent_remembers_every_frame_of_the_packet_being_routed() {
         let mut table = InterfaceTable::new();
         let egress = table.add_test_capture();
         let other = table.add_test_capture();
-        let frame = SentFrame {
-            packet: 1,
-            len: 60,
-            checksum: 0x1234,
-        };
-        // Nothing set yet: a failed send leaves it that way, so a retry goes out.
-        assert!(!table.is_last_sent(egress, frame));
-        table.set_last_sent(egress, frame);
-        assert!(table.is_last_sent(egress, frame));
-        // Another egress, another length or checksum, or the next packet: not the same frame.
-        assert!(!table.is_last_sent(other, frame));
-        assert!(!table.is_last_sent(egress, SentFrame { len: 61, ..frame }));
-        assert!(!table.is_last_sent(
-            egress,
-            SentFrame {
-                checksum: 0x1235,
-                ..frame
-            }
-        ));
-        assert!(!table.is_last_sent(egress, SentFrame { packet: 2, ..frame }));
-        assert!(!table.is_last_sent(CaptureKey::from_u64(999), frame));
-        table.set_last_sent(CaptureKey::from_u64(999), frame); // an unknown key is a no-op
+        // Nothing recorded yet: a failed send leaves it that way, so a retry goes out.
+        assert!(!table.was_sent(egress, 1, b"first"));
+        table.record_sent(egress, 1, b"first");
+        table.record_sent(egress, 1, b"second");
+        assert!(table.was_sent(egress, 1, b"first"));
+        assert!(table.was_sent(egress, 1, b"second"));
+        // Another egress, other bytes, or the next packet: not a sent frame.
+        assert!(!table.was_sent(other, 1, b"first"));
+        assert!(!table.was_sent(egress, 1, b"third"));
+        assert!(!table.was_sent(egress, 2, b"first"));
+        // The next packet's first frame clears the previous packet's.
+        table.record_sent(egress, 2, b"third");
+        assert!(table.was_sent(egress, 2, b"third"));
+        assert!(!table.was_sent(egress, 1, b"first"));
+        assert!(!table.was_sent(CaptureKey::from_u64(999), 2, b"third"));
+        table.record_sent(CaptureKey::from_u64(999), 2, b"third"); // an unknown key is a no-op
     }
 
     #[test]

--- a/src/dispatch/pair_tests.rs
+++ b/src/dispatch/pair_tests.rs
@@ -499,8 +499,7 @@ fn inject(
         payload,
         &mut scratch,
     )
-    .expect("build the injected frame")
-    .len;
+    .expect("build the injected frame");
     injector.send(&scratch[..n])
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -11,7 +11,7 @@
 
 use std::fmt;
 use std::io;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::net::mac::MacAddr;
 
@@ -65,6 +65,14 @@ impl InterfaceAddresses {
         match dest_scope {
             Ipv6Scope::LinkLocal => self.v6,
             Ipv6Scope::Routable => self.v6_routable.or(self.v6),
+        }
+    }
+
+    /// Whether `ip` is one of the interface's own addresses.
+    pub(crate) fn has(&self, ip: IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(v4) => self.v4 == Some(v4),
+            IpAddr::V6(v6) => self.v6 == Some(v6) || self.v6_routable == Some(v6),
         }
     }
 

--- a/src/net/frame.rs
+++ b/src/net/frame.rs
@@ -35,14 +35,6 @@ pub(crate) enum FrameError {
     PayloadTooLarge { payload: usize },
 }
 
-/// What a builder wrote: the frame's length in the output buffer, and the UDP checksum it
-/// carries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Built {
-    pub(crate) len: usize,
-    pub(crate) udp_checksum: u16,
-}
-
 /// Ethernet frame carrying an IPv4 UDP datagram into `out`: dst/src MAC header and
 /// ethertype, then the IPv4 + UDP datagram with checksums filled.
 ///
@@ -57,15 +49,12 @@ pub(crate) fn ethernet_ipv4_udp(
     ttl: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<Built, FrameError> {
+) -> Result<usize, FrameError> {
     let (header, body) = split_l2(out, ETHERNET_HEADER_SIZE)?;
     let datagram = ipv4_udp(src, dst, ttl, payload, body)
         .map_err(|e| with_l2_header(e, ETHERNET_HEADER_SIZE))?;
     write_ethernet_header(header, dst_mac, src_mac, IPV4_ETHERTYPE);
-    Ok(Built {
-        len: ETHERNET_HEADER_SIZE + datagram.len,
-        ..datagram
-    })
+    Ok(ETHERNET_HEADER_SIZE + datagram)
 }
 
 /// Ethernet frame carrying an IPv6 UDP datagram into `out`: dst/src MAC header and
@@ -82,15 +71,12 @@ pub(crate) fn ethernet_ipv6_udp(
     hop_limit: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<Built, FrameError> {
+) -> Result<usize, FrameError> {
     let (header, body) = split_l2(out, ETHERNET_HEADER_SIZE)?;
     let datagram = ipv6_udp(src, dst, hop_limit, payload, body)
         .map_err(|e| with_l2_header(e, ETHERNET_HEADER_SIZE))?;
     write_ethernet_header(header, dst_mac, src_mac, IPV6_ETHERTYPE);
-    Ok(Built {
-        len: ETHERNET_HEADER_SIZE + datagram.len,
-        ..datagram
-    })
+    Ok(ETHERNET_HEADER_SIZE + datagram)
 }
 
 /// `DLT_NULL` frame carrying an IPv4 UDP datagram into `out` (BSD `lo0`
@@ -107,15 +93,12 @@ pub(crate) fn dlt_null_ipv4_udp(
     ttl: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<Built, FrameError> {
+) -> Result<usize, FrameError> {
     let (header, body) = split_l2(out, DLT_NULL_HEADER_SIZE)?;
     let datagram = ipv4_udp(src, dst, ttl, payload, body)
         .map_err(|e| with_l2_header(e, DLT_NULL_HEADER_SIZE))?;
     write_dlt_null_header(header, libc::AF_INET);
-    Ok(Built {
-        len: DLT_NULL_HEADER_SIZE + datagram.len,
-        ..datagram
-    })
+    Ok(DLT_NULL_HEADER_SIZE + datagram)
 }
 
 /// `DLT_NULL` frame carrying an IPv6 UDP datagram into `out` (BSD `lo0`
@@ -132,15 +115,12 @@ pub(crate) fn dlt_null_ipv6_udp(
     hop_limit: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<Built, FrameError> {
+) -> Result<usize, FrameError> {
     let (header, body) = split_l2(out, DLT_NULL_HEADER_SIZE)?;
     let datagram = ipv6_udp(src, dst, hop_limit, payload, body)
         .map_err(|e| with_l2_header(e, DLT_NULL_HEADER_SIZE))?;
     write_dlt_null_header(header, libc::AF_INET6);
-    Ok(Built {
-        len: DLT_NULL_HEADER_SIZE + datagram.len,
-        ..datagram
-    })
+    Ok(DLT_NULL_HEADER_SIZE + datagram)
 }
 
 /// Write an IPv4 + UDP datagram (headers and `payload`, with the IPv4-header and
@@ -155,7 +135,7 @@ pub(crate) fn ipv4_udp(
     ttl: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<Built, FrameError> {
+) -> Result<usize, FrameError> {
     let udp_length = datagram_length(payload)?;
     let frame_size = IPV4_HEADER_SIZE + usize::from(udp_length);
     // The IPv4 total-length field is also 16-bit and spans header + datagram.
@@ -182,10 +162,7 @@ pub(crate) fn ipv4_udp(
     let udp_checksum = checksum::udp_v4(*src.ip(), *dst.ip(), &out[udp..]);
     out[udp + 6..udp + 8].copy_from_slice(&udp_checksum.to_be_bytes());
 
-    Ok(Built {
-        len: frame_size,
-        udp_checksum,
-    })
+    Ok(frame_size)
 }
 
 /// Write an IPv6 + UDP datagram (headers and `payload`, with the UDP checksum
@@ -200,7 +177,7 @@ pub(crate) fn ipv6_udp(
     hop_limit: u8,
     payload: &[u8],
     out: &mut [u8],
-) -> Result<Built, FrameError> {
+) -> Result<usize, FrameError> {
     let udp_length = datagram_length(payload)?;
     let frame_size = IPV6_HEADER_SIZE + usize::from(udp_length);
     let out = checked_out(out, frame_size)?;
@@ -220,10 +197,7 @@ pub(crate) fn ipv6_udp(
     let udp_checksum = checksum::udp_v6(*src.ip(), *dst.ip(), &out[udp..]);
     out[udp + 6..udp + 8].copy_from_slice(&udp_checksum.to_be_bytes());
 
-    Ok(Built {
-        len: frame_size,
-        udp_checksum,
-    })
+    Ok(frame_size)
 }
 
 /// The UDP datagram length (header + `payload`) as a `u16`, or
@@ -302,7 +276,7 @@ mod tests {
         let payload = [0xde, 0xad, 0xbe, 0xef];
         let mut buf = [0xAAu8; 64]; // sentinel: every frame byte must be overwritten
 
-        let n = ipv4_udp(src, dst, 1, &payload, &mut buf).unwrap().len;
+        let n = ipv4_udp(src, dst, 1, &payload, &mut buf).unwrap();
         assert_eq!(n, IPV4_HEADER_SIZE + UDP_HEADER_SIZE + payload.len());
         let frame = &buf[..n];
         let udp = IPV4_HEADER_SIZE;
@@ -349,7 +323,7 @@ mod tests {
         let payload = [0xaa, 0xbb, 0xcc];
         let mut buf = [0xAAu8; 80]; // sentinel: every frame byte must be overwritten
 
-        let n = ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap().len;
+        let n = ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap();
         assert_eq!(n, IPV6_HEADER_SIZE + UDP_HEADER_SIZE + payload.len());
         let frame = &buf[..n];
         let udp = IPV6_HEADER_SIZE;
@@ -447,8 +421,7 @@ mod tests {
         let mut buf = [0xAAu8; 64];
 
         let built = ethernet_ipv4_udp(dst_mac, src_mac, src, dst, 1, &payload, &mut buf).unwrap();
-        assert_eq!(built.udp_checksum, u16::from_be_bytes([buf[40], buf[41]]));
-        let n = built.len;
+        let n = built;
         assert_eq!(
             n,
             ETHERNET_HEADER_SIZE + IPV4_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -461,7 +434,7 @@ mod tests {
 
         // Past the Ethernet header is exactly the standalone IPv4 datagram.
         let mut datagram = [0u8; 64];
-        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap().len;
+        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap();
         assert_eq!(&frame[ETHERNET_HEADER_SIZE..], &datagram[..dn]);
     }
 
@@ -475,8 +448,7 @@ mod tests {
         let mut buf = [0xAAu8; 80];
 
         let built = ethernet_ipv6_udp(dst_mac, src_mac, src, dst, 255, &payload, &mut buf).unwrap();
-        assert_eq!(built.udp_checksum, u16::from_be_bytes([buf[60], buf[61]]));
-        let n = built.len;
+        let n = built;
         assert_eq!(
             n,
             ETHERNET_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -488,9 +460,7 @@ mod tests {
         assert_eq!(u16::from_be_bytes([frame[12], frame[13]]), IPV6_ETHERTYPE);
 
         let mut datagram = [0u8; 80];
-        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram)
-            .unwrap()
-            .len;
+        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram).unwrap();
         assert_eq!(&frame[ETHERNET_HEADER_SIZE..], &datagram[..dn]);
     }
 
@@ -531,7 +501,7 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 2);
         let mut buf = [0u8; IPV4_HEADER_SIZE + UDP_HEADER_SIZE]; // exactly the empty-payload frame
         assert_eq!(
-            ipv4_udp(src, dst, 1, &[], &mut buf).map(|built| built.len),
+            ipv4_udp(src, dst, 1, &[], &mut buf),
             Ok(IPV4_HEADER_SIZE + UDP_HEADER_SIZE)
         );
     }
@@ -544,9 +514,7 @@ mod tests {
         let payload = [0xde, 0xad];
         let mut buf = [0xAAu8; 64];
 
-        let n = dlt_null_ipv4_udp(src, dst, 1, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n = dlt_null_ipv4_udp(src, dst, 1, &payload, &mut buf).unwrap();
         assert_eq!(
             n,
             DLT_NULL_HEADER_SIZE + IPV4_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -560,7 +528,7 @@ mod tests {
         );
         // Past the link header is exactly the standalone IPv4 datagram.
         let mut datagram = [0u8; 64];
-        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap().len;
+        let dn = ipv4_udp(src, dst, 1, &payload, &mut datagram).unwrap();
         assert_eq!(&frame[DLT_NULL_HEADER_SIZE..], &datagram[..dn]);
     }
 
@@ -572,9 +540,7 @@ mod tests {
         let payload = [0xaa, 0xbb, 0xcc];
         let mut buf = [0xAAu8; 80];
 
-        let n = dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n = dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap();
         assert_eq!(
             n,
             DLT_NULL_HEADER_SIZE + IPV6_HEADER_SIZE + UDP_HEADER_SIZE + payload.len()
@@ -586,9 +552,7 @@ mod tests {
             libc::AF_INET6.cast_unsigned()
         );
         let mut datagram = [0u8; 80];
-        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram)
-            .unwrap()
-            .len;
+        let dn = ipv6_udp(src, dst, 255, &payload, &mut datagram).unwrap();
         assert_eq!(&frame[DLT_NULL_HEADER_SIZE..], &datagram[..dn]);
     }
 }

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -261,9 +261,8 @@ mod tests {
         // Distinct dst/src MACs so a swapped read would fail.
         let dst_mac = MacAddr::from([0x02, 0, 0, 0, 0, 0xaa]);
         let src_mac = MacAddr::from([0x02, 0, 0, 0, 0, 0xbb]);
-        let n = frame::ethernet_ipv4_udp(dst_mac, src_mac, src, dst, 64, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n =
+            frame::ethernet_ipv4_udp(dst_mac, src_mac, src, dst, 64, &payload, &mut buf).unwrap();
 
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V4(src));
@@ -282,9 +281,8 @@ mod tests {
         let mut buf = [0u8; 80];
         let dst_mac = MacAddr::from([0x33, 0x33, 0, 0, 0, 0xfb]);
         let src_mac = MacAddr::from([0x02, 0, 0, 0, 0, 0xbb]);
-        let n = frame::ethernet_ipv6_udp(dst_mac, src_mac, src, dst, 255, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n =
+            frame::ethernet_ipv6_udp(dst_mac, src_mac, src, dst, 255, &payload, &mut buf).unwrap();
 
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V6(src));
@@ -302,9 +300,7 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5354);
         let payload = [0x01, 0x02];
         let mut buf = [0u8; 64];
-        let n = frame::dlt_null_ipv4_udp(src, dst, 64, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n = frame::dlt_null_ipv4_udp(src, dst, 64, &payload, &mut buf).unwrap();
 
         let packet = Packet::parse(LinkType::DltNull, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V4(src));
@@ -323,9 +319,7 @@ mod tests {
         let dst = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5354, 0, 0);
         let payload = [0x09];
         let mut buf = [0u8; 80];
-        let n = frame::dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n = frame::dlt_null_ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap();
 
         let packet = Packet::parse(LinkType::DltNull, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V6(src));
@@ -341,9 +335,7 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::new(10, 10, 10, 1), 5354);
         let payload = [0x01, 0x02];
         let mut buf = [0u8; 64];
-        let n = frame::ipv4_udp(src, dst, 64, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n = frame::ipv4_udp(src, dst, 64, &payload, &mut buf).unwrap();
 
         let packet = Packet::parse(LinkType::RawIp, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V4(src));
@@ -366,9 +358,7 @@ mod tests {
         let dst = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5354, 0, 0);
         let payload = [0x09];
         let mut buf = [0u8; 80];
-        let n = frame::ipv6_udp(src, dst, 255, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n = frame::ipv6_udp(src, dst, 255, &payload, &mut buf).unwrap();
 
         let packet = Packet::parse(LinkType::RawIp, &buf[..n]).unwrap();
         assert_eq!(packet.source, SocketAddr::V6(src));
@@ -386,9 +376,7 @@ mod tests {
         let payload = [0x11, 0x22, 0x33];
         let mut buf = [0u8; 64]; // zero-filled tail stands in for padding
         let mac = MacAddr::broadcast();
-        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &payload, &mut buf)
-            .unwrap()
-            .len;
+        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &payload, &mut buf).unwrap();
 
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n + 10]).unwrap();
         assert_eq!(packet.payload, &payload);
@@ -424,9 +412,7 @@ mod tests {
         let src = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1234);
         let dst = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 5678);
         let mac = MacAddr::broadcast();
-        frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[0xab; 4], buf)
-            .unwrap()
-            .len
+        frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[0xab; 4], buf).unwrap()
     }
 
     #[test]
@@ -533,9 +519,7 @@ mod tests {
         let dst = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 2);
         let mac = MacAddr::broadcast();
         let mut buf = [0u8; 64];
-        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[], &mut buf)
-            .unwrap()
-            .len;
+        let n = frame::ethernet_ipv4_udp(mac, mac, src, dst, 64, &[], &mut buf).unwrap();
         let packet = Packet::parse(LinkType::Ethernet, &buf[..n]).unwrap();
         assert!(packet.payload.is_empty());
     }
@@ -546,9 +530,7 @@ mod tests {
         let src = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 1234, 0, 0);
         let dst = SocketAddrV6::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb), 5678, 0, 0);
         let mac = MacAddr::broadcast();
-        frame::ethernet_ipv6_udp(mac, mac, src, dst, 64, &[0xab; 4], buf)
-            .unwrap()
-            .len
+        frame::ethernet_ipv6_udp(mac, mac, src, dst, 64, &[0xab; 4], buf).unwrap()
     }
 
     #[test]

--- a/src/net/port_reservation.rs
+++ b/src/net/port_reservation.rs
@@ -6,7 +6,7 @@
 //! frees the port.
 
 use std::io;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 
 use crate::sys::{open_socket, sockaddr_for, socklen_of};
@@ -16,7 +16,7 @@ use crate::sys::{open_socket, sockaddr_for, socklen_of};
 pub(crate) struct PortReservation {
     /// Held to keep the port claimed; never read.
     _fd: OwnedFd,
-    port: u16,
+    source: SocketAddr,
 }
 
 impl PortReservation {
@@ -47,12 +47,20 @@ impl PortReservation {
             return Err(io::Error::last_os_error());
         }
         let port = bound_port(fd.as_raw_fd())?;
-        Ok(Self { _fd: fd, port })
+        Ok(Self {
+            _fd: fd,
+            source: SocketAddr::new(addr, port),
+        })
     }
 
     /// The OS-assigned ephemeral port the reservation holds.
     pub(crate) fn port(&self) -> u16 {
-        self.port
+        self.source.port()
+    }
+
+    /// The reserved address and port: what the reflector sends from and devices reply to.
+    pub(crate) fn source(&self) -> SocketAddr {
+        self.source
     }
 }
 

--- a/src/reflector.rs
+++ b/src/reflector.rs
@@ -16,12 +16,15 @@ pub(crate) use search::SearchReflector;
 pub(crate) use simple::{Classify, Emit, SimpleReflector};
 
 use std::fmt;
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 
 use thiserror::Error;
 
-use crate::config::AddressFamily;
-use crate::dispatch::{CaptureKey, MessageType, PacketDispatcher, join_capped, join_deferrable};
+use crate::config::{AddressFamily, PeerList};
+use crate::dispatch::{
+    CaptureKey, DatagramSource, MessageType, PacketDispatcher, join_capped, join_deferrable,
+};
 use crate::interface::InterfaceAddresses;
 use crate::linear_map::LinearMap;
 use crate::logging::WARN_WINDOW;
@@ -46,6 +49,60 @@ pub(crate) enum Verdict {
     Excluded,
     /// Not a recognizable protocol message on this dedicated group. Drop it with a debug log.
     Junk,
+}
+
+/// Where a leg's group and broadcast re-emits go: onto the link, or, behind a link without a
+/// broadcast domain, to each of the entry's peers as unicast.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Delivery {
+    Link,
+    Peers(Box<[IpAddr]>),
+}
+
+impl Delivery {
+    /// The delivery an entry's `source_peers` / `target_peers` value describes.
+    pub(crate) fn new(peers: Option<&PeerList>) -> Self {
+        match peers {
+            Some(peers) => Self::Peers(peers.iter().copied().collect()),
+            None => Self::Link,
+        }
+    }
+
+    /// The address a datagram to `dst` reaches under this delivery: `dst` on the link, or the
+    /// first peer of its family. A reply to it must be listened for on a source of that scope.
+    pub(crate) fn destination(&self, dst: IpAddr) -> IpAddr {
+        match self {
+            Self::Link => dst,
+            Self::Peers(peers) => peers
+                .iter()
+                .copied()
+                .find(|peer| peer.is_ipv4() == dst.is_ipv4())
+                .unwrap_or(dst),
+        }
+    }
+
+    /// Send a group or broadcast datagram on `egress` where the delivery says.
+    ///
+    /// # Errors
+    /// As the dispatcher's [`send_udp_group`](PacketDispatcher::send_udp_group) and
+    /// [`send_udp_to_peers`](PacketDispatcher::send_udp_to_peers): for peers, only when no copy
+    /// went out.
+    pub(crate) fn send(
+        &self,
+        dispatcher: &mut PacketDispatcher,
+        egress: CaptureKey,
+        dst: SocketAddr,
+        source: DatagramSource,
+        ttl: u8,
+        payload: &[u8],
+    ) -> io::Result<()> {
+        match self {
+            Self::Link => dispatcher.send_udp_group(egress, dst, source, ttl, payload),
+            Self::Peers(peers) => {
+                dispatcher.send_udp_to_peers(egress, peers, dst, source, ttl, payload)
+            }
+        }
+    }
 }
 
 /// Transforms a datagram's payload before it is re-emitted: the SSDP DIAL `LOCATION` rewrite, applied
@@ -285,6 +342,16 @@ mod tests {
             }
             Err(e) => panic!("unexpected loopback capture open failure: {e}"),
         }
+    }
+
+    #[test]
+    fn delivery_follows_the_entrys_peers() {
+        let peers: PeerList = "127.0.0.1".parse().unwrap();
+        assert_eq!(
+            Delivery::new(Some(&peers)),
+            Delivery::Peers(Box::new([IpAddr::V4(Ipv4Addr::LOCALHOST)]))
+        );
+        assert_eq!(Delivery::new(None), Delivery::Link);
     }
 
     #[test]

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -20,8 +20,8 @@ use crate::net::mdns::{
 };
 
 use super::{
-    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, require_bidirectional_families,
-    require_group_join, require_macs_matchable,
+    BuildError, Delivery, Emit, InterfaceMap, SimpleReflector, Verdict,
+    require_bidirectional_families, require_group_join, require_macs_matchable,
 };
 
 /// mDNS's classifier kind *is* its message type: `Query`/`Response` map straight across.
@@ -114,6 +114,7 @@ pub(crate) fn build(
         },
         Box::new(SimpleReflector::new(
             target,
+            Delivery::new(reflector.target_peers.as_ref()),
             "mDNS",
             "query",
             query_verdict,
@@ -132,6 +133,9 @@ pub(crate) fn build(
         Box::new(
             SimpleReflector::new(
                 source,
+                // Never to peers: a client takes a unicast answer only to its own question that
+                // asked for one (§5.4); the config refuses peers on this side.
+                Delivery::Link,
                 "mDNS",
                 "response",
                 response_verdict,

--- a/src/reflector/mdns.rs
+++ b/src/reflector/mdns.rs
@@ -3,12 +3,14 @@
 //! every in-use family's group: queries flow source → target, responses target → source. Atop the
 //! capture's own-egress drop, this breaks the reflection loop. Each re-emits to the same group at
 //! TTL 255 (RFC 6762 §11), sourced from the egress interface. The dispatcher's filter pins the
-//! group, so the reflector only gates on the query/response classifier.
+//! group for queries; for responses it also takes an answer sent to the target interface itself,
+//! which a device sends when the query asked for a unicast response (the QU bit, RFC 6762 §5.4)
+//! or arrived as unicast (a copy to a peer, §5.5). Such an answer goes out on the source's group.
 //!
-//! Limitation: this is a multicast-only relay. A one-shot / legacy querier — one that asks from an
-//! ephemeral source port, or sets the unicast-response (QU) bit — is answered *unicast* to that port,
-//! off the group, so its answer is never captured or reflected across the link. (SSDP and WSD instead
-//! proxy each searcher's unicast reply through a per-searcher session; mDNS does not.)
+//! Limitation: a legacy querier asking from an ephemeral port expects its answer there, but the
+//! relayed query is sourced from port 5353, so the device answers on the group, which that
+//! querier does not listen on. (SSDP and WSD instead proxy each searcher's unicast reply through
+//! a per-searcher session; mDNS does not.)
 
 use std::net::SocketAddr;
 
@@ -121,13 +123,18 @@ pub(crate) fn build(
             Emit::fixed(MDNS_PORT, MDNS_TTL),
         )),
     );
-    // target → source: reflect responses, optionally only from the configured device's MAC.
+    // target → source: reflect responses, optionally only from the configured device's MAC. An
+    // answer to a query that asked for a unicast response, or that reached a peer as unicast,
+    // comes to this host rather than the group (RFC 6762 §5.4, §5.5) and is taken in as well. A
+    // response comes from port 5353, and one from elsewhere is ignored by every client (§6).
     dispatcher.register(
         target,
         Filter {
+            src_port: Some(MDNS_PORT),
             dst_ip: Some(group_ips),
             dst_port: Some(MDNS_PORT.into()),
             src_mac: reflector.macs.clone(),
+            dst_own: Some(reflector.address_family),
             ..Filter::default()
         },
         Box::new(
@@ -139,7 +146,7 @@ pub(crate) fn build(
                 "mDNS",
                 "response",
                 response_verdict,
-                Emit::fixed(MDNS_PORT, MDNS_TTL),
+                Emit::fixed(MDNS_PORT, MDNS_TTL).unicast_to_group(MDNS_GROUP_V4, MDNS_GROUP_V6),
             )
             // A response whose A/AAAA records are all link-local or otherwise never a peer
             // advertises endpoints the source side can never use; queries carry no advertisement,

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -25,7 +25,7 @@ use crate::net::packet::Packet;
 use crate::net::port_reservation::PortReservation;
 use crate::reactor::Reactor;
 
-use super::{ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
+use super::{Delivery, ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
 
 /// In-flight session cap, so a burst of searchers can't exhaust ephemeral ports or registrations. At
 /// the cap a new search is dropped (no live session is evicted early).
@@ -154,6 +154,8 @@ pub(crate) struct SearchReflector {
     source: CaptureKey,
     /// The target capture: where the search is re-emitted and the replies are captured.
     target: CaptureKey,
+    /// Where the re-emitted searches go on `target`.
+    delivery: Delivery,
     /// The configured device allow-set, scoping the response registration as the announcement direction is.
     device_macs: Option<MacSet>,
     /// Protocol label for logs, e.g. `"SSDP"`.
@@ -179,6 +181,7 @@ impl SearchReflector {
     pub(crate) fn new(
         source: CaptureKey,
         target: CaptureKey,
+        delivery: Delivery,
         device_macs: Option<MacSet>,
         name: &'static str,
         response_type: MessageType,
@@ -191,6 +194,7 @@ impl SearchReflector {
         Self {
             source,
             target,
+            delivery,
             device_macs,
             name,
             response_type,
@@ -203,9 +207,10 @@ impl SearchReflector {
         }
     }
 
-    /// Open a session for a new searcher: reserve an ephemeral port on the target's own address of the
-    /// search's family and register the reply capture there, before the caller reflects, so a fast
-    /// responder can't beat the capture. `message_type` is the search's own type, carried on the
+    /// Open a session for a new searcher: reserve an ephemeral port on the target's own address of
+    /// the scope the search reaches (the group's, or the peers' behind a tunnel) and register the
+    /// reply capture there, before the caller reflects, so a fast responder can't beat the
+    /// capture. `message_type` is the search's own type, carried on the
     /// failure outcomes. `Err` (logged) is either [`Outcome::Stalled`] (the target has no source
     /// address of the search's family yet; transient / best-effort v6) or [`Outcome::Dropped`] (a real
     /// inability to open the session: session cap, no source MAC to reply to, reservation failure).
@@ -236,12 +241,13 @@ impl SearchReflector {
             );
             return Err(Outcome::Dropped(message_type));
         };
-        let Some(our_addr) = reply_source(dispatcher, self.target, packet.dest.ip()) else {
+        let destination = self.delivery.destination(packet.dest.ip());
+        let Some(our_addr) = reply_source(dispatcher, self.target, destination) else {
             log::debug!(
-                "{}: cannot reflect search from {}: target has no source address for {} yet",
+                "{}: cannot reflect search from {}: target has no source address for \
+                 {destination} yet",
                 self.name,
-                packet.source,
-                packet.dest.ip()
+                packet.source
             );
             return Err(Outcome::Stalled(message_type));
         };
@@ -346,11 +352,12 @@ impl PacketHandler for SearchReflector {
             dest: packet.dest,
         };
         if let Some(session) = self.sessions.get_mut(&key) {
-            let port = session.reservation.port();
-            return match dispatcher.send_udp_group(
+            let source = session.reservation.source();
+            return match self.delivery.send(
+                dispatcher,
                 self.target,
                 packet.dest,
-                DatagramSource::Egress { port },
+                DatagramSource::Exact(source),
                 self.ttl,
                 packet.payload,
             ) {
@@ -359,7 +366,7 @@ impl PacketHandler for SearchReflector {
                     // MX window, so a retransmit with a smaller MX must not cut their replies off.
                     session.expiry = session.expiry.max(expiry);
                     log::debug!(
-                        "re-reflected {} search from {} to {} on reserved port {port}",
+                        "re-reflected {} search from {} to {} from {source}",
                         self.name,
                         packet.source,
                         packet.dest
@@ -384,18 +391,19 @@ impl PacketHandler for SearchReflector {
             Ok(session) => session,
             Err(outcome) => return outcome, // make_session logged the cause
         };
-        let port = session.reservation.port();
-        match dispatcher.send_udp_group(
+        let source = session.reservation.source();
+        match self.delivery.send(
+            dispatcher,
             self.target,
             packet.dest,
-            DatagramSource::Egress { port },
+            DatagramSource::Exact(source),
             self.ttl,
             packet.payload,
         ) {
             Ok(()) => {
                 self.sessions.insert(key, session);
                 log::debug!(
-                    "reflected {} search from {} to {} on reserved port {port}; opened a session, {} active",
+                    "reflected {} search from {} to {} from {source}; opened a session, {} active",
                     self.name,
                     packet.source,
                     packet.dest,
@@ -477,6 +485,8 @@ mod tests {
 
     use super::*;
     use crate::capture::{Capture, loopback_lock};
+    #[cfg(target_os = "linux")]
+    use crate::net::LinkType;
     use crate::reflector::NoRewrite;
 
     const TEST_TTL: u8 = 2;
@@ -496,6 +506,7 @@ mod tests {
         SearchReflector::new(
             CaptureKey::from_u64(1),
             CaptureKey::from_u64(0),
+            Delivery::Link,
             None,
             "TEST",
             MessageType::SsdpResponse,
@@ -971,6 +982,67 @@ mod tests {
         }
     }
 
+    // Peers behind a tunnel are reached by routable addresses, so a session for a link-local
+    // group must listen on the address its search copies are sent from, or the replies land
+    // where nothing waits for them.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_session_listens_where_its_search_copies_come_from() -> std::io::Result<()> {
+        let Some(tun) = crate::capture::Tun::create() else {
+            return Ok(());
+        };
+        assert!(tun.add_address("fe80::1/64") && tun.add_address("fd00:99::1/64"));
+        let mut dispatcher = PacketDispatcher::new();
+        let target = dispatcher.add_capture(Capture::open(&tun.name)?)?;
+        let mut reactor = Reactor::new()?;
+        let peer: IpAddr = "fd00:99::2".parse().unwrap();
+        let mut reflector = SearchReflector::new(
+            CaptureKey::from_u64(999),
+            target,
+            Delivery::Peers(Box::new([peer])),
+            None,
+            "TEST",
+            MessageType::SsdpResponse,
+            TEST_TTL,
+            always_reflect,
+            fixed_window,
+            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+            |_| false,
+        );
+        let packet = Packet {
+            source: "[fe80::a]:1900".parse().unwrap(),
+            dest: "[ff02::c]:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: Some(MacAddr::from([0x02, 0, 0, 0, 0, 1])),
+            payload: b"M-SEARCH",
+        };
+        let outcome = reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
+        assert_eq!(outcome, Outcome::Reflected(MessageType::SsdpSearch));
+        let listening = reflector
+            .sessions
+            .iter()
+            .map(|(_, session)| session.reservation.source())
+            .next()
+            .expect("a session");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let copy = loop {
+            let Some(bytes) = tun.next_packet(deadline)? else {
+                panic!("the search copy never reached the far end");
+            };
+            if let Ok(parsed) = Packet::parse(LinkType::RawIp, &bytes)
+                && parsed.payload == b"M-SEARCH"
+            {
+                break (parsed.source, parsed.dest);
+            }
+        };
+        assert_eq!(copy.1, SocketAddr::new(peer, 1900));
+        assert_eq!(copy.0, listening);
+        Ok(())
+    }
+
     #[test]
     #[cfg_attr(miri, ignore = "needs a real capture device")]
     fn a_failed_reflect_rolls_back_the_session_registration() {
@@ -989,6 +1061,7 @@ mod tests {
         let mut reflector = SearchReflector::new(
             CaptureKey::from_u64(999), // synthetic source: no reply comes back in this test
             target,
+            Delivery::Link,
             None,
             "TEST",
             MessageType::SsdpResponse,

--- a/src/reflector/search.rs
+++ b/src/reflector/search.rs
@@ -213,7 +213,7 @@ impl SearchReflector {
     /// capture. `message_type` is the search's own type, carried on the
     /// failure outcomes. `Err` (logged) is either [`Outcome::Stalled`] (the target has no source
     /// address of the search's family yet; transient / best-effort v6) or [`Outcome::Dropped`] (a real
-    /// inability to open the session: session cap, no source MAC to reply to, reservation failure).
+    /// inability to open the session: session cap, reservation failure).
     fn make_session(
         &self,
         packet: &Packet,
@@ -231,16 +231,8 @@ impl SearchReflector {
             );
             return Err(Outcome::Dropped(message_type));
         }
-        let Some(searcher_mac) = packet.src_mac else {
-            log_rate!(
-                log::Level::Warn,
-                WARN_WINDOW,
-                "{}: cannot reflect search from {}: frame has no source MAC to reply to",
-                self.name,
-                packet.source
-            );
-            return Err(Outcome::Dropped(message_type));
-        };
+        // A frame off a link without MACs has none; the reply's L2 destination goes unused there.
+        let searcher_mac = packet.src_mac.unwrap_or(MacAddr::broadcast());
         let destination = self.delivery.destination(packet.dest.ip());
         let Some(our_addr) = reply_source(dispatcher, self.target, destination) else {
             log::debug!(
@@ -813,33 +805,6 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore = "needs a real socket")]
-    fn make_session_drops_a_search_with_no_source_mac() {
-        // No source MAC means no L2 address to reply to, so make_session drops the search rather than
-        // open a session it could never answer.
-        let mut dispatcher = PacketDispatcher::new();
-        let reflector = test_reflector();
-        let packet = Packet {
-            source: "10.0.0.1:5".parse().unwrap(),
-            dest: "239.255.255.250:1900".parse().unwrap(),
-            ttl: TEST_TTL,
-            dst_mac: None,
-            src_mac: None,
-            payload: b"search",
-        };
-        let outcome = reflector.make_session(
-            &packet,
-            &mut dispatcher,
-            Instant::now(),
-            MessageType::SsdpSearch,
-        );
-        assert!(matches!(
-            outcome,
-            Err(Outcome::Dropped(MessageType::SsdpSearch))
-        ));
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore = "needs a real socket")]
     fn make_session_drops_at_the_session_cap() {
         // At MAX_SESSIONS in flight a new searcher is dropped; no live session is evicted early.
         let mut dispatcher = PacketDispatcher::new();
@@ -980,6 +945,46 @@ mod tests {
             }
             Err(e) => panic!("unexpected loopback capture open failure: {e}"),
         }
+    }
+
+    // A search off a link without MACs (a tunnel) carries no source MAC; the reply needs none
+    // there, so the session opens all the same.
+    #[test]
+    #[cfg_attr(miri, ignore = "needs a real capture device")]
+    fn a_search_without_a_source_mac_opens_a_session() {
+        let _serial = loopback_lock();
+        let Some(target_cap) = open_loopback_or_skip() else {
+            return;
+        };
+        let mut dispatcher = PacketDispatcher::new();
+        let target = dispatcher
+            .add_capture(target_cap)
+            .expect("add the loopback capture");
+        let mut reactor = Reactor::new().expect("reactor");
+        let mut reflector = SearchReflector::new(
+            CaptureKey::from_u64(999),
+            target,
+            Delivery::Link,
+            None,
+            "TEST",
+            MessageType::SsdpResponse,
+            TEST_TTL,
+            always_reflect,
+            fixed_window,
+            Box::new(|| Box::new(NoRewrite) as Box<dyn ReplyRewrite>),
+            |_| false,
+        );
+        let packet = Packet {
+            source: "10.0.0.1:5".parse().unwrap(),
+            dest: "239.255.255.250:1900".parse().unwrap(),
+            ttl: TEST_TTL,
+            dst_mac: None,
+            src_mac: None,
+            payload: b"M-SEARCH",
+        };
+        let outcome = reflector.on_packet(&packet, &mut dispatcher, &mut reactor);
+        assert_eq!(outcome, Outcome::Reflected(MessageType::SsdpSearch));
+        assert_eq!(reflector.sessions.len(), 1);
     }
 
     // Peers behind a tunnel are reached by routable addresses, so a session for a link-local

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -5,9 +5,9 @@
 //! re-emit it on the egress interface, verbatim or through an optional [`ReplyRewrite`] (SSDP's
 //! advertisement direction rewrites the DIAL `LOCATION`). What differs per protocol enters as
 //! parameters: the [`Classify`] gate and the [`Emit`] policy (which source and TTL the re-emit
-//! carries). Where it goes follows from the captured destination alone ([`link_destination`]). The
-//! search directions are stateful (per-searcher sessions), so they use the shared `SearchReflector`
-//! instead.
+//! carries, and where a unicast one goes). The destination otherwise follows from the captured one
+//! ([`link_destination`]). The search directions are stateful (per-searcher sessions), so they use
+//! the shared `SearchReflector` instead.
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -87,12 +87,25 @@ impl Ttl {
     }
 }
 
-/// How a re-emit is stamped: the source and TTL it carries. The destination follows from the
-/// captured one ([`link_destination`]).
+/// Where a re-emit whose captured destination is unicast goes. A group or broadcast destination
+/// keeps its own ([`link_destination`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnicastTo {
+    /// Nowhere: the leg's filter pins a group, so a unicast destination is not its traffic.
+    Nowhere,
+    /// The egress link's broadcast: a directed broadcast, which reads as unicast without the
+    /// mask, or a wake sent to a sleeping device's own address.
+    Broadcast,
+    /// The protocol's group of the family: an answer a peer sent to this host's own address.
+    Group { v4: Ipv4Addr, v6: Ipv6Addr },
+}
+
+/// How a re-emit is stamped: the source and TTL it carries, and where a unicast one goes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Emit {
     pub(crate) source: Source,
     pub(crate) ttl: Ttl,
+    pub(crate) unicast: UnicastTo,
 }
 
 impl Emit {
@@ -101,6 +114,7 @@ impl Emit {
         Self {
             source: Source::Egress(SourcePort::Fixed(port)),
             ttl: Ttl::Fixed(ttl),
+            unicast: UnicastTo::Nowhere,
         }
     }
 
@@ -109,6 +123,7 @@ impl Emit {
         Self {
             source: Source::Egress(SourcePort::Captured),
             ttl: Ttl::Captured,
+            unicast: UnicastTo::Nowhere,
         }
     }
 
@@ -117,6 +132,23 @@ impl Emit {
         Self {
             source: Source::Captured,
             ttl: Ttl::Captured,
+            unicast: UnicastTo::Nowhere,
+        }
+    }
+
+    /// A unicast destination goes to the egress link's broadcast.
+    pub(crate) const fn unicast_to_broadcast(self) -> Self {
+        Self {
+            unicast: UnicastTo::Broadcast,
+            ..self
+        }
+    }
+
+    /// A unicast destination goes to the protocol's group of its family.
+    pub(crate) const fn unicast_to_group(self, v4: Ipv4Addr, v6: Ipv6Addr) -> Self {
+        Self {
+            unicast: UnicastTo::Group { v4, v6 },
+            ..self
         }
     }
 }
@@ -200,12 +232,22 @@ impl<C: Classify> PacketHandler for SimpleReflector<C> {
             }
         };
 
-        let dest = link_destination(
+        let Some(dest) = link_destination(
             packet.dest,
             dispatcher
                 .egress_addrs(self.egress)
                 .and_then(InterfaceAddresses::v4_directed_broadcast),
-        );
+            self.emit.unicast,
+        ) else {
+            log::debug!(
+                "{}: dropping {} to {} from {}: not for this leg",
+                self.name,
+                self.kind,
+                packet.dest,
+                packet.source
+            );
+            return Outcome::Filtered;
+        };
 
         // A family the egress can't currently source is a quiet, transient drop (address
         // loss): a Stalled, not a genuine send failure.
@@ -274,18 +316,28 @@ const V6_ALL_NODES: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1);
 
 /// Where a re-emit of a packet captured to `dest` goes, at the captured port: a multicast group
 /// (the dispatcher's filter pinned it) and the IPv4 limited broadcast re-emit to themselves; any
-/// other IPv4 destination, a directed broadcast or a unicast wake aimed at this host, goes to the
-/// egress's own directed broadcast, or the limited broadcast while its prefix is unknown; any other
-/// IPv6 destination goes to the all-nodes group.
-fn link_destination(dest: SocketAddr, directed_broadcast: Option<Ipv4Addr>) -> SocketAddr {
-    match dest {
-        SocketAddr::V4(v4) if v4.ip().is_multicast() || v4.ip().is_broadcast() => dest,
-        SocketAddr::V4(v4) => {
-            SocketAddr::from((directed_broadcast.unwrap_or(Ipv4Addr::BROADCAST), v4.port()))
+/// other destination goes where `unicast` says. For [`UnicastTo::Broadcast`], a directed broadcast
+/// or a wake sent to a device's own address goes to the egress's own directed broadcast, or the
+/// limited broadcast while its prefix is unknown, and any other IPv6 destination to the all-nodes
+/// group; for [`UnicastTo::Group`], to the group of its family; for [`UnicastTo::Nowhere`],
+/// `None`.
+fn link_destination(
+    dest: SocketAddr,
+    directed_broadcast: Option<Ipv4Addr>,
+    unicast: UnicastTo,
+) -> Option<SocketAddr> {
+    let port = dest.port();
+    Some(match (dest, unicast) {
+        (SocketAddr::V4(v4), _) if v4.ip().is_multicast() || v4.ip().is_broadcast() => dest,
+        (SocketAddr::V6(v6), _) if v6.ip().is_multicast() => dest,
+        (_, UnicastTo::Nowhere) => return None,
+        (SocketAddr::V4(_), UnicastTo::Broadcast) => {
+            SocketAddr::from((directed_broadcast.unwrap_or(Ipv4Addr::BROADCAST), port))
         }
-        SocketAddr::V6(v6) if v6.ip().is_multicast() => dest,
-        SocketAddr::V6(v6) => SocketAddr::from((V6_ALL_NODES, v6.port())),
-    }
+        (SocketAddr::V6(_), UnicastTo::Broadcast) => SocketAddr::from((V6_ALL_NODES, port)),
+        (SocketAddr::V4(_), UnicastTo::Group { v4, .. }) => SocketAddr::from((v4, port)),
+        (SocketAddr::V6(_), UnicastTo::Group { v6, .. }) => SocketAddr::from((v6, port)),
+    })
 }
 
 #[cfg(test)]
@@ -372,30 +424,79 @@ mod tests {
     fn link_destination_keeps_groups_and_broadcasts_the_rest() {
         let dest = |s: &str| s.parse::<SocketAddr>().unwrap();
         let egress = Some(Ipv4Addr::new(192, 0, 2, 255));
+        let to_broadcast = Emit::captured_from_egress().unicast_to_broadcast().unicast;
         for group in ["224.0.0.251:5353", "[ff02::fb]:5353"] {
-            assert_eq!(dest(group), link_destination(dest(group), egress));
+            assert_eq!(
+                Some(dest(group)),
+                link_destination(dest(group), egress, to_broadcast)
+            );
         }
-        // The limited broadcast stays limited; a directed broadcast or a unicast wake aimed at
-        // this host goes to the egress's own directed broadcast, at the captured port.
+        // The limited broadcast stays limited; a directed broadcast or a wake sent to a device's
+        // own address goes to the egress's own directed broadcast, at the captured port.
         assert_eq!(
-            dest("255.255.255.255:9"),
-            link_destination(dest("255.255.255.255:9"), egress)
+            Some(dest("255.255.255.255:9")),
+            link_destination(dest("255.255.255.255:9"), egress, to_broadcast)
         );
         for captured in ["10.0.0.255:9", "10.0.0.2:9"] {
             assert_eq!(
-                dest("192.0.2.255:9"),
-                link_destination(dest(captured), egress)
+                Some(dest("192.0.2.255:9")),
+                link_destination(dest(captured), egress, to_broadcast)
             );
             // Without the egress prefix, link-wide still means the limited broadcast.
             assert_eq!(
-                dest("255.255.255.255:9"),
-                link_destination(dest(captured), None)
+                Some(dest("255.255.255.255:9")),
+                link_destination(dest(captured), None, to_broadcast)
             );
         }
         assert_eq!(
-            dest("[ff02::1]:9"),
-            link_destination(dest("[fe80::2]:9"), egress)
+            Some(dest("[ff02::1]:9")),
+            link_destination(dest("[fe80::2]:9"), egress, to_broadcast)
         );
+    }
+
+    #[test]
+    fn link_destination_drops_a_unicast_destination_by_default() {
+        let dest = |s: &str| s.parse::<SocketAddr>().unwrap();
+        let egress = Some(Ipv4Addr::new(192, 0, 2, 255));
+        let nowhere = Emit::fixed(5353, 255).unicast;
+        assert_eq!(None, link_destination(dest("10.0.0.2:9"), egress, nowhere));
+        assert_eq!(None, link_destination(dest("[fe80::2]:9"), egress, nowhere));
+        // Groups and broadcasts still go out.
+        for kept in ["224.0.0.251:5353", "[ff02::fb]:5353", "255.255.255.255:9"] {
+            assert_eq!(
+                Some(dest(kept)),
+                link_destination(dest(kept), egress, nowhere)
+            );
+        }
+    }
+
+    #[test]
+    fn link_destination_sends_a_unicast_answer_to_the_group() {
+        let dest = |s: &str| s.parse::<SocketAddr>().unwrap();
+        let egress = Some(Ipv4Addr::new(192, 0, 2, 255));
+        let to_group = Emit::fixed(5353, 255)
+            .unicast_to_group(Ipv4Addr::new(224, 0, 0, 251), "ff02::fb".parse().unwrap())
+            .unicast;
+        // An answer to this host's own address, in either family, goes to that family's group.
+        assert_eq!(
+            Some(dest("224.0.0.251:5353")),
+            link_destination(dest("10.0.0.1:5353"), egress, to_group)
+        );
+        assert_eq!(
+            Some(dest("[ff02::fb]:5353")),
+            link_destination(dest("[fd00::1]:5353"), egress, to_group)
+        );
+        // Groups and broadcasts keep their destination.
+        for kept in [
+            "224.0.0.251:5353",
+            "[ff02::fb]:5353",
+            "255.255.255.255:5353",
+        ] {
+            assert_eq!(
+                Some(dest(kept)),
+                link_destination(dest(kept), egress, to_group)
+            );
+        }
     }
 
     #[test]

--- a/src/reflector/simple.rs
+++ b/src/reflector/simple.rs
@@ -17,7 +17,7 @@ use crate::logging::log_rate;
 use crate::net::packet::Packet;
 use crate::reactor::Reactor;
 
-use super::{NoRewrite, ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
+use super::{Delivery, NoRewrite, ReplyRewrite, Verdict, WARN_WINDOW, egress_sources};
 
 /// A leg's ingress gate: is this packet a message for it? See [`Verdict`].
 pub(crate) trait Classify {
@@ -47,7 +47,7 @@ impl Source {
             Self::Egress(port) => DatagramSource::Egress {
                 port: port.resolve(packet),
             },
-            Self::Captured => DatagramSource::Captured(packet.source),
+            Self::Captured => DatagramSource::Exact(packet.source),
         }
     }
 }
@@ -126,6 +126,8 @@ impl Emit {
 /// [`ReplyRewrite`] transforms the payload before re-emit (default: forward verbatim).
 pub(crate) struct SimpleReflector<C> {
     egress: CaptureKey,
+    /// Where the re-emits go on `egress`.
+    delivery: Delivery,
     /// Protocol tag for logs, e.g. `"mDNS"`.
     name: &'static str,
     /// The message kind/direction this reflector handles, for logs, e.g. `"query"`.
@@ -142,6 +144,7 @@ pub(crate) struct SimpleReflector<C> {
 impl<C: Classify> SimpleReflector<C> {
     pub(crate) fn new(
         egress: CaptureKey,
+        delivery: Delivery,
         name: &'static str,
         kind: &'static str,
         classify: C,
@@ -149,6 +152,7 @@ impl<C: Classify> SimpleReflector<C> {
     ) -> Self {
         Self {
             egress,
+            delivery,
             name,
             kind,
             classify,
@@ -233,7 +237,8 @@ impl<C: Classify> PacketHandler for SimpleReflector<C> {
         }
         let payload = rewritten.unwrap_or(packet.payload);
 
-        match dispatcher.send_udp_group(
+        match self.delivery.send(
+            dispatcher,
             self.egress,
             dest,
             self.emit.source.resolve(packet),
@@ -328,6 +333,7 @@ mod tests {
         let reactor = Reactor::new().expect("reactor");
         let reflector = SimpleReflector::new(
             egress,
+            Delivery::Link,
             "TEST",
             "response",
             reflect_all as fn(&[u8]) -> Verdict,

--- a/src/reflector/ssdp.rs
+++ b/src/reflector/ssdp.rs
@@ -23,8 +23,9 @@ use crate::reactor::Reactor;
 
 use super::dial::{ProxyPlacement, rewrite_location};
 use super::{
-    BuildError, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector,
-    Verdict, require_bidirectional_families, require_group_join, require_macs_matchable,
+    BuildError, Delivery, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector,
+    SimpleReflector, Verdict, require_bidirectional_families, require_group_join,
+    require_macs_matchable,
 };
 
 /// What a DIAL-enabled SSDP reflector needs to rewrite a device's `LOCATION` to a source-side proxy: the
@@ -201,6 +202,7 @@ pub(crate) fn build(
     // the source side can never use.
     let advertisement = SimpleReflector::new(
         source,
+        Delivery::new(reflector.source_peers.as_ref()),
         "SSDP",
         "advertisement",
         advertisement_verdict,
@@ -243,6 +245,7 @@ pub(crate) fn build(
         Box::new(SearchReflector::new(
             source,
             target,
+            Delivery::new(reflector.target_peers.as_ref()),
             reflector.macs.clone(),
             "SSDP",
             MessageType::SsdpResponse,

--- a/src/reflector/udp.rs
+++ b/src/reflector/udp.rs
@@ -7,7 +7,7 @@ use crate::config::Reflector;
 use crate::dispatch::{Filter, MessageType, PacketDispatcher, PortSet};
 
 use super::{
-    BuildError, Emit, InterfaceMap, SimpleReflector, Verdict, missing_required_family,
+    BuildError, Delivery, Emit, InterfaceMap, SimpleReflector, Verdict, missing_required_family,
     require_group_join,
 };
 
@@ -77,6 +77,7 @@ pub(crate) fn build(
             filter,
             Box::new(SimpleReflector::new(
                 egress,
+                Delivery::new(reflector.target_peers.as_ref()),
                 "UDP relay",
                 "datagram",
                 relay,

--- a/src/reflector/udp.rs
+++ b/src/reflector/udp.rs
@@ -81,7 +81,7 @@ pub(crate) fn build(
                 "UDP relay",
                 "datagram",
                 relay,
-                Emit::captured(),
+                Emit::captured().unicast_to_broadcast(),
             )),
         );
     }

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -130,7 +130,7 @@ pub(crate) fn build(
                 target_macs: reflector.macs.clone(),
                 family: reflector.address_family,
             },
-            Emit::captured_from_egress(),
+            Emit::captured_from_egress().unicast_to_broadcast(),
         )),
     );
     log::info!(

--- a/src/reflector/wol.rs
+++ b/src/reflector/wol.rs
@@ -16,7 +16,8 @@ use crate::net::mac::{MacAddr, MacSet};
 use crate::net::packet::Packet;
 
 use super::{
-    BuildError, Classify, Emit, InterfaceMap, SimpleReflector, Verdict, missing_required_family,
+    BuildError, Classify, Delivery, Emit, InterfaceMap, SimpleReflector, Verdict,
+    missing_required_family,
 };
 
 const PREFIX_LEN: usize = 6;
@@ -122,6 +123,7 @@ pub(crate) fn build(
         },
         Box::new(SimpleReflector::new(
             egress,
+            Delivery::new(reflector.target_peers.as_ref()),
             "WoL",
             "wake",
             WakeClassifier {

--- a/src/reflector/wsd.rs
+++ b/src/reflector/wsd.rs
@@ -15,8 +15,9 @@ use crate::net::wsd::{
 };
 
 use super::{
-    BuildError, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector, SimpleReflector,
-    Verdict, require_bidirectional_families, require_group_join, require_macs_matchable,
+    BuildError, Delivery, Emit, InterfaceMap, NoRewrite, ReplyRewrite, SearchReflector,
+    SimpleReflector, Verdict, require_bidirectional_families, require_group_join,
+    require_macs_matchable,
 };
 
 /// WSD's classifier kind maps to its group message types. The `ProbeMatches`/`ResolveMatches` unicast
@@ -127,6 +128,7 @@ pub(crate) fn build(
         Box::new(
             SimpleReflector::new(
                 source,
+                Delivery::new(reflector.source_peers.as_ref()),
                 "WSD",
                 "announcement",
                 announcement_verdict,
@@ -151,6 +153,7 @@ pub(crate) fn build(
         Box::new(SearchReflector::new(
             source,
             target,
+            Delivery::new(reflector.target_peers.as_ref()),
             reflector.macs.clone(),
             "WSD",
             MessageType::WsdResponse,


### PR DESCRIPTION
A WireGuard tunnel delivers a datagram only to the peer whose allowed addresses cover its destination, so a group or broadcast sent there reaches nobody, and the kernel answers the preserved source with an ICMP unreachable (the tester's Roon-over-WireGuard logs). An entry can now list the hosts behind an interface, `source_peers` / `target_peers`; every group or broadcast that entry would send there goes to each of them as a unicast copy instead, for every protocol it enables. Peers are per entry, allowed on any link (GRE carries multicast without a broadcast domain; on Ethernet the copy travels in a broadcast frame), and a peer the link cannot reach costs only its own copy.

What the fan-out needed underneath: the duplicate check keys on a hash of the frame and remembers every frame a packet sent on an egress, so copies to different peers never collide and two entries with overlapping lists deliver to a shared peer once; a search session reserves its port on the address of the scope the search reaches and sends every copy from exactly that address; a search off a link without MACs opens a session. The mDNS response leg also takes an answer sent to netflector's own address, which a device sends for a unicast query and for the QU bit, and requires the RFC's source port 5353.

Testing: unit tests on a tun device for the fan-out, overlapping lists, colliding checksums, the session's address and the mDNS answer; a WireGuard peer without an endpoint on FreeBSD; 40 e2e cases over peers on the target, the source and both, a receiver bound to its own address proving each unicast copy, plus a negative for the source port. Full e2e suite green on Docker and natively on FreeBSD 15.
